### PR TITLE
fixed some issues with editable card properties when dealing with alts

### DIFF
--- a/octgnFX/Octgn/Play/Card.cs
+++ b/octgnFX/Octgn/Play/Card.cs
@@ -532,6 +532,8 @@ namespace Octgn.Play
             if (name.Equals("Id", scompare)) return _type.Model.Id;
             if (!_type.Model.PropertySet().Keys.Any(x => x.Name.Equals(name, scompare))) { return defaultReturn; }
             if (alternate == null)
+                alternate = Alternate();
+            if (alternate == "")
             {
                 if (PropertyOverrides.ContainsKey(name) && PropertyOverrides[name].ContainsKey(""))
                 {
@@ -556,7 +558,9 @@ namespace Octgn.Play
 
         public void SetProperty(string name, object val, bool notifyServer = true)
         {
-            if(PropertyOverrides.ContainsKey(name))
+            if (!(val is string))
+                val = val.ToString(); // Convert the value to a string, as only strings are valid types
+            if (!PropertyOverrides.ContainsKey(name))
                 PropertyOverrides.Add(name, new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase));
             PropertyOverrides[name][Alternate()] = val;
             if (notifyServer)

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+fixed editable card properties when dealing with alternate cards


### PR DESCRIPTION
- the getProperty API call will get the property of whatever 'alternate' side is active, instead of always getting the default ones
- setting properties will always store them as strings, as thats the only type that default properties are stored as
- fixed a bug preventing the first override of a property 