### PR TITLE
Added option on Custom Games List to hide uninstalled games...

### DIFF
--- a/octgnFX/Octgn/Controls/CustomGames.xaml
+++ b/octgnFX/Octgn/Controls/CustomGames.xaml
@@ -29,7 +29,7 @@
                         IsEnabled="{Binding IsJoinableGameSelected, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:CustomGameList}}}">
                 </Button>
                 <Button Click="ButtonJoinOfflineGame" Content="Join Offline Game" Padding="10,0,10,0" Margin="0,0,5,0"></Button>
-                <CheckBox x:Name="HideUninstalledGames" Click="HideUninstalledGames_OnClick"  IsChecked="True" Margin="0,5,0,4" Width="259">Hide games that are not installed.</CheckBox>
+                <CheckBox x:Name="HideUninstalledGames" Click="HideUninstalledGames_OnClick"  Margin="0,5,0,4" Width="259">Hide games that are not installed.</CheckBox>
             </StackPanel>
         </Border>
         <ListView x:Name="ListViewGameList" Grid.Row="2" SelectionChanged="ListViewGameListSelectionChanged" 

--- a/octgnFX/Octgn/Controls/CustomGames.xaml.cs
+++ b/octgnFX/Octgn/Controls/CustomGames.xaml.cs
@@ -5,7 +5,7 @@ using System.Timers;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-
+using Octgn.Extentions;
 using Skylabs.Lobby;
 
 namespace Octgn.Controls
@@ -66,6 +66,7 @@ namespace Octgn.Controls
             dragHandler = this.ListViewGameList_OnDragDelta;
             ListViewGameList.AddHandler(Thumb.DragDeltaEvent, dragHandler, true);
             HostedGameList = new ObservableCollection<HostedGameViewModel>();
+	        HideUninstalledGames.IsChecked = Prefs.HideUninstalledGamesInList;
             Program.LobbyClient.OnLoginComplete += LobbyClient_OnLoginComplete;
             Program.LobbyClient.OnDisconnect += LobbyClient_OnDisconnect;
             Program.LobbyClient.OnDataReceived += LobbyClient_OnDataReceived;
@@ -409,6 +410,7 @@ namespace Octgn.Controls
 
 	    private void HideUninstalledGames_OnClick(object sender, RoutedEventArgs e)
 	    {
+		    Prefs.HideUninstalledGamesInList = HideUninstalledGames.IsChecked.ToBool();
 			RefreshGameList();
 	    }
     }

