### PR TITLE
Get removed marker in event instead of "None"

### DIFF
--- a/octgnFX/Octgn/Networking/ClientHandler.cs
+++ b/octgnFX/Octgn/Networking/ClientHandler.cs
@@ -485,16 +485,8 @@ namespace Octgn.Networking
                 Program.GameMess.PlayerEvent(player, "removes {0} {1} marker(s) from {2}", count, name, card);
                 if (isScriptChange == false)
                 {
-                    if (player == Player.LocalPlayer && marker == null)
-                    {
-                        Program.GameEngine.EventProxy.OnMarkerChanged_3_1_0_0(card, "None", oldCount, newCount, isScriptChange);
-                        Program.GameEngine.EventProxy.OnMarkerChanged_3_1_0_1(card, "None", oldCount, newCount, isScriptChange);
-                    }
-                    else
-                    {
-                        Program.GameEngine.EventProxy.OnMarkerChanged_3_1_0_0(card, marker.Model.ModelString(), oldCount, newCount, isScriptChange);
-                        Program.GameEngine.EventProxy.OnMarkerChanged_3_1_0_1(card, marker.Model.ModelString(), oldCount, newCount, isScriptChange);
-                    }
+                    Program.GameEngine.EventProxy.OnMarkerChanged_3_1_0_0(card, marker.Model.ModelString(), oldCount, newCount, isScriptChange);
+                    Program.GameEngine.EventProxy.OnMarkerChanged_3_1_0_1(card, marker.Model.ModelString(), oldCount, newCount, isScriptChange);
                 }
 
             }


### PR DESCRIPTION
Since only the local player doesn't get the event "right", this should fix it.