### PR TITLE
Resource controller properly reworked.

### DIFF
--- a/octgn/Octgn.App/Global.asax.cs
+++ b/octgn/Octgn.App/Global.asax.cs
@@ -14,8 +14,8 @@ namespace Octgn.App
 
             routes.MapRoute(
                 "DefinitionResources",
-                "Resource/{gameID}/{file}/{resourcePath}",
-                new { controller = "DefinitionResource", action = "Render", file = "", gameID = "", resourcePath = "" }
+                "Resource/{resourcePath}/{o8xPath}",
+                new { controller = "DefinitionResource", action = "Render", resourcePath = "", o8xPath = ""}
                 );
 
 			routes.MapRoute(


### PR DESCRIPTION
Render/{resourcepath}/{o8g\s path to load the resource from}
o8x path is optional and when defined it will look from the resource path inside the o8x
replace / or \ with -- as dir seperator in both paths when calling it.
