### PR TITLE
fixed onMoveCards w. moving card within a group

### DIFF
--- a/octgnFX/Octgn/Play/Actions/Move.cs
+++ b/octgnFX/Octgn/Play/Actions/Move.cs
@@ -270,7 +270,7 @@ namespace Octgn.Play.Actions
                             Program.GameMess.PlayerEvent(Who, "reorders {0}", To);
                         card.SetIndex(Idx[iindex]);
                     }
-                    if ((oldGroup != To) || (oldX != X[iindex]) || (oldY != Y[iindex]))
+                    if ((oldGroup != To) || (oldX != X[iindex]) || (oldY != Y[iindex]) || (oldIndex != Idx[iindex]))
                     {
                         if (IsScriptMove) Program.GameEngine.EventProxy.OnScriptedMoveCard_3_1_0_1(Who, card, oldGroup, To, oldIndex, Idx[iindex], oldX, oldY, X[iindex], Y[iindex], IsScriptMove, oldHighlight, oldMarkers);
                         else Program.GameEngine.EventProxy.OnMoveCard_3_1_0_1(Who, card, oldGroup, To, oldIndex, Idx[iindex], oldX, oldY, X[iindex], Y[iindex], IsScriptMove, oldHighlight, oldMarkers);

--- a/octgnFX/Octgn/Play/Card.cs
+++ b/octgnFX/Octgn/Play/Card.cs
@@ -130,7 +130,7 @@ namespace Octgn.Play
                 idxs[i] = cur.Index;
                 fups[i] = cur.FaceUp;
             }
-            MoveCardsTo(to, cards, fups, idxs, isScriptMove);
+//            MoveCardsTo(to, cards, fups, idxs, isScriptMove);
         }
 
         public static void MoveCardsToTable(Card[] cards, int[] x, int[] y, bool[] lFaceUp, int[] idx, bool isScriptMove)


### PR DESCRIPTION
onMoveCards wasn't being triggered when a card was moved within a group,
since it wasn't checking for changes to just a card's index.