### PR TITLE
support for Game Phases

### DIFF
--- a/octgnFX/Octgn.Core/Play/GameMessageDispatcher.cs
+++ b/octgnFX/Octgn.Core/Play/GameMessageDispatcher.cs
@@ -70,6 +70,12 @@
             AddMessage(new TurnMessage(turnPlayer,turnNumber));
         }
 
+
+        public void Phase(IPlayPlayer turnPlayer, string phase)
+        {
+            AddMessage(new PhaseMessage(turnPlayer, phase));
+        }
+
         public void GameDebug(string message, params object[] args)
         {
             AddMessage(new DebugMessage(message, args));
@@ -294,6 +300,20 @@
             TurnPlayer = turnPlayer;
         }
     }
+
+    public class PhaseMessage : GameMessage
+    {
+        public override bool CanMute { get { return false; } }
+        public string Phase { get; private set; }
+        public IPlayPlayer TurnPlayer { get; set; }
+        public PhaseMessage(IPlayPlayer turnPlayer, string phase)
+            : base(BuiltInPlayer.Turn, "{0}: ", new object[] { phase })
+        {
+            Phase = phase;
+            TurnPlayer = turnPlayer;
+        }
+    }
+
 
     public class DebugMessage : GameMessage
     {

--- a/octgnFX/Octgn.DataNew/Entities/Game.cs
+++ b/octgnFX/Octgn.DataNew/Entities/Game.cs
@@ -36,6 +36,7 @@
         public Font ContextFont { get; set; }
         public Font NoteFont { get; set; }
         public Font DeckEditorFont { get; set; }
+        public List<GamePhase> Phases { get; set; }
         public List<Document> Documents { get; set; }
         public Dictionary<string, CardSize> CardSizes { get; set; }
         public Dictionary<string, GameBoard> GameBoards { get; set; } 

--- a/octgnFX/Octgn.DataNew/Entities/GamePhase.cs
+++ b/octgnFX/Octgn.DataNew/Entities/GamePhase.cs
@@ -1,0 +1,8 @@
+﻿namespace Octgn.DataNew.Entities
+{
+    public class GamePhase
+    {
+        public string Name { get; set; }
+        public string Icon { get; set; }
+    }
+}

--- a/octgnFX/Octgn.DataNew/GameSerializer.cs
+++ b/octgnFX/Octgn.DataNew/GameSerializer.cs
@@ -70,6 +70,7 @@ namespace Octgn.DataNew
                               OctgnVersion = Version.Parse(g.octgnVersion),
                               Variables = new List<Variable>(),
                               MarkerSize = g.markersize,
+                              Phases = new List<GamePhase>(),
                               Documents = new List<Document>(),
                               Sounds = new Dictionary<string, GameSound>(),
                               FileHash = fileHash,
@@ -241,6 +242,19 @@ namespace Octgn.DataNew
                 ret.Player = player;
             }
             #endregion Player
+
+            #region phases
+            if (g.phases != null)
+            {
+                foreach (var phase in g.phases)
+                {
+                    var p = new GamePhase();
+                    p.Icon = Path.Combine(directory, phase.icon);
+                    p.Name = phase.name;
+                    ret.Phases.Add(p);
+                }
+            }
+            #endregion phases
 
             #region documents
             if (g.documents != null)

--- a/octgnFX/Octgn.DataNew/Octgn.DataNew.csproj
+++ b/octgnFX/Octgn.DataNew/Octgn.DataNew.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Def.cs" />
     <Compile Include="Entities\Card.cs" />
     <Compile Include="Entities\CardSize.cs" />
+    <Compile Include="Entities\GamePhase.cs" />
     <Compile Include="Entities\Include.cs" />
     <Compile Include="Entities\Counter.cs" />
     <Compile Include="Entities\DataRectangle.cs" />

