### PR TITLE
Broadening the usage for the askMarker() dialog

### DIFF
--- a/octgnFX/Octgn/Scripting/Controls/MarkerDlg.xaml
+++ b/octgnFX/Octgn/Scripting/Controls/MarkerDlg.xaml
@@ -110,7 +110,7 @@
           <TextBox x:Name="quantityBox" Width="100" VerticalAlignment="Center" Text="1" />
         </Border>
         <Button Grid.Column="3" Grid.Row="3" VerticalAlignment="Center" Padding="5" MinWidth="120" Click="AddClicked"
-                IsDefault="True" IsEnabled="{Binding ElementName=Dlg, Path=IsModelSelected}">Add</Button>
+                IsDefault="True" IsEnabled="{Binding ElementName=Dlg, Path=IsModelSelected}">OK</Button>
       </Grid>
     </Border>
   </Grid>


### PR DESCRIPTION
Changed the askMarker() dialog to have an 'OK' button instead of an 'Add' button. This way it's more universal for cases such as if it's used to find out which markers the user wants to remove rather than add.
