### PR TITLE
fixes #1312

### DIFF
--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_0.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_0.cs
@@ -342,6 +342,7 @@ namespace Octgn.Scripting.Versions
         {
             var c = Card.Find(id);
             if (c == null) return new string[0];
+            if ((!c.FaceUp && !c.PeekingPlayers.Contains(Player.LocalPlayer)) || c.Type.Model == null) return new string[0];
             return c.Alternates();
         }
 
@@ -349,6 +350,7 @@ namespace Octgn.Scripting.Versions
         {
             var c = Card.Find(id);
             if (c == null) return "";
+            if ((!c.FaceUp && !c.PeekingPlayers.Contains(Player.LocalPlayer)) || c.Type.Model == null) return "";
             return c.Alternate();
         }
 

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_1.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_1.cs
@@ -342,6 +342,7 @@ namespace Octgn.Scripting.Versions
         {
             var c = Card.Find(id);
             if (c == null) return new string[0];
+            if ((!c.FaceUp && !c.PeekingPlayers.Contains(Player.LocalPlayer)) || c.Type.Model == null) return new string[0];
             return c.Alternates();
         }
 
@@ -349,6 +350,7 @@ namespace Octgn.Scripting.Versions
         {
             var c = Card.Find(id);
             if (c == null) return "";
+            if ((!c.FaceUp && !c.PeekingPlayers.Contains(Player.LocalPlayer)) || c.Type.Model == null) return "";
             return c.Alternate();
         }
 

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
@@ -342,6 +342,7 @@ namespace Octgn.Scripting.Versions
         {
             var c = Card.Find(id);
             if (c == null) return new string[0];
+            if ((!c.FaceUp && !c.PeekingPlayers.Contains(Player.LocalPlayer)) || c.Type.Model == null) return new string[0];
             return c.Alternates();
         }
 
@@ -349,6 +350,7 @@ namespace Octgn.Scripting.Versions
         {
             var c = Card.Find(id);
             if (c == null) return "";
+            if ((!c.FaceUp && !c.PeekingPlayers.Contains(Player.LocalPlayer)) || c.Type.Model == null) return "";
             return c.Alternate();
         }
 

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,0 +1,1 @@
+python cannot see alternates while the card is not visible to you - brine


### PR DESCRIPTION
Removed python's ability to see alternates of facedown cards
- will return the default values for card.alternate and card.alternates
