### PR TITLE
Fix for MyGet.org change to https

### DIFF
--- a/octgnFX/Octgn.Library/Paths.cs
+++ b/octgnFX/Octgn.Library/Paths.cs
@@ -64,7 +64,7 @@
             LocalFeedPath = FS.Path.Combine(DataDirectory, "LocalFeed");
             FS.Directory.CreateDirectory(LocalFeedPath);
             DeckPath = FS.Path.Combine(DataDirectory, "Decks");
-            MainOctgnFeed = "http://www.myget.org/F/octgngames/";
+            MainOctgnFeed = "https://www.myget.org/F/octgngames/";
 
             foreach (var prop in this.GetType().GetProperties())
             {

--- a/octgnFX/Octgn.Online.GameService/App.config
+++ b/octgnFX/Octgn.Online.GameService/App.config
@@ -11,7 +11,7 @@
     <add key="ListenPort" value="5879" />
     <add key="GameManagerHost" value="http://localhost:5880" />
   </appSettings>
-  <UpdateManagerConfig Enabled="False" UpdateFrequency="60000" UpdateFeed="http://www.myget.org/F/octgn/" PackageName="Octgn.Online.GameService" />
+  <UpdateManagerConfig Enabled="False" UpdateFrequency="60000" UpdateFeed="https://www.myget.org/F/octgn/" PackageName="Octgn.Online.GameService" />
   <log4net>
     <root>
       <!-- Levels: 1=OFF,2=FATAL,3=ERROR,4=WARN,5=INFO,6=DEBUG,7ALL -->

--- a/octgnFX/Octgn.Online.SASManager/App.config
+++ b/octgnFX/Octgn.Online.SASManager/App.config
@@ -11,7 +11,7 @@
     <add key="GameServiceHost" value="http://localhost:5880/GameManager" />
     <add key="SASManagerHost" value="http://localhost:5890" />
   </appSettings>
-  <UpdateManagerConfig Enabled="false" UpdateFrequency="60000" UpdateFeed="http://www.myget.org/F/octgn/" PackageName="Octgn.Online.SASManagerService" />
+  <UpdateManagerConfig Enabled="false" UpdateFrequency="60000" UpdateFeed="https://www.myget.org/F/octgn/" PackageName="Octgn.Online.SASManagerService" />
   <log4net>
     <root>
       <!-- Levels: 1=OFF,2=FATAL,3=ERROR,4=WARN,5=INFO,6=DEBUG,7ALL -->

--- a/octgnFX/Octgn.Online.StandAloneServer/App.config
+++ b/octgnFX/Octgn.Online.StandAloneServer/App.config
@@ -14,7 +14,7 @@
     
     
   <add key="LOGENTRIES_TOKEN" value="" /><add key="log4net.Internal.Debug" value="true" /><add key="LOGENTRIES_ACCOUNT_KEY" value="" /><add key="LOGENTRIES_LOCATION" value="" /></appSettings>
-  <UpdateManagerConfig Enabled="false" UpdateFrequency="60000" UpdateFeed="http://www.myget.org/F/octgn/" PackageName="Octgn.Online.StandAloneServer" />
+  <UpdateManagerConfig Enabled="false" UpdateFrequency="60000" UpdateFeed="https://www.myget.org/F/octgn/" PackageName="Octgn.Online.StandAloneServer" />
   <log4net>
     <root>
       <!-- Levels: 1=OFF,2=FATAL,3=ERROR,4=WARN,5=INFO,6=DEBUG,7ALL -->

--- a/octgnFX/Octgn/app.config
+++ b/octgnFX/Octgn/app.config
@@ -12,7 +12,7 @@
     <add key="WebsitePath" value="https://www.octgn.net/" />
     <add key="UpdateCheckPath" value="https://raw.github.com/kellyelton/OCTGN/master/deploy/currentversion.txt" />
     <add key="UpdateCheckPathTest" value="https://raw.github.com/kellyelton/OCTGN/test/deploy/currentversiontest.txt" />
-    <add key="GameFeed" value="http://www.myget.org/F/octgngames/" />
+    <add key="GameFeed" value="https://www.myget.org/F/octgngames/" />
     <add key="UseGamePackageManagement" value="false" />
     <add key="log4net.Internal.Debug" value="false" />
     <add key="LOGENTRIES_TOKEN" value="" />


### PR DESCRIPTION
Simple hotfix when the feeds list is loaded, I check all the feeds starting with http://www.myget.org and change to https://www.myget.org.  This does not change the file itself, but changes the loaded feed list itself, so will get us past the July 1 hard stop.