--- a/octgnFX/Octgn/Extentions/Conversion.cs
+++ b/octgnFX/Octgn/Extentions/Conversion.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Octgn.Extentions
+{
+	public static class Conversion
+	{
+		public static string ToStringValue(this object item)
+		{
+			return item.ToStringValue(String.Empty);
+		}
+
+		public static string ToStringValue(this object item, string defaultValue)
+		{
+			string value;
+			try
+			{
+				value = item.ToString();
+			}
+			catch
+			{
+				value = defaultValue;
+			}
+			return value;
+		}
+
+		public static object ToStringValue(this object item, object defaultValue)
+		{
+			string value;
+			object objectValue;
+
+			try
+			{
+				value = item.ToString();
+				if (value.Length == 0)
+				{
+					objectValue = defaultValue;
+				}
+				else
+				{
+					objectValue = value;
+				}
+			}
+			catch
+			{
+				objectValue = defaultValue;
+			}
+			return objectValue;
+		}
+
+		public static int ToInt32(this object item)
+		{
+			return item.ToInt32(0);
+		}
+
+		public static int ToInt32(this object item, int defaultValue)
+		{
+			int value;
+			try
+			{
+				if (item.IsANumber())
+				{
+					value = Convert.ToInt32(item);
+				}
+				else
+				{
+					value = defaultValue;
+				}
+			}
+			catch
+			{
+				value = defaultValue;
+			}
+			return value;
+		}
+
+		public static short ToInt16(this object item)
+		{
+			return item.ToInt16(0);
+		}
+
+		public static short ToInt16(this object item, short defaultValue)
+		{
+			short value;
+			try
+			{
+				value = Convert.ToInt16(item);
+			}
+			catch
+			{
+				value = defaultValue;
+			}
+			return value;
+		}
+
+		public static decimal ToDecimal(this object item)
+		{
+			return item.ToDecimal(0);
+		}
+
+		public static decimal ToDecimal(this object item, decimal defaultValue)
+		{
+			decimal value;
+			try
+			{
+				value = Convert.ToDecimal(item);
+			}
+			catch
+			{
+				value = defaultValue;
+			}
+			return value;
+		}
+
+		public static bool ToBool(this object item)
+		{
+			return item.ToBool(false);
+		}
+
+		public static bool ToBool(this object item, bool defaultValue)
+		{
+			bool value;
+			try
+			{
+				value = Convert.ToBoolean(item);
+			}
+			catch
+			{
+				value = defaultValue;
+			}
+			return value;
+		}
+
+		public static DateTime ToDateTime(this object item)
+		{
+			return item.ToDateTime(DateTime.Now);
+		}
+
+		public static DateTime ToDateTime(this object item, DateTime defaultValue)
+		{
+			DateTime value;
+			try
+			{
+				value = Convert.ToDateTime(item);
+			}
+			catch
+			{
+				value = defaultValue;
+			}
+			return value;
+		}
+
+		public static bool IsANumber(this object itemValue)
+		{
+			double convertedNumber = 0;
+			bool isSuccessful = false;
+			if (itemValue == null)
+			{
+				return isSuccessful;
+			}
+
+			isSuccessful = Double.TryParse(itemValue.ToString()
+				, System.Globalization.NumberStyles.Any
+				, System.Threading.Thread.CurrentThread.CurrentCulture.NumberFormat
+				, out convertedNumber);
+			return isSuccessful;
+		}
+
+	}
+}

--- a/octgnFX/Octgn/Octgn.csproj
+++ b/octgnFX/Octgn/Octgn.csproj
@@ -326,6 +326,7 @@
     <Compile Include="Controls\HostGameSettings.xaml.cs">
       <DependentUpon>HostGameSettings.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Extentions\Conversion.cs" />
     <Compile Include="GameUpdater.cs" />
     <Compile Include="Launcher\GameTableLauncher.cs" />
     <Compile Include="Mono.Options\Options.cs" />

--- a/octgnFX/Octgn/Prefs.cs
+++ b/octgnFX/Octgn/Prefs.cs
@@ -3,6 +3,8 @@ using System.Globalization;
 using System.IO;
 using System.Windows;
 using Octgn.Data;
+using Octgn.Extentions;
+
 namespace Octgn
 {
     using System.Windows.Controls;
@@ -386,5 +388,18 @@ namespace Octgn
                 SimpleConfig.Get().WriteValue("DefaultGameBack", value);
             }
         }
+
+	    public static bool HideUninstalledGamesInList
+	    {
+			get
+			{
+				return SimpleConfig.Get().ReadValue("HideUninstalledGamesInList", "false").ToBool(false);
+			}
+			set
+			{
+				SimpleConfig.Get().WriteValue("HideUninstalledGamesInList", value.ToString());
+			}
+	    }
+
     }
 }


### PR DESCRIPTION
Added checkbox to Custom Games list to hide games that the user does not have installed, taking the {Unknown Game} out of the list. 

So now instead of seeing all the games you don't have installed, you can see just the games you can play.  When the checkbox is toggled, it refreshes the list immediately.  As the system grows, should cut down on clutter.

Default is checked.  I cannot see that anyone would ever want it always unchecked, but that could always be a user option.

![image](https://f.cloud.github.com/assets/814669/666714/dbc6b082-d7d2-11e2-841e-20dfc7f7110b.png)

![image](https://f.cloud.github.com/assets/814669/666715/e7858100-d7d2-11e2-9e2e-5eb861cf8c43.png)