--- a/octgnFX/Octgn.Library/Schemas/Game.cs
+++ b/octgnFX/Octgn.Library/Schemas/Game.cs
@@ -34,6 +34,8 @@ public partial class game {
     
     private gameProxygen proxygenField;
     
+    private gamePhase[] phasesField;
+    
     private gameDocument[] documentsField;
     
     private gameGameMode[] gameModesField;
@@ -155,6 +157,18 @@ public partial class game {
         }
         set {
             this.proxygenField = value;
+        }
+    }
+    
+    /// <remarks/>
+    [System.Xml.Serialization.XmlArrayAttribute(Form=System.Xml.Schema.XmlSchemaForm.Unqualified)]
+    [System.Xml.Serialization.XmlArrayItemAttribute("phase", Form=System.Xml.Schema.XmlSchemaForm.Unqualified, IsNullable=false)]
+    public gamePhase[] phases {
+        get {
+            return this.phasesField;
+        }
+        set {
+            this.phasesField = value;
         }
     }
     
@@ -1618,6 +1632,41 @@ public partial class gameProxygen {
         }
         set {
             this.definitionsrcField = value;
+        }
+    }
+}
+
+/// <remarks/>
+[System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.1055.0")]
+[System.SerializableAttribute()]
+[System.Diagnostics.DebuggerStepThroughAttribute()]
+[System.ComponentModel.DesignerCategoryAttribute("code")]
+[System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true)]
+public partial class gamePhase {
+    
+    private string nameField;
+    
+    private string iconField;
+    
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public string name {
+        get {
+            return this.nameField;
+        }
+        set {
+            this.nameField = value;
+        }
+    }
+    
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public string icon {
+        get {
+            return this.iconField;
+        }
+        set {
+            this.iconField = value;
         }
     }
 }

--- a/octgnFX/Octgn.Library/Schemas/Game.xsd
+++ b/octgnFX/Octgn.Library/Schemas/Game.xsd
@@ -233,6 +233,42 @@
             </xs:attribute>
           </xs:complexType>
         </xs:element>
+
+        <xs:element name="phases" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+              Defines the set of phases that construct a player's turn
+            </xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="phase" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:annotation>
+                    <xs:documentation>
+                      Defines a single phase
+                    </xs:documentation>
+                  </xs:annotation>
+                  <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                      <xs:documentation>
+                        The name of the phase
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="icon" type="xs:string" use="required">
+                    <xs:annotation>
+                      <xs:documentation>
+                        An icon to associate with the phase.
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        
         <xs:element name="documents" minOccurs="0" maxOccurs="1">
           <xs:annotation>
             <xs:documentation>

--- a/octgnFX/Octgn.Library/Scripting/GameEvents.xml
+++ b/octgnFX/Octgn.Library/Scripting/GameEvents.xml
@@ -342,5 +342,12 @@
       <param name="markers" type ="string[]"/>
       <param name="faceups" type="bool[]"/>
     </event>
+    <event name="OnPhasePassed">
+      <param name="name" type="string"/>
+      <param name="id" type="int" />
+    </event>
+    <event name="OnPhasePaused">
+      <param name="player" type="Player"/>
+    </event>
   </eventversion>
 </events>

--- a/octgnFX/Octgn.Server/BinaryParser.cs
+++ b/octgnFX/Octgn.Server/BinaryParser.cs
@@ -621,6 +621,21 @@ namespace Octgn.Server
 					handler.SetPlayerColor(arg0, arg1);
 					break;
 				}
+				case 103:
+				{
+					byte arg0 = reader.ReadByte();
+					byte arg1 = reader.ReadByte();
+					handler.SetPhase(arg0, arg1);
+					break;
+				}
+				case 104:
+				{
+					int arg0 = reader.ReadInt32();
+					byte arg1 = reader.ReadByte();
+					bool arg2 = reader.ReadBoolean();
+					handler.StopPhaseReq(arg0, arg1, arg2);
+					break;
+				}
 				default:
 					Debug.WriteLine(L.D.ServerMessage__UnknownBinaryMessage + method);
 					break;

--- a/octgnFX/Octgn.Server/BinaryStubs.cs
+++ b/octgnFX/Octgn.Server/BinaryStubs.cs
@@ -1230,6 +1230,38 @@ namespace Octgn.Server
 			writer.Close();
 			Send(stream.ToArray());
 		}
