### PR TITLE
fix #1426 card.model not working for face-down cards in 3.1.0.1 API

### DIFF
--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_1.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_1.cs
@@ -372,7 +372,7 @@ namespace Octgn.Scripting.Versions
         // Ur dumb that's why.
         {
             Card c = Card.Find(id);
-            if (!c.FaceUp || c.Type.Model == null) return null;
+            //if (!c.FaceUp || c.Type.Model == null) return null;
             return c.Type.Model.Id.ToString();
         }
 


### PR DESCRIPTION
this change was previously done in 3.1.0.0 but someone must have forgotten to copy it in 3.1.0.1