### PR TITLE
Disable Remove Feed button where not useable

### DIFF
--- a/octgnFX/Octgn/Tabs/GameManagement/GameManagement.xaml
+++ b/octgnFX/Octgn/Tabs/GameManagement/GameManagement.xaml
@@ -27,7 +27,7 @@
         <Border IsEnabled="{Binding ButtonsEnabled}" Grid.ColumnSpan="3" Grid.Row="1" Style="{StaticResource ButtonBarPanel}">
             <WrapPanel >
                 <Button Click="ButtonAddClick" Content="Add Game Feed" Width="130" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" Style="{StaticResource FlatDarkGreenButtonStyle}"></Button>
-                <Button Click="ButtonRemoveClick" Content="Remove Game Feed" Width="120" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" Style="{StaticResource FlatDarkButtonStyle}"></Button>
+                <Button IsEnabled="{Binding RemoveButtonEnabled}" Click="ButtonRemoveClick" Content="Remove Game Feed" Width="120" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" Style="{StaticResource FlatDarkButtonStyle}"></Button>
                 <!--<Button Click="ButtonAddo8gClick" Content="Add o8g" Width="60" Height="30" VerticalAlignment="Center" Margin="0,0,5,0"></Button>-->
                 <Button Click="ButtonAddo8cClick" Content="Add Image Packs" Width="120" Height="30" VerticalAlignment="Center" Margin="0,0,5,0" Style="{StaticResource FlatDarkButtonStyle}"></Button>
             </WrapPanel>

--- a/octgnFX/Octgn/Tabs/GameManagement/GameManagement.xaml.cs
+++ b/octgnFX/Octgn/Tabs/GameManagement/GameManagement.xaml.cs
@@ -52,6 +52,12 @@ namespace Octgn.Tabs.GameManagement
                 {
                     return;
                 }
+                if (value.Name.Equals("Local", StringComparison.InvariantCultureIgnoreCase) ||
+                    value.Name.Equals("OCTGN Official", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    RemoveButtonEnabled = false;
+                }
+                else { RemoveButtonEnabled = true; }
                 this.selected = value;
                 this.OnPropertyChanged("Selected");
                 this.OnPropertyChanged("Packages");
@@ -99,6 +105,16 @@ namespace Octgn.Tabs.GameManagement
             {
                 buttonsEnabled = value;
                 OnPropertyChanged("ButtonsEnabled");
+            }
+        }
+        private bool removeButtonEnabled;
+        public bool RemoveButtonEnabled
+        {
+            get { return removeButtonEnabled && buttonsEnabled; }
+            set
+            {
+                removeButtonEnabled = value;
+                OnPropertyChanged("RemoveButtonEnabled");
             }
         }
 


### PR DESCRIPTION
just borrowed the check from where it popped up the window before, but might want to make sure users can't name feeds like that at some point...
