### PR TITLE
all alternates show up in deck editor data grid

### DIFF
--- a/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml.cs
@@ -555,6 +555,7 @@ namespace Octgn.DeckBuilder
             var cardid = e.CardId;
             var set = SetManager.Get().GetById(e.SetId);
             var card = set.Cards.FirstOrDefault(x => x.Id == cardid);
+            card.Alternate = e.Alternate;
             cardImageControl.Card.SetCard(card.Clone());
         }
 
@@ -729,7 +730,7 @@ namespace Octgn.DeckBuilder
             {
                 int cardIndex = activeRow.GetIndex();
                 var getCard = dragSection.Cards.ElementAt(cardIndex);
-                CardSelected(sender, new SearchCardImageEventArgs { SetId = getCard.SetId, Image = getCard.ImageUri, CardId = getCard.Id });
+                CardSelected(sender, new SearchCardImageEventArgs { SetId = getCard.SetId, Image = getCard.ImageUri, CardId = getCard.Id, Alternate = ""});
             }
         }
         private DropAdorner adorner;

--- a/octgnFX/Octgn/DeckBuilder/DeckEditorPreviewControl.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/DeckEditorPreviewControl.xaml.cs
@@ -354,10 +354,11 @@ namespace Octgn.DeckBuilder
                 var i = 0;
                 foreach (var a in c.Properties)
                 {
+                    if (c.Alternate == a.Key)
+                        Index = i;
                     Alternates.Add(new Alternate(this, a.Key, i));
                     i++;
                 }
-                Index = 0;
             }
 
             public event PropertyChangedEventHandler PropertyChanged;

--- a/octgnFX/Octgn/DeckBuilder/SearchControl.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/SearchControl.xaml.cs
@@ -330,7 +330,7 @@ namespace Octgn.DeckBuilder
                     var cardid = row["id"] as string;
                     Log.DebugFormat("Set ID: {0} \nImg Url: {1} \nCard ID: {2}", setid, row["img_uri"], cardid);
                     CardSelected(
-                        this, new SearchCardImageEventArgs { SetId = new Guid(setid), Image = (string)row["img_uri"], CardId = new Guid(cardid) });
+                        this, new SearchCardImageEventArgs { SetId = new Guid(setid), Image = (string)row["img_uri"], CardId = new Guid(cardid), Alternate = (string)row["Alternates"] });
                     Log.Debug("Card selected complete");
                 }
                 else
@@ -521,6 +521,7 @@ namespace Octgn.DeckBuilder
         public Guid SetId { get; set; }
         public Guid CardId { get; set; }
         public string Image { get; set; }
+        public string Alternate { get; set; }
     }
 
     public class SetConverter : IMultiValueConverter

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,2 @@
+alternates will show up in deck editor grid now - brine
 


### PR DESCRIPTION
This just adds all alternate versions of a card to the deck editor's data grid, allowing them to show up when the user creates filters.  Works with subscriber drag/drop images as well.

no mechanism to hide alternates yet, if someone feels this is important please add it in.