+
+    public void SetPhase(byte phase, byte nextPhase)
+    {
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+      writer.Write(handler.muted);
+			writer.Write((byte)103);
+			writer.Write(phase);
+			writer.Write(nextPhase);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
+
+    public void StopPhase(byte player, byte phase)
+    {
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+      writer.Write(handler.muted);
+			writer.Write((byte)105);
+			writer.Write(player);
+			writer.Write(phase);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
 	}
 	
 	class BinarySenderStub : BaseBinaryStub

--- a/octgnFX/Octgn.Server/Broadcaster.cs
+++ b/octgnFX/Octgn.Server/Broadcaster.cs
@@ -464,5 +464,17 @@ namespace Octgn.Server
       bin.SetPlayerColor(player, color);
       Send();
     }
+
+    public void SetPhase(byte phase, byte nextPhase)
+    {
+      bin.SetPhase(phase, nextPhase);
+      Send();
+    }
+
+    public void StopPhase(byte player, byte phase)
+    {
+      bin.StopPhase(player, phase);
+      Send();
+    }
 	}
 }

--- a/octgnFX/Octgn.Server/IClientCalls.cs
+++ b/octgnFX/Octgn.Server/IClientCalls.cs
@@ -77,5 +77,7 @@ namespace Octgn.Server
 		void Filter(int card, string color);
 		void SetBoard(string name);
 		void SetPlayerColor(byte player, string color);
+		void SetPhase(byte phase, byte nextPhase);
+		void StopPhase(byte player, byte phase);
 	}
 }

--- a/octgnFX/Octgn.Server/Protocol.xml
+++ b/octgnFX/Octgn.Server/Protocol.xml
@@ -530,4 +530,17 @@
 		<param name="player" type="Player"/>
 		<param name="color" type="string"/>
 	</msg>
+  <msg name="SetPhase" client="true" server="true">
+    <param name="phase" type="byte" />
+    <param name="nextPhase" type="byte" />
+  </msg>
+  <msg name="StopPhaseReq" server="true">
+    <param name="turnNumber" type="int" />
+    <param name="phase" type="byte" />
+    <param name="stop" type="bool" />
+  </msg>
+  <msg name="StopPhase" client="true">
+    <param name="player" type="Player" />
+    <param name="phase" type="byte" />
+  </msg>
 </protocol>

--- a/octgnFX/Octgn/Networking/BinaryParser.cs
+++ b/octgnFX/Octgn/Networking/BinaryParser.cs
@@ -821,6 +821,22 @@ namespace Octgn.Networking
 					handler.SetPlayerColor(arg0, arg1);
 					break;
 				}
+				case 103:
+				{
+					byte arg0 = reader.ReadByte();
+					byte arg1 = reader.ReadByte();
+					handler.SetPhase(arg0, arg1);
+					break;
+				}
+				case 105:
+				{
+					Player arg0 = Player.Find(reader.ReadByte());
+					if (arg0 == null)
+					{ Debug.WriteLine("[StopPhase] Player not found."); return; }
+					byte arg1 = reader.ReadByte();
+					handler.StopPhase(arg0, arg1);
+					break;
+				}
 		  default:
 			  Debug.WriteLine("[Client Parser] Unknown message (id =" + method + ")");
 				break;

--- a/octgnFX/Octgn/Networking/BinaryStubs.cs
+++ b/octgnFX/Octgn/Networking/BinaryStubs.cs
@@ -1519,6 +1519,49 @@ namespace Octgn.Networking
 			writer.Close();
 			Send(stream.ToArray());
 		}
+
+		public void SetPhase(byte phase, byte nextPhase)
+		{
+						//Log.Info("[ProtOut] SetPhase");
+					    if(Program.Client == null)return;
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+      if (Program.Client.Muted != 0)
+          writer.Write(Program.Client.Muted);
+      else
+          writer.Write(0);
+			writer.Write((byte)103);
+			writer.Write(phase);
+			writer.Write(nextPhase);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
+
+		public void StopPhaseReq(int turnNumber, byte phase, bool stop)
+		{
+						//Log.Info("[ProtOut] StopPhaseReq");
+					    if(Program.Client == null)return;
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+      if (Program.Client.Muted != 0)
+          writer.Write(Program.Client.Muted);
+      else
+          writer.Write(0);
+			writer.Write((byte)104);
+			writer.Write(turnNumber);
+			writer.Write(phase);
+			writer.Write(stop);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
 	}
 	
 	public class BinarySenderStub : BaseBinaryStub

--- a/octgnFX/Octgn/Networking/IServerCalls.cs
+++ b/octgnFX/Octgn/Networking/IServerCalls.cs
@@ -77,5 +77,7 @@ namespace Octgn.Networking
 		void Filter(Card card, Color? color);
 		void SetBoard(string name);
 		void SetPlayerColor(Player player, string color);
+		void SetPhase(byte phase, byte nextPhase);
+		void StopPhaseReq(int turnNumber, byte phase, bool stop);
 	}
 }

