### PR TITLE
Added webRead overload for optional timeout on calls.

### DIFF
--- a/octgnFX/Octgn/Scripting/PythonAPI.py
+++ b/octgnFX/Octgn/Scripting/PythonAPI.py
@@ -26,6 +26,10 @@ def webRead(url):
   apiResult = _api.Web_Read(url)
   return (apiResult.Item1, apiResult.Item2)
 
+def webRead(url, timeout):
+	apiResult = _api.Web_Read(url, timeout)
+	return (apiResult.Item1, apiResult.Item2)
+
 def currentGameName():
   return _api.GetGameName()
 


### PR DESCRIPTION
Changed error handling on http exceptions
http 200 range is an OK request 204 is for an empty response
All standard http spec errors should be accounted for.
new python api call: def webRead(url, timeout)
Timeout is in miliseconds.
calling the normal webRead(url) python api call uses the default timeout.
timeout status code should be 408 according to the http specifications
