### PR TITLE
API version immediately before the most recent one won't get flagged …

### DIFF
--- a/octgnFX/Octgn/Scripting/Versioned.cs
+++ b/octgnFX/Octgn/Scripting/Versioned.cs
@@ -105,7 +105,14 @@ namespace Octgn.Scripting
                     latestLive = v.Value;
 				    continue;
 				}
-				if (v.Value.Mode == ReleaseMode.Test)
+                // the version directly below the most recent version should not expire (we will always allow at least 2 API versions at any given time)
+                if (prevLive.Version == version)
+                {
+                    v.Value.DeleteDate = DateTime.MaxValue;
+                    prevLive = v.Value;
+                    continue;
+                }
+                if (v.Value.Mode == ReleaseMode.Test)
 				{
 				    v.Value.DeleteDate = DateTime.MaxValue;
 				    continue;

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,2 @@
+The API version immediately before the most recent one won't get flagged for incompatibility.
 


### PR DESCRIPTION
…for incompatibility