--- a/octgnFX/Octgn/Octgn.csproj
+++ b/octgnFX/Octgn/Octgn.csproj
@@ -432,6 +432,7 @@
     <Compile Include="Launchers\GameTableLauncher.cs" />
     <Compile Include="LobbyConfig.cs" />
     <Compile Include="Networking\ClientSocket.cs" />
+    <Compile Include="Play\Phase.cs" />
     <Compile Include="Play\Events.cs" />
     <Compile Include="Play\Gui\AdhocPileControl.xaml.cs">
       <DependentUpon>AdhocPileControl.xaml</DependentUpon>

--- a/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
+++ b/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
@@ -275,6 +275,31 @@ namespace Octgn.Play.Gui
                 p.Inlines.Add(chatRun);
                 return b;
             }
+            else if (m is PhaseMessage)
+            {
+                if (m.IsMuted) return null;
+
+                var brush = m.From.Color.CacheToBrush();
+
+                var p = new Paragraph();
+                var b = new GameMessageBlock(m);
+                b.TextAlignment = TextAlignment.Center;
+                b.Margin = new Thickness(2);
+                
+                var chatRun = new Run(string.Format(m.Message, m.Arguments));
+                chatRun.Foreground = brush;
+                chatRun.FontWeight = FontWeights.Bold;
+                p.Inlines.Add(chatRun);
+
+                var prun = new Run(" " + (m as PhaseMessage).TurnPlayer + " ");
+                prun.Foreground = (m as PhaseMessage).TurnPlayer.Color.CacheToBrush();
+                prun.FontWeight = FontWeights.Bold;
+                p.Inlines.Add(prun);
+
+                b.Blocks.Add(p);
+                
+                return b;
+            }
             else if (m is TurnMessage)
             {
                 if (m.IsMuted) return null;

--- a/octgnFX/Octgn/Play/Gui/TableControl.xaml.cs
+++ b/octgnFX/Octgn/Play/Gui/TableControl.xaml.cs
@@ -106,7 +106,7 @@ namespace Octgn.Play.Gui
             //if (!Program.GameSettings.HideBoard)
             //    if (tableDef.Board != null)
             //        SetBoard(tableDef);
-
+            
             if (!Program.GameSettings.UseTwoSidedTable)
                 middleLine.Visibility = Visibility.Collapsed;
 
@@ -539,7 +539,7 @@ namespace Octgn.Play.Gui
 
             }
         }
-
+        
         #region Mouse
 
         protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)

--- a/octgnFX/Octgn/Play/Phase.cs
+++ b/octgnFX/Octgn/Play/Phase.cs
@@ -1,0 +1,81 @@
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Octgn.DataNew.Entities;
+using System.Linq;
+using System.Windows;
+using Octgn.Utils;
+
+namespace Octgn.Play
+{
+    public sealed class Phase : INotifyPropertyChanged
+    {
+        
+        internal static Phase Find(byte id)
+        {
+            return Program.GameEngine.AllPhases.FirstOrDefault(p => p.Id == id);
+        }
+
+        private readonly GamePhase _model;
+        private readonly byte _id;
+        private bool _hold;
+        private bool _isActive;
+
+        internal Phase(byte id, GamePhase model)
+        {
+            _id = id;
+            _model = model;
+            _hold = false;
+        }
+        
+        
+        internal byte Id
+        {
+            get { return _id; }
+        }
+
+        public bool Hold
+        {
+            get { return _hold; }
+            set {
+                if (_hold == value) return;
+                _hold = value;
+                OnPropertyChanged("Hold");
+            }
+        }
+    
+        public string Name
+        {
+            get { return _model.Name; }
+        }
+
+        public string Icon
+        {
+            get { return _model.Icon; }
+        }
+        
+        public bool IsActive
+        {
+            get { return _isActive; }
+            set
+            {
+                if (_isActive == value) return;
+                _isActive = value;
+                OnPropertyChanged("IsActive");
+            }
+        }
+
+        #region INotifyPropertyChanged Members
+                 
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        #endregion
+
+        private void OnPropertyChanged(string property)
+        {
+            if (PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(property));
+        }
+    }
+}

