### PR TITLE
fixed #1578 issues with alternate card image fetching

### DIFF
--- a/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
+++ b/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
@@ -62,16 +62,16 @@ namespace Octgn.Core.DataExtensionMethods
             var set = card.GetSet();
 
             Uri uri = null;
-
-            var path = set.ImagePackUri;
-            if (Directory.Exists(path) == false)
+            
+            var imageUri = card.GetImageUri();
+            if (Directory.Exists(set.ImagePackUri) == false)
             {
-                throw new UserMessageException(L.D.Exception__CanNotFindDirectoryGameDefBroken_Format, path);
+                throw new UserMessageException(L.D.Exception__CanNotFindDirectoryGameDefBroken_Format, set.ImagePackUri);
             }
-            var files = Directory.GetFiles(set.ImagePackUri, card.GetImageUri() + ".*").OrderBy(x => x.Length).ToArray();
+            var files = Directory.GetFiles(set.ImagePackUri, imageUri + ".*").Where(x => Path.GetFileNameWithoutExtension(x) == imageUri).OrderBy(x => x.Length).ToArray();
             if (files.Length == 0) //Generate or grab proxy
             {
-                files = Directory.GetFiles(set.ProxyPackUri, card.GetImageUri() + ".png");
+                files = Directory.GetFiles(set.ProxyPackUri, imageUri + ".png");
                 if (files.Length != 0)
                 {
                     uri = new Uri(files.First());
@@ -82,7 +82,7 @@ namespace Octgn.Core.DataExtensionMethods
 
             if (uri == null)
             {
-                uri = new System.Uri(Path.Combine(set.ProxyPackUri, card.GetImageUri() + ".png"));
+                uri = new System.Uri(Path.Combine(set.ProxyPackUri, imageUri + ".png"));
                 card.GenerateProxyImage(set, uri.LocalPath);
             }
             return uri.LocalPath;

--- a/octgnFX/Octgn/DeckBuilder/DeckEditorPreviewControl.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/DeckEditorPreviewControl.xaml.cs
@@ -287,7 +287,7 @@ namespace Octgn.DeckBuilder
                 {
                     if (Card == null) return false; 
                     var set = Card.GetSet();
-                    var files = Directory.GetFiles(set.ImagePackUri, card.GetImageUri() + ".*").OrderBy(x => x.Length).ToArray();
+                    var files = Directory.GetFiles(set.ImagePackUri, card.GetImageUri() + ".*").Where(x => Path.GetFileNameWithoutExtension(x) == card.GetImageUri()).OrderBy(x => x.Length).ToArray();
                     if (files.Length == 0) return false;
                     return true;
                 }
@@ -437,8 +437,11 @@ namespace Octgn.DeckBuilder
                 var garbage = Config.Instance.Paths.GraveyardPath;
                 if (!Directory.Exists(garbage)) Directory.CreateDirectory(garbage);
 
+                var imageUri = Card.Card.GetImageUri();
+
                 var files =
-                    Directory.GetFiles(set.ImagePackUri, Card.Card.GetImageUri() + ".*")
+                    Directory.GetFiles(set.ImagePackUri, imageUri + ".*")
+                        .Where(x => Path.GetFileNameWithoutExtension(x) == imageUri)
                         .OrderBy(x => x.Length)
                         .ToArray();
 
@@ -448,7 +451,7 @@ namespace Octgn.DeckBuilder
                     f.MoveTo(System.IO.Path.Combine(garbage, f.Name));
                 }
 
-                var newPath = System.IO.Path.Combine(set.ImagePackUri, Card.Card.GetImageUri() + Path.GetExtension(file));
+                var newPath = System.IO.Path.Combine(set.ImagePackUri, imageUri + Path.GetExtension(file));
                 File.Copy(file, newPath);
                 OnPropertyChanged("Card");
 
@@ -530,6 +533,7 @@ namespace Octgn.DeckBuilder
 
                 var files =
                     Directory.GetFiles(set.ImagePackUri, Card.Card.GetImageUri() + ".*")
+                        .Where(x => Path.GetFileNameWithoutExtension(x) == Card.Card.GetImageUri())
                         .OrderBy(x => x.Length)
                         .ToArray();
 

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+Alternate card images load properly when the base card image is missing


### PR DESCRIPTION
Alternate card images load properly when the base card image is missing