### PR TITLE
Ignore color profile so corrupt color profiles don't break image loading

### DIFF
--- a/octgnFX/Octgn/DeckBuilder/DeckEditorPreviewControl.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/DeckEditorPreviewControl.xaml.cs
@@ -245,6 +245,8 @@ namespace Octgn.DeckBuilder
                     var ret = new BitmapImage();
                     ret.BeginInit();
                     ret.CacheOption = BitmapCacheOption.OnLoad;
+                    // Ignore color profile as a corrupt color profile will cause images to not load.
+                    ret.CreateOptions = BitmapCreateOptions.IgnoreColorProfile;
                     ret.StreamSource = imageStream;
                     //ret.UriSource = new Uri(CardUri, UriKind.Absolute);
                     ret.EndInit();

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+Fix some image loading stuff - Gemini


### PR DESCRIPTION
This was causing images in the deck editor preview not to show if the color profile in the image was corrupted.