--- a/octgnFX/Octgn/Play/PlayWindow.xaml
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml
@@ -305,6 +305,54 @@
             </Grid>
         </Border>
 
+        <Border x:Name="PhaseControl" Grid.Column="0" Grid.Row="2" Canvas.ZIndex="3" HorizontalAlignment="Right">
+            <Border.Resources>
+                <Storyboard x:Key="ShowPhaseStoryboard">
+                    <DoubleAnimation Storyboard.TargetName="PhaseToolBar" Storyboard.TargetProperty="Opacity" From="0.5" To="1.0" Duration="0:0:0.250"/>
+                    <ThicknessAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="Margin" From="0, 0, -300, 0" To="0 0 0 0" Duration="0:0:0.250"/>
+                    <DoubleAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="0:0:0.250"/>
+                </Storyboard>
+                <Storyboard x:Key="HidePhaseStoryboard">
+                    <DoubleAnimation Storyboard.TargetName="PhaseToolBar" Storyboard.TargetProperty="Opacity" From="1.0" To="0.5" Duration="0:0:0.250"/>
+                    <ThicknessAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="Margin" From="0 0 0 0" To="0, 0, -300, 0" Duration="0:0:0.250"/>
+                    <DoubleAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="0:0:0.250"/>
+                </Storyboard>
+            </Border.Resources>
+            <StackPanel Orientation="Vertical" MouseEnter="ShowPhaseStoryboard" MouseLeave="HidePhaseStoryboard" >
+                <StackPanel x:Name="PhaseToolBar" Background="{StaticResource GlassPanelBrush}" Orientation="Vertical" Cursor="Hand" MinWidth="100" Opacity="0.5" Height="45" MouseLeftButtonUp="LockPhaseStoryboard">
+                    <TextBlock Style="{StaticResource PanelText}" Padding="5,2,5,0" HorizontalAlignment="Right" VerticalAlignment="Top" DataContext="{Binding Source={x:Static octgn:Program.GameEngine}, Path=TurnPlayer}" Text="{Binding}" Foreground="{Binding Color}"/>
+                    <TextBlock Style="{StaticResource PanelText}" Padding="5,0,5,2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Text="{Binding Source={x:Static octgn:Program.GameEngine}, Path=CurrentPhase.Name}" />
+                </StackPanel>
+                <Border x:Name="PhaseListBorder" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0, 0, -300, 0"  >
+                    <ItemsControl Name="PhaseList" DataContext="{x:Static octgn:Program.GameEngine}" ItemsSource="{Binding AllPhases}" >
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                    <TextBlock Text="{Binding Name}" Visibility="{Binding IsMouseOver, ElementName=PhaseButton, Converter={StaticResource BooleanToVisibilityHiddenConverter}}" 
+                                          Background="#444444" Foreground="WhiteSmoke" FontWeight="Bold" VerticalAlignment="Center" />
+                                    <Button x:Name="PhaseButton" Click="PhaseClicked" Focusable="False" BorderThickness="3" >
+                                        <Button.Style>
+                                            <Style TargetType="Button">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsActive}" Value="True">
+                                                        <Setter Property="Background" Value="Red"></Setter>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Hold}" Value="True">
+                                                        <Setter Property="BorderBrush" Value="Blue" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Button.Style>
+                                        <Image Source="{Binding Icon}" HorizontalAlignment="Right" />
+                                    </Button>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Border>
+            </StackPanel>
+        </Border>
+
         <StackPanel Grid.Row="1" Canvas.ZIndex="-1">
             <!--<Border BorderThickness="1" Background="Khaki" BorderBrush="Olive" Padding="10,2,10,2" 
                 Visibility="{Binding ElementName=self,Path=ShowSubscribeMessage,Converter={StaticResource BooleanToVisibilityConverter}}">

