### PR TITLE
Font update 

### DIFF
--- a/octgnFX/Octgn/Definitions/FontDef.cs
+++ b/octgnFX/Octgn/Definitions/FontDef.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
+using System.Linq;
+using System.Xml.Linq;
+using Octgn.Data;
+
+namespace Octgn.Definitions
+{
+    public class FontDef
+    {
+        public string FileName { get; private set; }
+        public int Size { get; private set; }
+        public string Target { get; private set; }
+        public string Id { get; private set; }
+
+        public static List<FontDef> LoadAllFromXml(XElement xml, PackagePart part)
+        {
+            if (xml == null) return new List<FontDef>(0);
+
+            return xml.Elements("font")
+                .Select(x => FromXml(x, part))
+                .ToList();
+        }
+
+        public static FontDef FromXml(XElement xml, PackagePart part)
+        {
+            string srcUri = part.GetRelationship(xml.Attr<string>("src")).TargetUri.OriginalString;
+            return new FontDef { FileName = srcUri, Size = xml.Attr<int>("size"), Target = xml.Attr<string>("target"), Id = xml.Attr<string>("src") };
+        }
+    }
+}

--- a/octgnFX/Octgn/Launcher/GameList.xaml.cs
+++ b/octgnFX/Octgn/Launcher/GameList.xaml.cs
@@ -136,6 +136,11 @@ namespace Octgn.Launcher
                                         MessageBoxButton.YesNo, MessageBoxImage.Exclamation) != MessageBoxResult.Yes)
                         return;
 
+                if (game.Fonts.Count > 0)
+                {
+                    game.InstallFonts();
+                }
+
                 var gameData = new Data.Game
                                    {
                                        Id = game.Id,

--- a/octgnFX/Octgn/Octgn.csproj
+++ b/octgnFX/Octgn/Octgn.csproj
@@ -254,6 +254,7 @@
     </Compile>
     <Compile Include="Controls\TabCommands.cs" />
     <Compile Include="Controls\VirtualizingWrapPanel.cs" />
+    <Compile Include="Definitions\FontDef.cs" />
     <Compile Include="ErrorReporter.cs" />
     <Compile Include="Extentions\BitmapImageExtensions.cs" />
     <Compile Include="Extentions\ControlExtensions.cs" />


### PR DESCRIPTION
Fonts are now loaded the same way as .py files
in yourgame.xml:

``` xml
<fonts>
    <font src="r26" size="14" target="context"/><!--menu-->
    <font src="r26" size="14" target="chat"/><!--chat-->
</fonts>
```

in yourgame.xml.rels:

``` xml
<Relationship Target="/yourfont.ttf" Id="r26" Type="http://schemas.octgn.org/game/font" />
```

The same font can be reused for both targets.
Its also setup for more targets to be added at a later point should the need arise.
Fixes #603
