### PR TITLE
Fix for the Hide games checkbox...

### DIFF
--- a/octgnFX/Octgn/Controls/CustomGames.xaml
+++ b/octgnFX/Octgn/Controls/CustomGames.xaml
@@ -29,8 +29,7 @@
                         IsEnabled="{Binding IsJoinableGameSelected, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:CustomGameList}}}">
                 </Button>
                 <Button Click="ButtonJoinOfflineGame" Content="Join Offline Game" Padding="10,0,10,0" Margin="0,0,5,0"></Button>
-                <CheckBox x:Name="HideUninstalledGames" Click="HideUninstalledGames_OnClick"  Margin="0,5,0,4" Width="259" BorderThickness="1" Foreground="#FF818181">Hide games that are not installed.
-                </CheckBox>
+                <Button x:Name="HideUninstalledGamesButton" Content="Hide Uninstalled Games" Width="190" Click="HideUninstalledGamesButton_OnClick"/>
             </StackPanel>
         </Border>
         <ListView x:Name="ListViewGameList" Grid.Row="2" SelectionChanged="ListViewGameListSelectionChanged" 

--- a/octgnFX/Octgn/Controls/CustomGames.xaml.cs
+++ b/octgnFX/Octgn/Controls/CustomGames.xaml.cs
@@ -66,7 +66,7 @@ namespace Octgn.Controls
             dragHandler = this.ListViewGameList_OnDragDelta;
             ListViewGameList.AddHandler(Thumb.DragDeltaEvent, dragHandler, true);
             HostedGameList = new ObservableCollection<HostedGameViewModel>();
-	        HideUninstalledGames.IsChecked = Prefs.HideUninstalledGamesInList;
+	        HideUninstalledGames = Prefs.HideUninstalledGamesInList;
             Program.LobbyClient.OnLoginComplete += LobbyClient_OnLoginComplete;
             Program.LobbyClient.OnDisconnect += LobbyClient_OnDisconnect;
             Program.LobbyClient.OnDataReceived += LobbyClient_OnDataReceived;
@@ -74,7 +74,13 @@ namespace Octgn.Controls
             timer = new Timer(10000);
             timer.Start();
             timer.Elapsed += this.TimerElapsed;
+			UpdateHideButtonText();
         }
+
+		void UpdateHideButtonText()
+		{
+			HideUninstalledGamesButton.Content = HideUninstalledGames ? "Show Uninstalled Games" : "Hide Uninstalled Games";
+		}
 
         void RefreshGameList()
         {
@@ -86,8 +92,7 @@ namespace Octgn.Controls
                                              {
                                                  Log.Info("Refreshing visual list");
 
-												 var hideGames = HideUninstalledGames.IsChecked ?? false;
-												 if (hideGames)
+												 if (HideUninstalledGames)
 												 {
 													 list = list.Where(game => game.GameName != "{Unknown Game}").ToList();
 												 }
@@ -102,6 +107,8 @@ namespace Octgn.Controls
 
                                              }));
         }
+
+		private bool HideUninstalledGames { get; set; }
 
         private void ShowHostGameDialog()
         {
@@ -408,10 +415,14 @@ namespace Octgn.Controls
 
         #endregion
 
-	    private void HideUninstalledGames_OnClick(object sender, RoutedEventArgs e)
+	    private void HideUninstalledGamesButton_OnClick(object sender, RoutedEventArgs e)
 	    {
-		    Prefs.HideUninstalledGamesInList = HideUninstalledGames.IsChecked.ToBool();
+			// toggle text and value...
+		    HideUninstalledGames = !HideUninstalledGames;
+		    Prefs.HideUninstalledGamesInList = HideUninstalledGames;
+		    UpdateHideButtonText();
 			RefreshGameList();
 	    }
+
     }
 }


### PR DESCRIPTION
Adjusted text color of Hide Games checkbox to be legible in both white and dark themes.  I couldn't figure out how in WPF to make the background of the checkbox LABEL appear with a dark background, it just sets it transparent.  I just made this a medium grey which looks fine between the dark and light.

I can look at changing this to a toggle button instead of a checkbox, which would then have its own background, but wanted to get this hotfix in first.