--- a/octgnFX/Octgn/Play/PlayWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml.cs
@@ -169,6 +169,7 @@ namespace Octgn.Play
             Version oversion = Assembly.GetExecutingAssembly().GetName().Version;
             Title = "Octgn  version : " + oversion + " : " + Program.GameEngine.Definition.Name;
             Program.GameEngine.ComposeParts(this);
+            if (Program.GameEngine.AllPhases.Count() < 1) PhaseControl.Visibility = Visibility.Collapsed;
             this.Loaded += OnLoaded;
             this.chat.MouseEnter += ChatOnMouseEnter;
             this.chat.MouseLeave += ChatOnMouseLeave;
@@ -781,6 +782,48 @@ namespace Octgn.Play
             {
                 Program.Client.Rpc.StopTurnReq(Program.GameEngine.TurnNumber, btn.IsChecked != null && btn.IsChecked.Value);
                 if (btn.IsChecked != null) Program.GameEngine.StopTurn = btn.IsChecked.Value;
+            }
+        }
+
+        private bool LockPhaseList = false;
+
+        private void ShowPhaseStoryboard(object sender, MouseEventArgs e)
+        {
+            if (!LockPhaseList)
+            {
+                Storyboard sb = (Storyboard)PhaseControl.FindResource("ShowPhaseStoryboard");
+                sb.Begin(PhaseControl);
+            }
+        }
+
+        private void HidePhaseStoryboard(object sender, MouseEventArgs e)
+        {
+            if (!LockPhaseList)
+            {
+                Storyboard sb = (Storyboard)PhaseControl.FindResource("HidePhaseStoryboard");
+                sb.Begin(PhaseControl);
+            }
+        }
+
+        private void LockPhaseStoryboard(object sender, MouseEventArgs e)
+        {
+            LockPhaseList = !LockPhaseList;
+        }
+
+        public void PhaseClicked(object sender, RoutedEventArgs e)
+        {
+            var btn = (Button)sender;
+            var phase = (Phase)btn.DataContext;
+            if (Program.GameEngine.TurnPlayer == Player.LocalPlayer)
+            {
+                // turnplayer can change phases
+                Program.Client.Rpc.SetPhase(Program.GameEngine.CurrentPhase == null ? (byte)0 : Program.GameEngine.CurrentPhase.Id, phase.Id);
+            }
+            else
+            {
+                // other players can pause the phase change
+                Program.Client.Rpc.StopPhaseReq(Program.GameEngine.TurnNumber, phase.Id, !phase.Hold);
+                phase.Hold = !phase.Hold;
             }
         }
 

--- a/octgnFX/Octgn/Scripting/GameEvents.cs
+++ b/octgnFX/Octgn/Scripting/GameEvents.cs
@@ -129,6 +129,12 @@ namespace Octgn.Scripting
 								eventCache.Add("OnScriptedCardsMoved",new DataNew.Entities.GameEvent[0]);
 			if(gameEngine.Definition.Events.ContainsKey("OnScriptedCardsMoved"))
 				eventCache["OnScriptedCardsMoved"] = gameEngine.Definition.Events["OnScriptedCardsMoved"];
+								eventCache.Add("OnPhasePassed",new DataNew.Entities.GameEvent[0]);
+			if(gameEngine.Definition.Events.ContainsKey("OnPhasePassed"))
+				eventCache["OnPhasePassed"] = gameEngine.Definition.Events["OnPhasePassed"];
+								eventCache.Add("OnPhasePaused",new DataNew.Entities.GameEvent[0]);
+			if(gameEngine.Definition.Events.ContainsKey("OnPhasePaused"))
+				eventCache["OnPhasePaused"] = gameEngine.Definition.Events["OnPhasePaused"];
 							}
 		private static readonly Version C_3_1_0_0 = Version.Parse("3.1.0.0");
 		public void OnTableLoad_3_1_0_0()
