### PR TITLE
expose player.setActivePlayer() to python API

### DIFF
--- a/octgnFX/Octgn/Scripting/PythonAPI.py
+++ b/octgnFX/Octgn/Scripting/PythonAPI.py
@@ -154,6 +154,7 @@ class Card(object):
   @property
   def getIndex(self): return _api.CardGetIndex(self._id)
   def select(self): _api.CardSelect(self._id)
+  def peek(self): _api.CardPeek(self._id)
   def target(self, active = True): _api.CardTarget(self._id, active)
   def arrow(self, targetCard, active = True): _api.CardTargetArrow(self._id, targetCard._id, active)
   @property

--- a/octgnFX/Octgn/Scripting/ScriptApi.cs
+++ b/octgnFX/Octgn/Scripting/ScriptApi.cs
@@ -367,6 +367,17 @@ namespace Octgn.Scripting
                                });
         }
 
+        public void CardPeek(int id)
+        {
+            Card c = Card.Find(id);
+            _engine.Invoke(() =>
+            {
+                c.Peek();
+            });
+        }
+
+
+
         public void CardTargetArrow(int id, int targetId, bool active)
         {
             Card c = Card.Find(id);


### PR DESCRIPTION
This mimics the "green arrow" buttons in the interface to end your turn.
There's some stupididy involved in the core mechanics of this function
-- you need to give this function the ID of the player that you're
passing your turn to.  You can't simply say "I end my turn" and have the
client jump to the next player, because it doesn't keep track of the
actual turn orders.

So NEVER use me.setActivePlayer() because that doesn't actually do
anything.  For 2 player games, typically players[1].setActivePlayer()
will use the functionality you desire.  For multiplayer games, you'll
need some custom logic involved to determine who gets the next turn.
