### PR TITLE
bulk image importer added to deck editor (sub only)

### DIFF
--- a/octgnFX/Octgn.Core/Prefs.cs
+++ b/octgnFX/Octgn.Core/Prefs.cs
@@ -323,6 +323,25 @@ namespace Octgn.Core
             }
         }
 
+        public static string ImportImagesLastPath
+        {
+            get
+            {
+                var fpath = Config.Instance.ReadValue("ImportImagesLastPath", "");
+                if (string.IsNullOrWhiteSpace(fpath)) return fpath;
+                if (!Directory.Exists(fpath))
+                {
+                    ImportImagesLastPath = "";
+                    return "";
+                }
+                return fpath;
+            }
+            set
+            {
+                Config.Instance.WriteValue("ImportImagesLastPath", value);
+            }
+        }
+
         public static string WindowSkin
         {
             get

--- a/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml
+++ b/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml
@@ -86,6 +86,7 @@
                 <MenuItem Header="Save as..." Command="gui:Commands.SaveDeckAs" />
                 <MenuItem Header="Export as..." Command="gui:Commands.ExportDeckAs" />
                 <MenuItem Header="Share Deck..." Click="ShareDeckClicked"/>
+                <MenuItem Header="Import Images..." Click="ImportImagesClicked"/>
                 <Separator />
                 <MenuItem Header="Close" Click="CloseClicked" />
             </MenuItem>

--- a/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml.cs
@@ -1020,6 +1020,19 @@ namespace Octgn.DeckBuilder
             dlg.ShowDialog();
         }
 