@@ -1423,6 +1429,51 @@ namespace Octgn.Scripting
 			{
 				if(thisVersion < BASEOBJECTVERSION)
 					engine.ExecuteFunction(e.PythonFunction,player, cards, fromGroups, toGroups, indexs, xs, ys, highlights, markers, faceups);
+				else
+				{
+					engine.ExecuteFunction(e.PythonFunction, args);
+				}
+			}
+		}
+		public void OnPhasePassed_3_1_0_2(string name, int id)
+		{
+			if(Player.LocalPlayer.Spectator)return;
+			if(MuteEvents)return;
+			if(gameEngine.Definition.ScriptVersion != C_3_1_0_2 )
+				return;
+			var thisVersion = Version.Parse("3.1.0.2");
+			dynamic args = new System.Dynamic.ExpandoObject();
+			if(thisVersion >= BASEOBJECTVERSION)
+			{
+				args.name = name;
+				args.id = id;
+			}
+			foreach(var e in eventCache["OnPhasePassed"])
+			{
+				if(thisVersion < BASEOBJECTVERSION)
+					engine.ExecuteFunction(e.PythonFunction,name, id);
+				else
+				{
+					engine.ExecuteFunction(e.PythonFunction, args);
+				}
+			}
+		}
+		public void OnPhasePaused_3_1_0_2(Player player)
+		{
+			if(Player.LocalPlayer.Spectator)return;
+			if(MuteEvents)return;
+			if(gameEngine.Definition.ScriptVersion != C_3_1_0_2 )
+				return;
+			var thisVersion = Version.Parse("3.1.0.2");
+			dynamic args = new System.Dynamic.ExpandoObject();
+			if(thisVersion >= BASEOBJECTVERSION)
+			{
+				args.player = player;
+			}
+			foreach(var e in eventCache["OnPhasePaused"])
+			{
+				if(thisVersion < BASEOBJECTVERSION)
+					engine.ExecuteFunction(e.PythonFunction,player);
 				else
 				{
 					engine.ExecuteFunction(e.PythonFunction, args);

--- a/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
+++ b/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
@@ -49,6 +49,13 @@ def playSound(name):
 def turnNumber():
 	return _api.TurnNumber()
 
+def currentPhase():
+	apiResult = _api.GetCurrentPhase()
+	return (apiResult.Item1, apiResult.Item2)
+
+def setPhase(id):
+	_api.SetCurrentPhase(id)
+
 def openUrl(url):
 	return _api.Open_URL(url)
 

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
@@ -71,6 +71,20 @@ namespace Octgn.Scripting.Versions
                 Program.Client.Rpc.NextTurn(Player.Find((byte)id));
         }
 
+        public Tuple<string, int> GetCurrentPhase()
+        {
+            var phase = Program.GameEngine.CurrentPhase;
+            if (phase == null) return new Tuple<string, int>(null, 0);
+            return new Tuple<string, int>(phase.Name, phase.Id);
+        }
+
+        public void SetCurrentPhase(int phase)
+        {
+            if (Phase.Find((byte)phase) == null) return;
+            if (Program.GameEngine.TurnPlayer == Player.LocalPlayer)
+                Program.Client.Rpc.SetPhase(Program.GameEngine.CurrentPhase == null ? (byte)0 : Program.GameEngine.CurrentPhase.Id, (byte)phase);
+        }
+
         public bool IsSubscriber(int id)
         {
             return Player.Find((byte)id).Subscriber;

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+interactive Game Phases toolbar added to game window, with python and event hooks


### PR DESCRIPTION
Adds a phase toolbar to the top-right corner of the play table, which displays the active player name and the current phase name.  Hovering over the toolbar will animate a list of available clickable phases, active player can request phase changes and nonactive players can pause the phase (similar to the pass turn buttons).  Clicking the toolbar will anchor the phase list, so it doesn't disappear.

XML game definition, goes in between 'proxygen' and 'documents'
```xml
<phases>
  <phase name="Main Phase" icon="phases/mainphase.png" />
  <phase name="Battle Phase" icon="phases/battlephase.png" />
</phases>
```

Phases are indexed according to their sequential order listed in the XML, starting at 1 (0 is a null default phase)

python controls:
```python
print currentPhase()
>> ("Main Phase", 1)   ## a tuple, (string phaseName, int phaseId)

setPhase(2) ## int phase Id, must match an existing phase id
```

Events:

OnPhasePassed - reports the data of the previous phase if the phase change was successful
- args.name (string)
- args.id (id)

OnPhasePaused - reports the player holding the phase from changing
- args.player (Player)