### PR TITLE
Fix for #1145

### DIFF
--- a/octgnFX/Octgn/Play/State/GameSaveState.cs
+++ b/octgnFX/Octgn/Play/State/GameSaveState.cs
@@ -115,7 +115,6 @@
                 card.SetFaceUp(c.FaceUp);
                 card.SetHighlight(c.HighlightColor);
                 card.SetIndex(c.Index);
-                card.Orientation = CardOrientation.Rot0;
                 card.Orientation = c.Orientation;
                 card.SetOverrideGroupVisibility(c.OverrideGroupVisibility);
                 card.SetTargetedBy(Play.Player.Find(c.TargetedBy));


### PR DESCRIPTION
Re-placing all the cards on the table fixes the orientation issue.
Setting the Table's visibility to Undefined rather than Everyone fixes
the "Facedown cards displaying faceup to reconnected users" issue.
