### PR TITLE
to attribute now used for increment dbversion, cdata only for actual queries.

### DIFF
--- a/octgnFX/Octgn.Data/UpdataDatabaseQueries.xml
+++ b/octgnFX/Octgn.Data/UpdataDatabaseQueries.xml
@@ -2,14 +2,13 @@
 <updates>
   <update from="1" to="2">
       <![CDATA[
-        UPDATE dbinfo SET version=2;
+        --update version only
       ]]>
   </update>
   <update from="2" to="3">
       <![CDATA[
         ALTER TABLE cards ADD alternate TEXT DEFAULT '00000000-0000-0000-0000-000000000000';
         ALTER TABLE cards ADD dependent TEXT;
-        UPDATE dbinfo SET version=3;
       ]]>
   </update>
 </updates>


### PR DESCRIPTION
use a -- sql style comment to only increment db version.
Only actual queries are needed in the CDATA sections.