+        private void ImportImagesClicked(object sender, RoutedEventArgs e)
+        {
+            if (Game == null) return;
+            if (SubscriptionModule.Get().IsSubscribed == false)
+            {
+                TopMostMessageBox.Show("You must be a subscriber to use this functionality", "Subscriber Warning",
+                    MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+            var dlg = new ImportImages(Game);
+            dlg.ShowDialog();
+        }
+
         private void ChangeSleeve(object sender, RequestNavigateEventArgs e)
         {
             if (SubscriptionModule.Get().IsSubscribed == false)

--- a/octgnFX/Octgn/Octgn.csproj
+++ b/octgnFX/Octgn/Octgn.csproj
@@ -743,6 +743,9 @@
     <Compile Include="Windows\PickCardFromList.xaml.cs">
       <DependentUpon>PickCardFromList.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Windows\ImportImages.xaml.cs">
+      <DependentUpon>ImportImages.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Windows\ShareDeck.xaml.cs">
       <DependentUpon>ShareDeck.xaml</DependentUpon>
     </Compile>
@@ -1334,6 +1337,10 @@
     <Page Include="Windows\PickCardFromList.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Windows\ImportImages.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Windows\ShareDeck.xaml">
       <SubType>Designer</SubType>

--- a/octgnFX/Octgn/Windows/ImportImages.xaml
+++ b/octgnFX/Octgn/Windows/ImportImages.xaml
@@ -1,0 +1,69 @@
+﻿<controls:DecorableWindow x:Class="Octgn.Windows.ImportImages"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:Octgn.Controls" 
+                          xmlns:me="clr-namespace:Octgn.Windows"
+        CanResize="False" MinMaxButtonVisibility="Collapsed" 
+        MinimizeButtonVisibility="Collapsed" WindowIcon="pack://application:,,,/OCTGN;component/Resources/FileIcons/Deck.ico"
+        SizeToContent="Height"
+        Title="Import Card Images" Height="600" MaxHeight="600" Width="700" MaxWidth="700"
+        x:Name="me" >
+    <controls:DecorableWindow.Resources>
+        <me:PathConverter x:Key="PathConverter" />
+    </controls:DecorableWindow.Resources>
+    <Border Style="{StaticResource DarkPanel}" Padding="5">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="210"/>
+                <ColumnDefinition Width="300*"/>
+            </Grid.ColumnDefinitions>
+            <DockPanel Height="550">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5,0,5,5">
+                    <TextBlock Text="Target Set: "/>
+                    <ComboBox Width="130" x:Name="setsCombo" ItemsSource="{Binding ElementName=me,Path=Sets}" DisplayMemberPath="Name" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5,0,5,5">
+                    <Button Click="ButtonImportFolder" Content="Folder" Padding="3" Style="{StaticResource FlatDarkButtonStyle}" Height="Auto" />
+                    <Grid Width="5" />
+                    <TextBox HorizontalAlignment="Center" Width="160" x:Name="importFolder" IsReadOnly="True" Text="{Binding ElementName=me,Path=FolderDir, Mode=OneWay}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5,0,5,5" >
+                    <TextBlock Text="Property Match: "/>
+                    <ComboBox Width="95" x:Name="propertyCombo" ItemsSource="{Binding ElementName=me,Path=Properties}" DisplayMemberPath="Name" />
+                </StackPanel>
+                <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" FlowDirection="RightToLeft" Margin="5,0,5,5">
+                    <Button Style="{StaticResource FlatDarkButtonStyle}" Content="Cancel" Height="20" Padding="5,0,5,0" Click="CancelClicked"/>
+                    <Grid Width="5" />
+                    <Button Style="{StaticResource FlatDarkGreenButtonStyle}" Content="Load" Height="20" Padding="5,0,5,0" Click="LoadClicked"/>
+                    <Grid Width="5" />
+                    <Button Style="{StaticResource FlatDarkRedButtonStyle}" Content="Import" Height="20" Padding="5,0,5,0" Click="ImportClicked"/>
+                </StackPanel>
+                <ListBox ItemsSource="{Binding ElementName=me, Path=Items}" ScrollViewer.HorizontalScrollBarVisibility="Disabled" SelectedItem="{Binding ElementName=me, Path=SelectedItem}" >
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Path=Name}" Background="Green" />
+                                <TextBlock Text="{Binding Path=Error}" Foreground="Red" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </DockPanel>
+            <ListBox Grid.Column="1" Margin="5 0 0 0" Height="535" ItemsSource="{Binding ElementName=me, Path=SelectedItem.PossiblePaths}" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Disabled" SelectedItem="{Binding ElementName=me, Path=SelectedItem.Path}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Vertical">
+                            <Image Source="{Binding}" Width="100" />
+                            <TextBlock Width="100" Text="{Binding Converter={StaticResource PathConverter}}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+                <ListBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel IsItemsHost="True"/>
+                    </ItemsPanelTemplate>
+                </ListBox.ItemsPanel>
+            </ListBox>
+        </Grid>
+    </Border>
+</controls:DecorableWindow>

--- a/octgnFX/Octgn/Windows/ImportImages.xaml.cs
+++ b/octgnFX/Octgn/Windows/ImportImages.xaml.cs
@@ -1,0 +1,320 @@
+﻿using GalaSoft.MvvmLight.Messaging;
+using Octgn.UiMessages;
+
+namespace Octgn.Windows
+{
+    using System;
+    using System.ComponentModel;
+    using System.IO;
+    using System.Windows;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Windows.Forms;
+    using System.Text.RegularExpressions;
+
+    using log4net;
+
+    using Octgn.Annotations;
+    using Octgn.Core.DataExtensionMethods;
+    using Octgn.DataNew.Entities;
+    using System.Linq;
+    using Octgn.DeckBuilder;
+    using Octgn.Library;
+    using Octgn.Controls;
+    using System.Windows.Data;
+    using Octgn.Core;
+
+    /// <summary>
+    /// Interaction logic for ImportImages.xaml
+    /// </summary>
+    public partial class ImportImages : INotifyPropertyChanged
+    {
+
+        public ImportImages() : this(null)
+        {
+        }
+
+        public ImportImages(Game game)
+        {
+            Game = game;
+            if (!string.IsNullOrWhiteSpace(Prefs.ImportImagesLastPath))
+                FolderDir = Prefs.ImportImagesLastPath;
+            Items = new ObservableCollection<ImportImagesItem>();
+            Sets = (new SetPropertyDef(Game.Sets())).Sets;
+            Properties = game.AllProperties();
+            InitializeComponent();
+            setsCombo.SelectedIndex = 0;
+            propertyCombo.SelectedIndex = 0;
+        }
+
+        public Game Game { get; private set; }
+        public IEnumerable<Set> Sets { get; private set; }
+        public IEnumerable<PropertyDef> Properties { get; private set; }
+        public ObservableCollection<ImportImagesItem> Items { get; private set; }
+        public static ObservableCollection<string> ImagePaths;
+
+        private ImportImagesItem _selectedItem;
+
+        public ImportImagesItem SelectedItem
+        {
+            get { return _selectedItem; }
+            set
+            {
+                if (value == _selectedItem) return;
+                _selectedItem = value;
+                OnPropertyChanged("SelectedItem");
+            }
+        }
+        
+        private string _folderDir;
+
+        public string FolderDir
+        {
+            get
+            { return _folderDir; }
+            set
+            {
+                if (value == _folderDir) return;
+                _folderDir = value;
+                OnPropertyChanged("FolderDir");
+            }
+        }
+        
+        public string SanitizeString(string name)
+        {
+            string ret = new string(name.Where(char.IsLetterOrDigit).ToArray()).ToLower().TrimStart('0');
+            return ret;
+        }
+
+
+        private void ButtonImportFolder(object sender, RoutedEventArgs e)
+        {
+            var dialog = new FolderBrowserDialog();
+            if (FolderDir != null && Directory.Exists(FolderDir)) dialog.SelectedPath = FolderDir;
+            dialog.ShowDialog();
+            FolderDir = dialog.SelectedPath;
+            Prefs.ImportImagesLastPath = (string)dialog.SelectedPath;
+        }
+
+        private void LoadClicked(object sender, RoutedEventArgs e)
+        {
+            if (setsCombo.SelectedItem == null) return;
+            if (propertyCombo.SelectedItem == null) return;
+            if (!Directory.Exists(FolderDir)) return;
+            Items.Clear();
+            var selectedSet = setsCombo.SelectedItem as Set;
+
+            var selectedProperty = propertyCombo.SelectedItem as PropertyDef;
+            ImagePaths = new ObservableCollection<string>(Directory.EnumerateFiles(FolderDir).Where(file => Regex.IsMatch(file, @"^.+\.(jpg|jpeg|png)$")));
+
+            foreach (var c in selectedSet.Cards)
+            {
+                foreach (var alternate in c.Properties)
+                {
+                    Card card = new Card(c);
+                    card.Alternate = alternate.Key;
+                    var cardPropertyValue = card.Properties[card.Alternate].Properties[selectedProperty].ToString();
+                    var sanitizedValue = SanitizeString(cardPropertyValue);
+
+                    // first check for exact matches, then if none show up we check for partial matches
+                    var matchedImages = ImagePaths.Where(x => SanitizeString(Path.GetFileNameWithoutExtension(x)) == sanitizedValue).ToList();
+                    if (matchedImages.Count() < 1) matchedImages = ImagePaths.Where(x => SanitizeString(Path.GetFileNameWithoutExtension(x)).Contains(sanitizedValue)).ToList();
+
+                    var ret = new ImportImagesItem() { Path = null, Card = card, Filter = sanitizedValue, PossiblePaths = null };
+
+                    if (matchedImages.Count() < 1)
+                    {
+                    }
+                    else if (matchedImages.Count() > 1)
+                    {
+                        ret.PossiblePaths = new ObservableCollection<string>(matchedImages);
+                    }
+                    else
+                    {
+                        var singleImage = matchedImages.First();
+                        ret.Path = singleImage;
+                        ImagePaths.Remove(singleImage);
+                        ret.PossiblePaths = new ObservableCollection<string>(matchedImages);
+                    }
+                    Items.Add(ret);
+                }
+            }
+            OnPropertyChanged("Items");
+        }
+
+        private void ImportClicked(object sender, RoutedEventArgs e)
+        {
+            if (Items.Where(x => x.Path == null).Count() > 0)
+            {
+                var res = TopMostMessageBox.Show("Not all cards have an image matched.  Continue?", "Missing Images Warning",
+                        MessageBoxButton.YesNo,
+                        MessageBoxImage.Exclamation);
+                if (res == MessageBoxResult.No)
+                    return;
+            }
+            
+            foreach (var item in Items)
+            {
+
+                var file = item.Path;
+                if (!File.Exists(file)) continue;
+
+                var card = item.Card;
+                var set = card.GetSet();
+                var garbage = Config.Instance.Paths.GraveyardPath;
+                if (!Directory.Exists(garbage)) Directory.CreateDirectory(garbage);
+                var imageUri = card.GetImageUri();
+
+                var files =
+                    Directory.GetFiles(set.ImagePackUri, imageUri + ".*")
+                        .Where(x => Path.GetFileNameWithoutExtension(x).Equals(imageUri, StringComparison.InvariantCultureIgnoreCase))
+                        .OrderBy(x => x.Length)
+                        .ToArray();
+
+                // Delete all the old picture files
+                foreach (var f in files.Select(x => new FileInfo(x)))
+                {
+                    f.MoveTo(System.IO.Path.Combine(garbage, f.Name));
+                }
+
+                var newPath = System.IO.Path.Combine(set.ImagePackUri, imageUri + Path.GetExtension(file));
+                File.Copy(file, newPath);
+            }
+            this.Close();
+        }
+        
+        private void CancelClicked(object sender, RoutedEventArgs e)
+        {
+            this.Close();
+        }
+
+        public new event PropertyChangedEventHandler PropertyChanged;
+
+        [NotifyPropertyChangedInvocator]
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            var handler = PropertyChanged;
+            if (handler != null)
+            {
+                handler(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+    }
+
+    public class PathConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return Path.GetFileNameWithoutExtension(value as string);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+
+    }
+
+    public partial class ImportImagesItem : INotifyPropertyChanged
+    {
+        private Card _card;
+        
+        private string _path;
+
+        private ObservableCollection<string> _possiblePaths;
+
+        private string _filter;
+
+        public ImportImagesItem()
+        {
+        }
+
+        public Card Card
+        {
+            get
+            {
+                return _card;
+            }
+            set
+            {
+                if (_card == value) return;
+                _card = value;
+                OnPropertyChanged("Card");
+            }
+        }
+
+        public string Name
+        {
+            get
+            {
+                return _card.Properties[_card.Alternate].Properties.Where(x => x.Key.Name == "Name").First().Value.ToString();
+            }
+        }
+        
+        public ObservableCollection<string> PossiblePaths
+        {
+            get
+            {
+                if (_possiblePaths == null || _possiblePaths.Count() < 1) return ImportImages.ImagePaths;
+                return _possiblePaths;
+            }
+            set
+            {
+                if (_possiblePaths == value) return;
+                _possiblePaths = value;
+                OnPropertyChanged("PossiblePaths");
+            }
+        }
+
+        public string Error
+        {
+            get
+            {
+                if (_path != null) return null;
+                if (_possiblePaths == null) return "No Images Found";
+                else return "Multiple Images Found";
+            }
+        }
+
+        public string Filter
+        {
+            get
+            {
+                return _filter;
+            }
+            set
+            {
+                if (_filter == value) return;
+                _filter = value;
+                OnPropertyChanged("Filter");
+            }
+        }
+
+        public string Path
+        {
+            get
+            {
+                return _path;
+            }
+            set
+            {
+                if (_path == value) return;
+                _path = value;
+                OnPropertyChanged("Path");
+                OnPropertyChanged("Error");
+            }
+        }
+
+        public new event PropertyChangedEventHandler PropertyChanged;
+
+        [NotifyPropertyChangedInvocator]
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            var handler = PropertyChanged;
+            if (handler != null)
+            {
+                handler(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+    }
+}

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,3 @@
+Added a bulk card image importer option to deck editor (sub only)
+
 


### PR DESCRIPTION
sooooo I have  no idea if we actually want to keep this within the program, or pull it out into a deck editor plugin.  It's not very pretty but it works.

I have a basic string sanitizer function that's used to compare the filename to a matched card property, I'm not good with regex or smart matching functions so if anyone has any cool ideas feel free to improve it.

Also, I kept the subscriber lock on it, unsure if we still care about that or not.