### PR TITLE
Major changes to the Phase system

### DIFF
--- a/octgnFX/Octgn.Library/Scripting/GameEvents.xml
+++ b/octgnFX/Octgn.Library/Scripting/GameEvents.xml
@@ -267,6 +267,8 @@
     <event name="OnTurnPassed">
       <!-- Triggers when the turn is passed to another player -->
       <param name="player" type="Player"/>
+      <param name="turn" type="int"/>
+      <param name="force" type="bool"/>
     </event>
     <event name="OnCardTargeted">
       <param name="player" type="Player"/>
@@ -345,6 +347,7 @@
     <event name="OnPhasePassed">
       <param name="name" type="string"/>
       <param name="id" type="int" />
+      <param name="force" type="bool" />
     </event>
     <event name="OnPhasePaused">
       <param name="player" type="Player"/>
@@ -362,6 +365,10 @@
     </event>
     <event name="OverrideGameReset" />
     <event name="OverridePhasePassed">
+      <param name="name" type="string"/>
+      <param name="id" type="int" />
+    </event>
+    <event name="OverridePhaseClicked">
       <param name="name" type="string"/>
       <param name="id" type="int" />
     </event>

--- a/octgnFX/Octgn.Server/BinaryParser.cs
+++ b/octgnFX/Octgn.Server/BinaryParser.cs
@@ -114,7 +114,8 @@ namespace Octgn.Server
 				{
 					byte arg0 = reader.ReadByte();
 					bool arg1 = reader.ReadBoolean();
-					handler.NextTurn(arg0, arg1);
+					bool arg2 = reader.ReadBoolean();
+					handler.NextTurn(arg0, arg1, arg2);
 					break;
 				}
 				case 17:
@@ -126,24 +127,49 @@ namespace Octgn.Server
 				}
 				case 19:
 				{
+					byte arg0 = reader.ReadByte();
+					bool arg1 = reader.ReadBoolean();
+					handler.SetPhaseReq(arg0, arg1);
+					break;
+				}
+				case 21:
+				{
+					byte arg0 = reader.ReadByte();
+					bool arg1 = reader.ReadBoolean();
+					handler.StopPhaseReq(arg0, arg1);
+					break;
+				}
+				case 22:
+				{
+					byte arg0 = reader.ReadByte();
+					handler.SetActivePlayer(arg0);
+					break;
+				}
+				case 23:
+				{
+					handler.ClearActivePlayer();
+					break;
+				}
+				case 24:
+				{
 					string arg0 = reader.ReadString();
 					handler.ChatReq(arg0);
 					break;
 				}
-				case 21:
+				case 26:
 				{
 					string arg0 = reader.ReadString();
 					handler.PrintReq(arg0);
 					break;
 				}
-				case 23:
+				case 28:
 				{
 					int arg0 = reader.ReadInt32();
 					int arg1 = reader.ReadInt32();
 					handler.RandomReq(arg0, arg1);
 					break;
 				}
-				case 25:
+				case 30:
 				{
 					int arg0 = reader.ReadInt32();
 					int arg1 = reader.ReadInt32();
@@ -151,7 +177,7 @@ namespace Octgn.Server
 					handler.CounterReq(arg0, arg1, arg2);
 					break;
 				}
-				case 27:
+				case 32:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -174,7 +200,7 @@ namespace Octgn.Server
 					handler.LoadDeck(arg0, arg1, arg2, arg3, arg4, arg5);
 					break;
 				}
-				case 28:
+				case 33:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -192,7 +218,7 @@ namespace Octgn.Server
 					handler.CreateCard(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 29:
+				case 34:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -215,7 +241,7 @@ namespace Octgn.Server
 					handler.CreateCardAt(arg0, arg1, arg2, arg3, arg4, arg5);
 					break;
 				}
-				case 30:
+				case 35:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -228,7 +254,7 @@ namespace Octgn.Server
 					handler.CreateAliasDeprecated(arg0, arg1);
 					break;
 				}
-				case 31:
+				case 36:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -247,7 +273,7 @@ namespace Octgn.Server
 					handler.MoveCardReq(arg0, arg1, arg2, arg3, arg4);
 					break;
 				}
-				case 33:
+				case 38:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -273,27 +299,27 @@ namespace Octgn.Server
 					handler.MoveCardAtReq(arg0, arg1, arg2, arg3, arg4, arg5);
 					break;
 				}
-				case 35:
+				case 40:
 				{
 					int arg0 = reader.ReadInt32();
 					handler.PeekReq(arg0);
 					break;
 				}
-				case 37:
+				case 42:
 				{
 					int arg0 = reader.ReadInt32();
 					bool arg1 = reader.ReadBoolean();
 					handler.UntargetReq(arg0, arg1);
 					break;
 				}
-				case 39:
+				case 44:
 				{
 					int arg0 = reader.ReadInt32();
 					bool arg1 = reader.ReadBoolean();
 					handler.TargetReq(arg0, arg1);
 					break;
 				}
-				case 41:
+				case 46:
 				{
 					int arg0 = reader.ReadInt32();
 					int arg1 = reader.ReadInt32();
@@ -301,28 +327,28 @@ namespace Octgn.Server
 					handler.TargetArrowReq(arg0, arg1, arg2);
 					break;
 				}
-				case 43:
+				case 48:
 				{
 					int arg0 = reader.ReadInt32();
 					string arg1 = reader.ReadString();
 					handler.Highlight(arg0, arg1);
 					break;
 				}
-				case 44:
+				case 49:
 				{
 					int arg0 = reader.ReadInt32();
 					bool arg1 = reader.ReadBoolean();
 					handler.TurnReq(arg0, arg1);
 					break;
 				}
-				case 46:
+				case 51:
 				{
 					int arg0 = reader.ReadInt32();
 					CardOrientation arg1 = (CardOrientation)reader.ReadByte();
 					handler.RotateReq(arg0, arg1);
 					break;
 				}
-				case 48:
+				case 53:
 				{
 					int arg0 = reader.ReadInt32();
 					length = reader.ReadInt16();
@@ -332,7 +358,7 @@ namespace Octgn.Server
 					handler.ShuffleDeprecated(arg0, arg1);
 					break;
 				}
-				case 49:
+				case 54:
 				{
 					byte arg0 = reader.ReadByte();
 					int arg1 = reader.ReadInt32();
@@ -347,13 +373,13 @@ namespace Octgn.Server
 					handler.Shuffled(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 50:
+				case 55:
 				{
 					int arg0 = reader.ReadInt32();
 					handler.UnaliasGrpDeprecated(arg0);
 					break;
 				}
-				case 51:
+				case 56:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -366,7 +392,7 @@ namespace Octgn.Server
 					handler.UnaliasDeprecated(arg0, arg1);
 					break;
 				}
-				case 52:
+				case 57:
 				{
 					int arg0 = reader.ReadInt32();
 					Guid arg1 = new Guid(reader.ReadBytes(16));
@@ -377,7 +403,7 @@ namespace Octgn.Server
 					handler.AddMarkerReq(arg0, arg1, arg2, arg3, arg4, arg5);
 					break;
 				}
-				case 54:
+				case 59:
 				{
 					int arg0 = reader.ReadInt32();
 					Guid arg1 = new Guid(reader.ReadBytes(16));
@@ -388,7 +414,7 @@ namespace Octgn.Server
 					handler.RemoveMarkerReq(arg0, arg1, arg2, arg3, arg4, arg5);
 					break;
 				}
-				case 56:
+				case 61:
 				{
 					int arg0 = reader.ReadInt32();
 					int arg1 = reader.ReadInt32();
@@ -400,7 +426,7 @@ namespace Octgn.Server
 					handler.TransferMarkerReq(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
 					break;
 				}
-				case 58:
+				case 63:
 				{
 					int arg0 = reader.ReadInt32();
 					byte arg1 = reader.ReadByte();
@@ -408,27 +434,27 @@ namespace Octgn.Server
 					handler.PassToReq(arg0, arg1, arg2);
 					break;
 				}
-				case 60:
+				case 65:
 				{
 					int arg0 = reader.ReadInt32();
 					byte arg1 = reader.ReadByte();
 					handler.TakeFromReq(arg0, arg1);
 					break;
 				}
-				case 62:
+				case 67:
 				{
 					int arg0 = reader.ReadInt32();
 					byte arg1 = reader.ReadByte();
 					handler.DontTakeReq(arg0, arg1);
 					break;
 				}
-				case 64:
+				case 69:
 				{
 					int arg0 = reader.ReadInt32();
 					handler.FreezeCardsVisibility(arg0);
 					break;
 				}
-				case 65:
+				case 70:
 				{
 					int arg0 = reader.ReadInt32();
 					bool arg1 = reader.ReadBoolean();
@@ -436,21 +462,21 @@ namespace Octgn.Server
 					handler.GroupVisReq(arg0, arg1, arg2);
 					break;
 				}
-				case 67:
+				case 72:
 				{
 					int arg0 = reader.ReadInt32();
 					byte arg1 = reader.ReadByte();
 					handler.GroupVisAddReq(arg0, arg1);
 					break;
 				}
-				case 69:
+				case 74:
 				{
 					int arg0 = reader.ReadInt32();
 					byte arg1 = reader.ReadByte();
 					handler.GroupVisRemoveReq(arg0, arg1);
 					break;
 				}
-				case 71:
+				case 76:
 				{
 					int arg0 = reader.ReadInt32();
 					int arg1 = reader.ReadInt32();
@@ -458,7 +484,7 @@ namespace Octgn.Server
 					handler.LookAtReq(arg0, arg1, arg2);
 					break;
 				}
-				case 73:
+				case 78:
 				{
 					int arg0 = reader.ReadInt32();
 					int arg1 = reader.ReadInt32();
@@ -467,7 +493,7 @@ namespace Octgn.Server
 					handler.LookAtTopReq(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 75:
+				case 80:
 				{
 					int arg0 = reader.ReadInt32();
 					int arg1 = reader.ReadInt32();
@@ -476,7 +502,7 @@ namespace Octgn.Server
 					handler.LookAtBottomReq(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 77:
+				case 82:
 				{
 					length = reader.ReadInt16();
 					Guid[] arg0 = new Guid[length];
@@ -485,12 +511,12 @@ namespace Octgn.Server
 					handler.StartLimitedReq(arg0);
 					break;
 				}
-				case 79:
+				case 84:
 				{
 					handler.CancelLimitedReq();
 					break;
 				}
-				case 81:
+				case 86:
 				{
 					byte arg0 = reader.ReadByte();
 					int arg1 = reader.ReadInt32();
@@ -498,7 +524,7 @@ namespace Octgn.Server
 					handler.CardSwitchTo(arg0, arg1, arg2);
 					break;
 				}
-				case 82:
+				case 87:
 				{
 					byte arg0 = reader.ReadByte();
 					string arg1 = reader.ReadString();
@@ -507,7 +533,7 @@ namespace Octgn.Server
 					handler.PlayerSetGlobalVariable(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 83:
+				case 88:
 				{
 					string arg0 = reader.ReadString();
 					string arg1 = reader.ReadString();
@@ -515,31 +541,31 @@ namespace Octgn.Server
 					handler.SetGlobalVariable(arg0, arg1, arg2);
 					break;
 				}
-				case 85:
+				case 90:
 				{
 					handler.Ping();
 					break;
 				}
-				case 86:
+				case 91:
 				{
 					bool arg0 = reader.ReadBoolean();
 					handler.IsTableBackgroundFlipped(arg0);
 					break;
 				}
-				case 87:
+				case 92:
 				{
 					byte arg0 = reader.ReadByte();
 					string arg1 = reader.ReadString();
 					handler.PlaySound(arg0, arg1);
 					break;
 				}
-				case 88:
+				case 93:
 				{
 					byte arg0 = reader.ReadByte();
 					handler.Ready(arg0);
 					break;
 				}
-				case 90:
+				case 95:
 				{
 					byte arg0 = reader.ReadByte();
 					string arg1 = reader.ReadString();
@@ -547,27 +573,27 @@ namespace Octgn.Server
 					handler.RemoteCall(arg0, arg1, arg2);
 					break;
 				}
-				case 91:
+				case 96:
 				{
 					byte arg0 = reader.ReadByte();
 					handler.GameStateReq(arg0);
 					break;
 				}
-				case 92:
+				case 97:
 				{
 					byte arg0 = reader.ReadByte();
 					string arg1 = reader.ReadString();
 					handler.GameState(arg0, arg1);
 					break;
 				}
-				case 93:
+				case 98:
 				{
 					int arg0 = reader.ReadInt32();
 					byte arg1 = reader.ReadByte();
 					handler.DeleteCard(arg0, arg1);
 					break;
 				}
-				case 95:
+				case 100:
 				{
 					length = reader.ReadInt16();
 					Guid[] arg0 = new Guid[length];
@@ -577,7 +603,7 @@ namespace Octgn.Server
 					handler.AddPacksReq(arg0, arg1);
 					break;
 				}
-				case 97:
+				case 102:
 				{
 					int arg0 = reader.ReadInt32();
 					byte arg1 = reader.ReadByte();
@@ -585,7 +611,7 @@ namespace Octgn.Server
 					handler.AnchorCard(arg0, arg1, arg2);
 					break;
 				}
-				case 98:
+				case 103:
 				{
 					int arg0 = reader.ReadInt32();
 					byte arg1 = reader.ReadByte();
@@ -595,47 +621,31 @@ namespace Octgn.Server
 					handler.SetCardProperty(arg0, arg1, arg2, arg3, arg4);
 					break;
 				}
-				case 99:
+				case 104:
 				{
 					int arg0 = reader.ReadInt32();
 					byte arg1 = reader.ReadByte();
 					handler.ResetCardProperties(arg0, arg1);
 					break;
 				}
-				case 100:
+				case 105:
 				{
 					int arg0 = reader.ReadInt32();
 					string arg1 = reader.ReadString();
 					handler.Filter(arg0, arg1);
 					break;
 				}
-				case 101:
+				case 106:
 				{
 					string arg0 = reader.ReadString();
 					handler.SetBoard(arg0);
 					break;
 				}
-				case 102:
+				case 107:
 				{
 					byte arg0 = reader.ReadByte();
 					string arg1 = reader.ReadString();
 					handler.SetPlayerColor(arg0, arg1);
-					break;
-				}
-				case 103:
-				{
-					byte arg0 = reader.ReadByte();
-					byte arg1 = reader.ReadByte();
-					bool arg2 = reader.ReadBoolean();
-					handler.SetPhase(arg0, arg1, arg2);
-					break;
-				}
-				case 104:
-				{
-					int arg0 = reader.ReadInt32();
-					byte arg1 = reader.ReadByte();
-					bool arg2 = reader.ReadBoolean();
-					handler.StopPhaseReq(arg0, arg1, arg2);
 					break;
 				}
 				default:

--- a/octgnFX/Octgn.Server/BinaryStubs.cs
+++ b/octgnFX/Octgn.Server/BinaryStubs.cs
@@ -192,7 +192,7 @@ namespace Octgn.Server
 			Send(stream.ToArray());
 		}
 
-    public void NextTurn(byte nextPlayer, bool force)
+    public void NextTurn(byte player, bool setActive, bool force)
     {
 			MemoryStream stream = new MemoryStream(512);
 			stream.Seek(4, SeekOrigin.Begin);
@@ -200,7 +200,8 @@ namespace Octgn.Server
 
       writer.Write(handler.muted);
 			writer.Write((byte)16);
-			writer.Write(nextPlayer);
+			writer.Write(player);
+			writer.Write(setActive);
 			writer.Write(force);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -223,7 +224,7 @@ namespace Octgn.Server
 			Send(stream.ToArray());
 		}
 
-    public void Chat(byte player, string text)
+    public void SetPhase(byte phase, byte[] players, bool force)
     {
 			MemoryStream stream = new MemoryStream(512);
 			stream.Seek(4, SeekOrigin.Begin);
@@ -231,6 +232,54 @@ namespace Octgn.Server
 
       writer.Write(handler.muted);
 			writer.Write((byte)20);
+			writer.Write(phase);
+			writer.Write((short)players.Length);
+			foreach (byte p in players)
+				writer.Write(p);
+			writer.Write(force);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
+
+    public void SetActivePlayer(byte player)
+    {
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+      writer.Write(handler.muted);
+			writer.Write((byte)22);
+			writer.Write(player);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
+
+    public void ClearActivePlayer()
+    {
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+      writer.Write(handler.muted);
+			writer.Write((byte)23);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
+
+    public void Chat(byte player, string text)
+    {
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+      writer.Write(handler.muted);
+			writer.Write((byte)25);
 			writer.Write(player);
 			writer.Write(text);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -246,7 +295,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)22);
+			writer.Write((byte)27);
 			writer.Write(player);
 			writer.Write(text);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -262,7 +311,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)24);
+			writer.Write((byte)29);
 			writer.Write(result);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -277,7 +326,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)26);
+			writer.Write((byte)31);
 			writer.Write(player);
 			writer.Write(counter);
 			writer.Write(value);
@@ -295,7 +344,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)27);
+			writer.Write((byte)32);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
 				writer.Write(p);
@@ -323,7 +372,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)28);
+			writer.Write((byte)33);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
 				writer.Write(p);
@@ -347,7 +396,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)29);
+			writer.Write((byte)34);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
 				writer.Write(p);
@@ -375,7 +424,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)30);
+			writer.Write((byte)35);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
 				writer.Write(p);
@@ -395,7 +444,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)32);
+			writer.Write((byte)37);
 			writer.Write(player);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
@@ -421,7 +470,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)34);
+			writer.Write((byte)39);
 			writer.Write(player);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
@@ -452,7 +501,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)36);
+			writer.Write((byte)41);
 			writer.Write(player);
 			writer.Write(card);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -468,7 +517,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)38);
+			writer.Write((byte)43);
 			writer.Write(player);
 			writer.Write(card);
 			writer.Write(isScriptChange);
@@ -485,7 +534,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)40);
+			writer.Write((byte)45);
 			writer.Write(player);
 			writer.Write(card);
 			writer.Write(isScriptChange);
@@ -502,7 +551,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)42);
+			writer.Write((byte)47);
 			writer.Write(player);
 			writer.Write(card);
 			writer.Write(otherCard);
@@ -520,7 +569,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)43);
+			writer.Write((byte)48);
 			writer.Write(card);
 			writer.Write(color);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -536,7 +585,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)45);
+			writer.Write((byte)50);
 			writer.Write(player);
 			writer.Write(card);
 			writer.Write(up);
@@ -553,7 +602,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)47);
+			writer.Write((byte)52);
 			writer.Write(player);
 			writer.Write(card);
 			writer.Write((byte)rot);
@@ -570,7 +619,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)48);
+			writer.Write((byte)53);
 			writer.Write(group);
 			writer.Write((short)card.Length);
 			foreach (int p in card)
@@ -588,7 +637,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)49);
+			writer.Write((byte)54);
 			writer.Write(player);
 			writer.Write(group);
 			writer.Write((short)card.Length);
@@ -610,7 +659,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)50);
+			writer.Write((byte)55);
 			writer.Write(group);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -625,7 +674,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)51);
+			writer.Write((byte)56);
 			writer.Write((short)card.Length);
 			foreach (int p in card)
 				writer.Write(p);
@@ -645,7 +694,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)53);
+			writer.Write((byte)58);
 			writer.Write(player);
 			writer.Write(card);
 			writer.Write(id.ToByteArray());
@@ -666,7 +715,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)55);
+			writer.Write((byte)60);
 			writer.Write(player);
 			writer.Write(card);
 			writer.Write(id.ToByteArray());
@@ -687,7 +736,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)57);
+			writer.Write((byte)62);
 			writer.Write(player);
 			writer.Write(from);
 			writer.Write(to);
@@ -709,7 +758,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)59);
+			writer.Write((byte)64);
 			writer.Write(player);
 			writer.Write(id);
 			writer.Write(to);
@@ -727,7 +776,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)61);
+			writer.Write((byte)66);
 			writer.Write(id);
 			writer.Write(to);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -743,7 +792,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)63);
+			writer.Write((byte)68);
 			writer.Write(id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -758,7 +807,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)64);
+			writer.Write((byte)69);
 			writer.Write(group);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -773,7 +822,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)66);
+			writer.Write((byte)71);
 			writer.Write(player);
 			writer.Write(group);
 			writer.Write(defined);
@@ -791,7 +840,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)68);
+			writer.Write((byte)73);
 			writer.Write(player);
 			writer.Write(group);
 			writer.Write(who);
@@ -808,7 +857,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)70);
+			writer.Write((byte)75);
 			writer.Write(player);
 			writer.Write(group);
 			writer.Write(who);
@@ -825,7 +874,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)72);
+			writer.Write((byte)77);
 			writer.Write(player);
 			writer.Write(uid);
 			writer.Write(group);
@@ -843,7 +892,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)74);
+			writer.Write((byte)79);
 			writer.Write(player);
 			writer.Write(uid);
 			writer.Write(group);
@@ -862,7 +911,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)76);
+			writer.Write((byte)81);
 			writer.Write(player);
 			writer.Write(uid);
 			writer.Write(group);
@@ -881,7 +930,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)78);
+			writer.Write((byte)83);
 			writer.Write(player);
 			writer.Write((short)packs.Length);
 			foreach (Guid g in packs)
@@ -899,7 +948,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)80);
+			writer.Write((byte)85);
 			writer.Write(player);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -914,7 +963,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)81);
+			writer.Write((byte)86);
 			writer.Write(player);
 			writer.Write(card);
 			writer.Write(alternate);
@@ -931,7 +980,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)82);
+			writer.Write((byte)87);
 			writer.Write(player);
 			writer.Write(name);
 			writer.Write(oldval);
@@ -949,7 +998,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)83);
+			writer.Write((byte)88);
 			writer.Write(name);
 			writer.Write(oldval);
 			writer.Write(val);
@@ -966,7 +1015,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)85);
+			writer.Write((byte)90);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
 			writer.Close();
@@ -980,7 +1029,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)86);
+			writer.Write((byte)91);
 			writer.Write(isFlipped);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -995,7 +1044,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)87);
+			writer.Write((byte)92);
 			writer.Write(player);
 			writer.Write(name);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1011,7 +1060,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)88);
+			writer.Write((byte)93);
 			writer.Write(player);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -1026,7 +1075,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)89);
+			writer.Write((byte)94);
 			writer.Write(player);
 			writer.Write(state);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1042,7 +1091,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)90);
+			writer.Write((byte)95);
 			writer.Write(player);
 			writer.Write(function);
 			writer.Write(args);
@@ -1059,7 +1108,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)91);
+			writer.Write((byte)96);
 			writer.Write(player);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -1074,7 +1123,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)92);
+			writer.Write((byte)97);
 			writer.Write(toPlayer);
 			writer.Write(state);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1090,7 +1139,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)93);
+			writer.Write((byte)98);
 			writer.Write(card);
 			writer.Write(player);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1106,7 +1155,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)94);
+			writer.Write((byte)99);
 			writer.Write(player);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -1121,7 +1170,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)96);
+			writer.Write((byte)101);
 			writer.Write(player);
 			writer.Write((short)packs.Length);
 			foreach (Guid g in packs)
@@ -1140,7 +1189,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)97);
+			writer.Write((byte)102);
 			writer.Write(id);
 			writer.Write(player);
 			writer.Write(anchor);
@@ -1157,7 +1206,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)98);
+			writer.Write((byte)103);
 			writer.Write(id);
 			writer.Write(player);
 			writer.Write(name);
@@ -1176,7 +1225,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)99);
+			writer.Write((byte)104);
 			writer.Write(id);
 			writer.Write(player);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1192,7 +1241,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)100);
+			writer.Write((byte)105);
 			writer.Write(card);
 			writer.Write(color);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1208,7 +1257,7 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)101);
+			writer.Write((byte)106);
 			writer.Write(name);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -1223,42 +1272,9 @@ namespace Octgn.Server
 			BinaryWriter writer = new BinaryWriter(stream);
 
       writer.Write(handler.muted);
-			writer.Write((byte)102);
+			writer.Write((byte)107);
 			writer.Write(player);
 			writer.Write(color);
-			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
-			writer.Write((int)stream.Length);
-			writer.Close();
-			Send(stream.ToArray());
-		}
-
-    public void SetPhase(byte phase, byte nextPhase, bool force)
-    {
-			MemoryStream stream = new MemoryStream(512);
-			stream.Seek(4, SeekOrigin.Begin);
-			BinaryWriter writer = new BinaryWriter(stream);
-
-      writer.Write(handler.muted);
-			writer.Write((byte)103);
-			writer.Write(phase);
-			writer.Write(nextPhase);
-			writer.Write(force);
-			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
-			writer.Write((int)stream.Length);
-			writer.Close();
-			Send(stream.ToArray());
-		}
-
-    public void StopPhase(byte player, byte phase)
-    {
-			MemoryStream stream = new MemoryStream(512);
-			stream.Seek(4, SeekOrigin.Begin);
-			BinaryWriter writer = new BinaryWriter(stream);
-
-      writer.Write(handler.muted);
-			writer.Write((byte)105);
-			writer.Write(player);
-			writer.Write(phase);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
 			writer.Close();

--- a/octgnFX/Octgn.Server/Broadcaster.cs
+++ b/octgnFX/Octgn.Server/Broadcaster.cs
@@ -117,15 +117,33 @@ namespace Octgn.Server
       Send();
     }
 
-    public void NextTurn(byte nextPlayer, bool force)
+    public void NextTurn(byte player, bool setActive, bool force)
     {
-      bin.NextTurn(nextPlayer, force);
+      bin.NextTurn(player, setActive, force);
       Send();
     }
 
     public void StopTurn(byte player)
     {
       bin.StopTurn(player);
+      Send();
+    }
+
+    public void SetPhase(byte phase, byte[] players, bool force)
+    {
+      bin.SetPhase(phase, players, force);
+      Send();
+    }
+
+    public void SetActivePlayer(byte player)
+    {
+      bin.SetActivePlayer(player);
+      Send();
+    }
+
+    public void ClearActivePlayer()
+    {
+      bin.ClearActivePlayer();
       Send();
     }
 
@@ -462,18 +480,6 @@ namespace Octgn.Server
     public void SetPlayerColor(byte player, string color)
     {
       bin.SetPlayerColor(player, color);
-      Send();
-    }
-
-    public void SetPhase(byte phase, byte nextPhase, bool force)
-    {
-      bin.SetPhase(phase, nextPhase, force);
-      Send();
-    }
-
-    public void StopPhase(byte player, byte phase)
-    {
-      bin.StopPhase(player, phase);
       Send();
     }
 	}

--- a/octgnFX/Octgn.Server/IClientCalls.cs
+++ b/octgnFX/Octgn.Server/IClientCalls.cs
@@ -19,8 +19,11 @@ namespace Octgn.Server
 		void Nick(byte player, string nick);
 		void Start();
 		void Reset(byte player);
-		void NextTurn(byte nextPlayer, bool force);
+		void NextTurn(byte player, bool setActive, bool force);
 		void StopTurn(byte player);
+		void SetPhase(byte phase, byte[] players, bool force);
+		void SetActivePlayer(byte player);
+		void ClearActivePlayer();
 		void Chat(byte player, string text);
 		void Print(byte player, string text);
 		void Random(int result);
@@ -77,7 +80,5 @@ namespace Octgn.Server
 		void Filter(int card, string color);
 		void SetBoard(string name);
 		void SetPlayerColor(byte player, string color);
-		void SetPhase(byte phase, byte nextPhase, bool force);
-		void StopPhase(byte player, byte phase);
 	}
 }

--- a/octgnFX/Octgn.Server/Protocol.xml
+++ b/octgnFX/Octgn.Server/Protocol.xml
@@ -77,9 +77,11 @@
   </msg>
 
   <msg name="NextTurn" client="true" server="true">
-    <param name="nextPlayer" type="Player" />
+    <param name="player" type="Player" />
+    <param name="setActive" type="bool" />
     <param name="force" type="bool" />
   </msg>
+      
   <msg name="StopTurnReq" server="true">
     <param name="turnNumber" type="int" />
     <param name="stop" type="bool" />
@@ -88,6 +90,28 @@
     <param name="player" type="Player" />
   </msg>
 
+  <msg name="SetPhaseReq" server="true">
+    <param name="nextPhase" type="byte" />
+    <param name="force" type="bool" />
+  </msg>
+  <msg name="SetPhase" client="true">
+    <param name="phase" type="byte" />
+    <param name="players" type="Player[]" />
+    <param name="force" type="bool" />
+  </msg>
+
+  <msg name="StopPhaseReq" server="true">
+    <param name="phase" type="byte" />
+    <param name="stop" type="bool" />
+  </msg>
+
+  <msg name="SetActivePlayer" client="true" server="true">
+    <param name="player" type="Player" />
+  </msg>
+
+  <msg name="ClearActivePlayer" client="true" server="true">
+  </msg>
+  
   <msg name="ChatReq" server="true" allowedbyspectator="true">
     <param name="text" type="string" />
   </msg>
@@ -531,18 +555,4 @@
 		<param name="player" type="Player"/>
 		<param name="color" type="string"/>
 	</msg>
-  <msg name="SetPhase" client="true" server="true">
-    <param name="phase" type="byte" />
-    <param name="nextPhase" type="byte" />
-    <param name="force" type="bool" />
-  </msg>
-  <msg name="StopPhaseReq" server="true">
-    <param name="turnNumber" type="int" />
-    <param name="phase" type="byte" />
-    <param name="stop" type="bool" />
-  </msg>
-  <msg name="StopPhase" client="true">
-    <param name="player" type="Player" />
-    <param name="phase" type="byte" />
-  </msg>
 </protocol>

--- a/octgnFX/Octgn/Networking/BinaryParser.cs
+++ b/octgnFX/Octgn/Networking/BinaryParser.cs
@@ -118,7 +118,8 @@ namespace Octgn.Networking
 					if (arg0 == null)
 					{ Debug.WriteLine("[NextTurn] Player not found."); return; }
 					bool arg1 = reader.ReadBoolean();
-					handler.NextTurn(arg0, arg1);
+					bool arg2 = reader.ReadBoolean();
+					handler.NextTurn(arg0, arg1, arg2);
 					break;
 				}
 				case 18:
@@ -131,6 +132,34 @@ namespace Octgn.Networking
 				}
 				case 20:
 				{
+					byte arg0 = reader.ReadByte();
+					length = reader.ReadInt16();
+					Player[] arg1 = new Player[length];
+					for (int i = 0; i < length; ++i)
+					{
+					  arg1[i] = Player.Find(reader.ReadByte());
+					  if (arg1[i] == null) 
+					    Debug.WriteLine("[SetPhase] Player not found.");
+					}
+					bool arg2 = reader.ReadBoolean();
+					handler.SetPhase(arg0, arg1, arg2);
+					break;
+				}
+				case 22:
+				{
+					Player arg0 = Player.Find(reader.ReadByte());
+					if (arg0 == null)
+					{ Debug.WriteLine("[SetActivePlayer] Player not found."); return; }
+					handler.SetActivePlayer(arg0);
+					break;
+				}
+				case 23:
+				{
+					handler.ClearActivePlayer();
+					break;
+				}
+				case 25:
+				{
 					Player arg0 = Player.FindIncludingSpectators(reader.ReadByte());
 					if (arg0 == null)
 					{ Debug.WriteLine("[Chat] Player not found."); return; }
@@ -138,7 +167,7 @@ namespace Octgn.Networking
 					handler.Chat(arg0, arg1);
 					break;
 				}
-				case 22:
+				case 27:
 				{
 					Player arg0 = Player.FindIncludingSpectators(reader.ReadByte());
 					if (arg0 == null)
@@ -147,13 +176,13 @@ namespace Octgn.Networking
 					handler.Print(arg0, arg1);
 					break;
 				}
-				case 24:
+				case 29:
 				{
 					int arg0 = reader.ReadInt32();
 					handler.Random(arg0);
 					break;
 				}
-				case 26:
+				case 31:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -166,7 +195,7 @@ namespace Octgn.Networking
 					handler.Counter(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 27:
+				case 32:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -193,7 +222,7 @@ namespace Octgn.Networking
 					handler.LoadDeck(arg0, arg1, arg2, arg3, arg4, arg5);
 					break;
 				}
-				case 28:
+				case 33:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -213,7 +242,7 @@ namespace Octgn.Networking
 					handler.CreateCard(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 29:
+				case 34:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -236,7 +265,7 @@ namespace Octgn.Networking
 					handler.CreateCardAt(arg0, arg1, arg2, arg3, arg4, arg5);
 					break;
 				}
-				case 30:
+				case 35:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -249,7 +278,7 @@ namespace Octgn.Networking
 					handler.CreateAliasDeprecated(arg0, arg1);
 					break;
 				}
-				case 32:
+				case 37:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -273,7 +302,7 @@ namespace Octgn.Networking
 					handler.MoveCard(arg0, arg1, arg2, arg3, arg4, arg5);
 					break;
 				}
-				case 34:
+				case 39:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -302,7 +331,7 @@ namespace Octgn.Networking
 					handler.MoveCardAt(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
 					break;
 				}
-				case 36:
+				case 41:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -313,7 +342,7 @@ namespace Octgn.Networking
 					handler.Peek(arg0, arg1);
 					break;
 				}
-				case 38:
+				case 43:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -325,7 +354,7 @@ namespace Octgn.Networking
 					handler.Untarget(arg0, arg1, arg2);
 					break;
 				}
-				case 40:
+				case 45:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -337,7 +366,7 @@ namespace Octgn.Networking
 					handler.Target(arg0, arg1, arg2);
 					break;
 				}
-				case 42:
+				case 47:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -352,7 +381,7 @@ namespace Octgn.Networking
 					handler.TargetArrow(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 43:
+				case 48:
 				{
 					Card arg0 = Card.Find(reader.ReadInt32());
 					if (arg0 == null)
@@ -362,7 +391,7 @@ namespace Octgn.Networking
 					handler.Highlight(arg0, arg1);
 					break;
 				}
-				case 45:
+				case 50:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -374,7 +403,7 @@ namespace Octgn.Networking
 					handler.Turn(arg0, arg1, arg2);
 					break;
 				}
-				case 47:
+				case 52:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -386,7 +415,7 @@ namespace Octgn.Networking
 					handler.Rotate(arg0, arg1, arg2);
 					break;
 				}
-				case 48:
+				case 53:
 				{
 					Group arg0 = Group.Find(reader.ReadInt32());
 					if (arg0 == null)
@@ -398,7 +427,7 @@ namespace Octgn.Networking
 					handler.ShuffleDeprecated(arg0, arg1);
 					break;
 				}
-				case 49:
+				case 54:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -417,7 +446,7 @@ namespace Octgn.Networking
 					handler.Shuffled(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 50:
+				case 55:
 				{
 					Group arg0 = Group.Find(reader.ReadInt32());
 					if (arg0 == null)
@@ -425,7 +454,7 @@ namespace Octgn.Networking
 					handler.UnaliasGrpDeprecated(arg0);
 					break;
 				}
-				case 51:
+				case 56:
 				{
 					length = reader.ReadInt16();
 					int[] arg0 = new int[length];
@@ -438,7 +467,7 @@ namespace Octgn.Networking
 					handler.UnaliasDeprecated(arg0, arg1);
 					break;
 				}
-				case 53:
+				case 58:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -454,7 +483,7 @@ namespace Octgn.Networking
 					handler.AddMarker(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
 					break;
 				}
-				case 55:
+				case 60:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -470,7 +499,7 @@ namespace Octgn.Networking
 					handler.RemoveMarker(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
 					break;
 				}
-				case 57:
+				case 62:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -489,7 +518,7 @@ namespace Octgn.Networking
 					handler.TransferMarker(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
 					break;
 				}
-				case 59:
+				case 64:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -504,7 +533,7 @@ namespace Octgn.Networking
 					handler.PassTo(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 61:
+				case 66:
 				{
 					ControllableObject arg0 = ControllableObject.Find(reader.ReadInt32());
 					if (arg0 == null)
@@ -515,7 +544,7 @@ namespace Octgn.Networking
 					handler.TakeFrom(arg0, arg1);
 					break;
 				}
-				case 63:
+				case 68:
 				{
 					ControllableObject arg0 = ControllableObject.Find(reader.ReadInt32());
 					if (arg0 == null)
@@ -523,7 +552,7 @@ namespace Octgn.Networking
 					handler.DontTake(arg0);
 					break;
 				}
-				case 64:
+				case 69:
 				{
 					Group arg0 = Group.Find(reader.ReadInt32());
 					if (arg0 == null)
@@ -531,7 +560,7 @@ namespace Octgn.Networking
 					handler.FreezeCardsVisibility(arg0);
 					break;
 				}
-				case 66:
+				case 71:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -544,7 +573,7 @@ namespace Octgn.Networking
 					handler.GroupVis(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 68:
+				case 73:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -558,7 +587,7 @@ namespace Octgn.Networking
 					handler.GroupVisAdd(arg0, arg1, arg2);
 					break;
 				}
-				case 70:
+				case 75:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -572,7 +601,7 @@ namespace Octgn.Networking
 					handler.GroupVisRemove(arg0, arg1, arg2);
 					break;
 				}
-				case 72:
+				case 77:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -585,7 +614,7 @@ namespace Octgn.Networking
 					handler.LookAt(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 74:
+				case 79:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -599,7 +628,7 @@ namespace Octgn.Networking
 					handler.LookAtTop(arg0, arg1, arg2, arg3, arg4);
 					break;
 				}
-				case 76:
+				case 81:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -613,7 +642,7 @@ namespace Octgn.Networking
 					handler.LookAtBottom(arg0, arg1, arg2, arg3, arg4);
 					break;
 				}
-				case 78:
+				case 83:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -625,7 +654,7 @@ namespace Octgn.Networking
 					handler.StartLimited(arg0, arg1);
 					break;
 				}
-				case 80:
+				case 85:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -633,7 +662,7 @@ namespace Octgn.Networking
 					handler.CancelLimited(arg0);
 					break;
 				}
-				case 81:
+				case 86:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -645,7 +674,7 @@ namespace Octgn.Networking
 					handler.CardSwitchTo(arg0, arg1, arg2);
 					break;
 				}
-				case 82:
+				case 87:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -656,7 +685,7 @@ namespace Octgn.Networking
 					handler.PlayerSetGlobalVariable(arg0, arg1, arg2, arg3);
 					break;
 				}
-				case 83:
+				case 88:
 				{
 					string arg0 = reader.ReadString();
 					string arg1 = reader.ReadString();
@@ -664,18 +693,18 @@ namespace Octgn.Networking
 					handler.SetGlobalVariable(arg0, arg1, arg2);
 					break;
 				}
-				case 85:
+				case 90:
 				{
 					handler.Ping();
 					break;
 				}
-				case 86:
+				case 91:
 				{
 					bool arg0 = reader.ReadBoolean();
 					handler.IsTableBackgroundFlipped(arg0);
 					break;
 				}
-				case 87:
+				case 92:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -684,7 +713,7 @@ namespace Octgn.Networking
 					handler.PlaySound(arg0, arg1);
 					break;
 				}
-				case 88:
+				case 93:
 				{
 					Player arg0 = Player.FindIncludingSpectators(reader.ReadByte());
 					if (arg0 == null)
@@ -692,7 +721,7 @@ namespace Octgn.Networking
 					handler.Ready(arg0);
 					break;
 				}
-				case 89:
+				case 94:
 				{
 					Player arg0 = Player.FindIncludingSpectators(reader.ReadByte());
 					if (arg0 == null)
@@ -701,7 +730,7 @@ namespace Octgn.Networking
 					handler.PlayerState(arg0, arg1);
 					break;
 				}
-				case 90:
+				case 95:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -711,7 +740,7 @@ namespace Octgn.Networking
 					handler.RemoteCall(arg0, arg1, arg2);
 					break;
 				}
-				case 91:
+				case 96:
 				{
 					Player arg0 = Player.FindIncludingSpectators(reader.ReadByte());
 					if (arg0 == null)
@@ -719,7 +748,7 @@ namespace Octgn.Networking
 					handler.GameStateReq(arg0);
 					break;
 				}
-				case 92:
+				case 97:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -728,7 +757,7 @@ namespace Octgn.Networking
 					handler.GameState(arg0, arg1);
 					break;
 				}
-				case 93:
+				case 98:
 				{
 					Card arg0 = Card.Find(reader.ReadInt32());
 					if (arg0 == null)
@@ -739,7 +768,7 @@ namespace Octgn.Networking
 					handler.DeleteCard(arg0, arg1);
 					break;
 				}
-				case 94:
+				case 99:
 				{
 					Player arg0 = Player.FindIncludingSpectators(reader.ReadByte());
 					if (arg0 == null)
@@ -747,7 +776,7 @@ namespace Octgn.Networking
 					handler.PlayerDisconnect(arg0);
 					break;
 				}
-				case 96:
+				case 101:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
@@ -760,7 +789,7 @@ namespace Octgn.Networking
 					handler.AddPacks(arg0, arg1, arg2);
 					break;
 				}
-				case 97:
+				case 102:
 				{
 					Card arg0 = Card.Find(reader.ReadInt32());
 					if (arg0 == null)
@@ -772,7 +801,7 @@ namespace Octgn.Networking
 					handler.AnchorCard(arg0, arg1, arg2);
 					break;
 				}
-				case 98:
+				case 103:
 				{
 					Card arg0 = Card.Find(reader.ReadInt32());
 					if (arg0 == null)
@@ -786,7 +815,7 @@ namespace Octgn.Networking
 					handler.SetCardProperty(arg0, arg1, arg2, arg3, arg4);
 					break;
 				}
-				case 99:
+				case 104:
 				{
 					Card arg0 = Card.Find(reader.ReadInt32());
 					if (arg0 == null)
@@ -797,7 +826,7 @@ namespace Octgn.Networking
 					handler.ResetCardProperties(arg0, arg1);
 					break;
 				}
-				case 100:
+				case 105:
 				{
 					Card arg0 = Card.Find(reader.ReadInt32());
 					if (arg0 == null)
@@ -807,36 +836,19 @@ namespace Octgn.Networking
 					handler.Filter(arg0, arg1);
 					break;
 				}
-				case 101:
+				case 106:
 				{
 					string arg0 = reader.ReadString();
 					handler.SetBoard(arg0);
 					break;
 				}
-				case 102:
+				case 107:
 				{
 					Player arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)
 					{ Debug.WriteLine("[SetPlayerColor] Player not found."); return; }
 					string arg1 = reader.ReadString();
 					handler.SetPlayerColor(arg0, arg1);
-					break;
-				}
-				case 103:
-				{
-					byte arg0 = reader.ReadByte();
-					byte arg1 = reader.ReadByte();
-					bool arg2 = reader.ReadBoolean();
-					handler.SetPhase(arg0, arg1, arg2);
-					break;
-				}
-				case 105:
-				{
-					Player arg0 = Player.Find(reader.ReadByte());
-					if (arg0 == null)
-					{ Debug.WriteLine("[StopPhase] Player not found."); return; }
-					byte arg1 = reader.ReadByte();
-					handler.StopPhase(arg0, arg1);
 					break;
 				}
 		  default:

--- a/octgnFX/Octgn/Networking/BinaryStubs.cs
+++ b/octgnFX/Octgn/Networking/BinaryStubs.cs
@@ -254,7 +254,7 @@ namespace Octgn.Networking
 			Send(stream.ToArray());
 		}
 
-		public void NextTurn(Player nextPlayer, bool force)
+		public void NextTurn(Player player, bool setActive, bool force)
 		{
 						//Log.Info("[ProtOut] NextTurn");
 					    if(Program.Client == null)return;
@@ -267,7 +267,8 @@ namespace Octgn.Networking
       else
           writer.Write(0);
 			writer.Write((byte)16);
-			writer.Write(nextPlayer.Id);
+			writer.Write(player.Id);
+			writer.Write(setActive);
 			writer.Write(force);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -296,6 +297,87 @@ namespace Octgn.Networking
 			Send(stream.ToArray());
 		}
 
+		public void SetPhaseReq(byte nextPhase, bool force)
+		{
+						//Log.Info("[ProtOut] SetPhaseReq");
+					    if(Program.Client == null)return;
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+      if (Program.Client.Muted != 0)
+          writer.Write(Program.Client.Muted);
+      else
+          writer.Write(0);
+			writer.Write((byte)19);
+			writer.Write(nextPhase);
+			writer.Write(force);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
+
+		public void StopPhaseReq(byte phase, bool stop)
+		{
+						//Log.Info("[ProtOut] StopPhaseReq");
+					    if(Program.Client == null)return;
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+      if (Program.Client.Muted != 0)
+          writer.Write(Program.Client.Muted);
+      else
+          writer.Write(0);
+			writer.Write((byte)21);
+			writer.Write(phase);
+			writer.Write(stop);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
+
+		public void SetActivePlayer(Player player)
+		{
+						//Log.Info("[ProtOut] SetActivePlayer");
+					    if(Program.Client == null)return;
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+      if (Program.Client.Muted != 0)
+          writer.Write(Program.Client.Muted);
+      else
+          writer.Write(0);
+			writer.Write((byte)22);
+			writer.Write(player.Id);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
+
+		public void ClearActivePlayer()
+		{
+						//Log.Info("[ProtOut] ClearActivePlayer");
+					    if(Program.Client == null)return;
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+      if (Program.Client.Muted != 0)
+          writer.Write(Program.Client.Muted);
+      else
+          writer.Write(0);
+			writer.Write((byte)23);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
+
 		public void ChatReq(string text)
 		{
 						//Log.Info("[ProtOut] ChatReq");
@@ -308,7 +390,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)19);
+			writer.Write((byte)24);
 			writer.Write(text);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -328,7 +410,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)21);
+			writer.Write((byte)26);
 			writer.Write(text);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -348,7 +430,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)23);
+			writer.Write((byte)28);
 			writer.Write(min);
 			writer.Write(max);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -369,7 +451,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)25);
+			writer.Write((byte)30);
 			writer.Write(counter.Id);
 			writer.Write(value);
 			writer.Write(isScriptChange);
@@ -391,7 +473,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)27);
+			writer.Write((byte)32);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
 				writer.Write(p);
@@ -424,7 +506,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)28);
+			writer.Write((byte)33);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
 				writer.Write(p);
@@ -453,7 +535,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)29);
+			writer.Write((byte)34);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
 				writer.Write(p);
@@ -486,7 +568,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)30);
+			writer.Write((byte)35);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
 				writer.Write(p);
@@ -511,7 +593,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)31);
+			writer.Write((byte)36);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
 				writer.Write(p);
@@ -541,7 +623,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)33);
+			writer.Write((byte)38);
 			writer.Write((short)id.Length);
 			foreach (int p in id)
 				writer.Write(p);
@@ -576,7 +658,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)35);
+			writer.Write((byte)40);
 			writer.Write(card.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -596,7 +678,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)37);
+			writer.Write((byte)42);
 			writer.Write(card.Id);
 			writer.Write(isScriptChange);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -617,7 +699,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)39);
+			writer.Write((byte)44);
 			writer.Write(card.Id);
 			writer.Write(isScriptChange);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -638,7 +720,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)41);
+			writer.Write((byte)46);
 			writer.Write(card.Id);
 			writer.Write(otherCard.Id);
 			writer.Write(isScriptChange);
@@ -660,7 +742,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)43);
+			writer.Write((byte)48);
 			writer.Write(card.Id);
 			writer.Write(color == null ? "" : color.ToString());
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -681,7 +763,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)44);
+			writer.Write((byte)49);
 			writer.Write(card.Id);
 			writer.Write(up);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -702,7 +784,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)46);
+			writer.Write((byte)51);
 			writer.Write(card.Id);
 			writer.Write((byte)rot);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -723,7 +805,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)48);
+			writer.Write((byte)53);
 			writer.Write(group.Id);
 			writer.Write((short)card.Length);
 			foreach (int p in card)
@@ -746,7 +828,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)49);
+			writer.Write((byte)54);
 			writer.Write(player.Id);
 			writer.Write(group.Id);
 			writer.Write((short)card.Length);
@@ -773,7 +855,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)50);
+			writer.Write((byte)55);
 			writer.Write(group.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -793,7 +875,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)51);
+			writer.Write((byte)56);
 			writer.Write((short)card.Length);
 			foreach (int p in card)
 				writer.Write(p);
@@ -818,7 +900,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)52);
+			writer.Write((byte)57);
 			writer.Write(card.Id);
 			writer.Write(id.ToByteArray());
 			writer.Write(name);
@@ -843,7 +925,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)54);
+			writer.Write((byte)59);
 			writer.Write(card.Id);
 			writer.Write(id.ToByteArray());
 			writer.Write(name);
@@ -868,7 +950,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)56);
+			writer.Write((byte)61);
 			writer.Write(from.Id);
 			writer.Write(to.Id);
 			writer.Write(id.ToByteArray());
@@ -894,7 +976,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)58);
+			writer.Write((byte)63);
 			writer.Write(id.Id);
 			writer.Write(to.Id);
 			writer.Write(requested);
@@ -916,7 +998,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)60);
+			writer.Write((byte)65);
 			writer.Write(id.Id);
 			writer.Write(from.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -937,7 +1019,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)62);
+			writer.Write((byte)67);
 			writer.Write(id.Id);
 			writer.Write(to.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -958,7 +1040,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)64);
+			writer.Write((byte)69);
 			writer.Write(group.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -978,7 +1060,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)65);
+			writer.Write((byte)70);
 			writer.Write(group.Id);
 			writer.Write(defined);
 			writer.Write(visible);
@@ -1000,7 +1082,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)67);
+			writer.Write((byte)72);
 			writer.Write(group.Id);
 			writer.Write(who.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1021,7 +1103,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)69);
+			writer.Write((byte)74);
 			writer.Write(group.Id);
 			writer.Write(who.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1042,7 +1124,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)71);
+			writer.Write((byte)76);
 			writer.Write(uid);
 			writer.Write(group.Id);
 			writer.Write(look);
@@ -1064,7 +1146,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)73);
+			writer.Write((byte)78);
 			writer.Write(uid);
 			writer.Write(group.Id);
 			writer.Write(count);
@@ -1087,7 +1169,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)75);
+			writer.Write((byte)80);
 			writer.Write(uid);
 			writer.Write(group.Id);
 			writer.Write(count);
@@ -1110,7 +1192,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)77);
+			writer.Write((byte)82);
 			writer.Write((short)packs.Length);
 			foreach (Guid g in packs)
 				writer.Write(g.ToByteArray());
@@ -1132,7 +1214,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)79);
+			writer.Write((byte)84);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
 			writer.Close();
@@ -1151,7 +1233,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)81);
+			writer.Write((byte)86);
 			writer.Write(player.Id);
 			writer.Write(card.Id);
 			writer.Write(alternate);
@@ -1173,7 +1255,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)82);
+			writer.Write((byte)87);
 			writer.Write(player.Id);
 			writer.Write(name);
 			writer.Write(oldval);
@@ -1196,7 +1278,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)83);
+			writer.Write((byte)88);
 			writer.Write(name);
 			writer.Write(oldval);
 			writer.Write(val);
@@ -1217,7 +1299,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)85);
+			writer.Write((byte)90);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
 			writer.Close();
@@ -1236,7 +1318,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)86);
+			writer.Write((byte)91);
 			writer.Write(isFlipped);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -1256,7 +1338,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)87);
+			writer.Write((byte)92);
 			writer.Write(player.Id);
 			writer.Write(name);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1277,7 +1359,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)88);
+			writer.Write((byte)93);
 			writer.Write(player.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -1297,7 +1379,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)90);
+			writer.Write((byte)95);
 			writer.Write(player.Id);
 			writer.Write(function);
 			writer.Write(args);
@@ -1319,7 +1401,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)91);
+			writer.Write((byte)96);
 			writer.Write(player.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -1339,7 +1421,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)92);
+			writer.Write((byte)97);
 			writer.Write(toPlayer.Id);
 			writer.Write(state);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1360,7 +1442,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)93);
+			writer.Write((byte)98);
 			writer.Write(card.Id);
 			writer.Write(player.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1381,7 +1463,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)95);
+			writer.Write((byte)100);
 			writer.Write((short)packs.Length);
 			foreach (Guid g in packs)
 				writer.Write(g.ToByteArray());
@@ -1404,7 +1486,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)97);
+			writer.Write((byte)102);
 			writer.Write(id.Id);
 			writer.Write(player.Id);
 			writer.Write(anchor);
@@ -1426,7 +1508,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)98);
+			writer.Write((byte)103);
 			writer.Write(id.Id);
 			writer.Write(player.Id);
 			writer.Write(name);
@@ -1450,7 +1532,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)99);
+			writer.Write((byte)104);
 			writer.Write(id.Id);
 			writer.Write(player.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1471,7 +1553,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)100);
+			writer.Write((byte)105);
 			writer.Write(card.Id);
 			writer.Write(color == null ? "" : color.ToString());
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
@@ -1492,7 +1574,7 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)101);
+			writer.Write((byte)106);
 			writer.Write(name);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
@@ -1512,53 +1594,9 @@ namespace Octgn.Networking
           writer.Write(Program.Client.Muted);
       else
           writer.Write(0);
-			writer.Write((byte)102);
+			writer.Write((byte)107);
 			writer.Write(player.Id);
 			writer.Write(color);
-			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
-			writer.Write((int)stream.Length);
-			writer.Close();
-			Send(stream.ToArray());
-		}
-
-		public void SetPhase(byte phase, byte nextPhase, bool force)
-		{
-						//Log.Info("[ProtOut] SetPhase");
-					    if(Program.Client == null)return;
-			MemoryStream stream = new MemoryStream(512);
-			stream.Seek(4, SeekOrigin.Begin);
-			BinaryWriter writer = new BinaryWriter(stream);
-
-      if (Program.Client.Muted != 0)
-          writer.Write(Program.Client.Muted);
-      else
-          writer.Write(0);
-			writer.Write((byte)103);
-			writer.Write(phase);
-			writer.Write(nextPhase);
-			writer.Write(force);
-			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
-			writer.Write((int)stream.Length);
-			writer.Close();
-			Send(stream.ToArray());
-		}
-
-		public void StopPhaseReq(int turnNumber, byte phase, bool stop)
-		{
-						//Log.Info("[ProtOut] StopPhaseReq");
-					    if(Program.Client == null)return;
-			MemoryStream stream = new MemoryStream(512);
-			stream.Seek(4, SeekOrigin.Begin);
-			BinaryWriter writer = new BinaryWriter(stream);
-
-      if (Program.Client.Muted != 0)
-          writer.Write(Program.Client.Muted);
-      else
-          writer.Write(0);
-			writer.Write((byte)104);
-			writer.Write(turnNumber);
-			writer.Write(phase);
-			writer.Write(stop);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
 			writer.Close();

--- a/octgnFX/Octgn/Networking/ClientHandler.cs
+++ b/octgnFX/Octgn/Networking/ClientHandler.cs
@@ -145,7 +145,7 @@ namespace Octgn.Networking
             Program.GameEngine.TurnPlayer = (setActive) ? player : null;
             Program.GameEngine.StopTurn = false;
             Program.GameEngine.CurrentPhase = null;
-            Program.GameMess.Turn(player, Program.GameEngine.TurnNumber);
+            Program.GameMess.Turn(Program.GameEngine.TurnPlayer, Program.GameEngine.TurnNumber);
             Program.GameEngine.EventProxy.OnTurn_3_1_0_0(player, Program.GameEngine.TurnNumber);
             Program.GameEngine.EventProxy.OnTurn_3_1_0_1(player, Program.GameEngine.TurnNumber);
             Program.GameEngine.EventProxy.OnTurnPassed_3_1_0_2(lastPlayer, lastTurn, force);

--- a/octgnFX/Octgn/Networking/IServerCalls.cs
+++ b/octgnFX/Octgn/Networking/IServerCalls.cs
@@ -21,8 +21,12 @@ namespace Octgn.Networking
 		void NickReq(string nick);
 		void Start();
 		void ResetReq();
-		void NextTurn(Player nextPlayer, bool force);
+		void NextTurn(Player player, bool setActive, bool force);
 		void StopTurnReq(int turnNumber, bool stop);
+		void SetPhaseReq(byte nextPhase, bool force);
+		void StopPhaseReq(byte phase, bool stop);
+		void SetActivePlayer(Player player);
+		void ClearActivePlayer();
 		void ChatReq(string text);
 		void PrintReq(string text);
 		void RandomReq(int min, int max);
@@ -77,7 +81,5 @@ namespace Octgn.Networking
 		void Filter(Card card, Color? color);
 		void SetBoard(string name);
 		void SetPlayerColor(Player player, string color);
-		void SetPhase(byte phase, byte nextPhase, bool force);
-		void StopPhaseReq(int turnNumber, byte phase, bool stop);
 	}
 }

--- a/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
+++ b/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
@@ -291,8 +291,9 @@ namespace Octgn.Play.Gui
                 chatRun.FontWeight = FontWeights.Bold;
                 p.Inlines.Add(chatRun);
 
-                var prun = new Run(" " + (m as PhaseMessage).TurnPlayer + " ");
-                prun.Foreground = (m as PhaseMessage).TurnPlayer.Color.CacheToBrush();
+                var turnPlayer = (m as PhaseMessage).TurnPlayer;
+                var prun = new Run(" " + turnPlayer + " ");
+                prun.Foreground = turnPlayer == null ? m.From.Color.CacheToBrush() : turnPlayer.Color.CacheToBrush();
                 prun.FontWeight = FontWeights.Bold;
                 p.Inlines.Add(prun);
 
@@ -327,8 +328,9 @@ namespace Octgn.Play.Gui
                 chatRun.FontWeight = FontWeights.Bold;
                 p.Inlines.Add(chatRun);
 
-                var prun = new Run(" " + (m as TurnMessage).TurnPlayer + " ");
-                prun.Foreground = (m as TurnMessage).TurnPlayer.Color.CacheToBrush();
+                var turnPlayer = (m as TurnMessage).TurnPlayer;
+                var prun = new Run(" " + turnPlayer + " ");
+                prun.Foreground = turnPlayer == null ? m.From.Color.CacheToBrush() : turnPlayer.Color.CacheToBrush();
                 prun.FontWeight = FontWeights.Bold;
                 p.Inlines.Add(prun);
 

--- a/octgnFX/Octgn/Play/PlayWindow.xaml
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml
@@ -319,11 +319,19 @@
 				</Storyboard>
 			</Border.Resources>
 			<StackPanel Orientation="Vertical" MouseEnter="ShowPhaseStoryboard" MouseLeave="HidePhaseStoryboard" >
-				<StackPanel x:Name="PhaseToolBar" Background="{StaticResource GlassPanelBrush}" Orientation="Vertical" Cursor="Hand" MinWidth="100" Opacity="0.5" Height="45" MouseLeftButtonUp="LockPhaseStoryboard">
-					<TextBlock Style="{StaticResource PanelText}" Padding="5,2,5,0" HorizontalAlignment="Right" VerticalAlignment="Top" DataContext="{Binding Source={x:Static octgn:Program.GameEngine}, Path=TurnPlayer}" Text="{Binding}" Foreground="{Binding Color}"/>
-					<TextBlock Style="{StaticResource PanelText}" Padding="5,0,5,2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Text="{Binding Source={x:Static octgn:Program.GameEngine}, Path=CurrentPhase.Name}" />
-				</StackPanel>
-				<Border x:Name="PhaseListBorder" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0, 0, -300, 0"  >
+                <Border BorderThickness="2" BorderBrush="{StaticResource GlassPanelBorder}" >
+                    <StackPanel x:Name="PhaseToolBar" Background="{StaticResource GlassPanelBrush}" Orientation="Vertical" Cursor="Hand" MinWidth="100" Opacity="0.5" Height="45" MouseLeftButtonUp="LockPhaseStoryboard"
+                            DataContext="{Binding Source={x:Static octgn:Program.GameEngine}}">
+                        <TextBlock Style="{StaticResource PanelText}" Padding="5,2,5,0" HorizontalAlignment="Right" VerticalAlignment="Top"  >
+                        <Run Text="Turn" />
+                        <Run Text="{Binding TurnNumber}" />
+                        <Run Text=":" />
+                        <Run Text="{Binding TurnPlayer.Name}" Foreground="{Binding TurnPlayer.Color}" />
+                        </TextBlock>
+                        <TextBlock Style="{StaticResource PanelText}" Padding="5,0,5,2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Text="{Binding CurrentPhase.Name}" />
+                    </StackPanel>
+                </Border>
+                <Border x:Name="PhaseListBorder" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0, 0, -300, 0"  >
 					<ItemsControl Name="PhaseList" DataContext="{x:Static octgn:Program.GameEngine}" ItemsSource="{Binding AllPhases}" >
 						<ItemsControl.ItemTemplate>
 							<DataTemplate>
@@ -476,16 +484,16 @@
                             <TextBlock Text="{Binding Name}" VerticalAlignment="Center" Focusable="False" />
                             <TextBlock VerticalAlignment="Center" Focusable="False" Margin="5,0,0,0" FontWeight="Normal"
                          FontSize="11" Initialized="InitializePlayerSummary" />
-                            <ToggleButton VerticalAlignment="Center" Click="NextTurnClicked" Focusable="False" Margin="5,0,-8,0"
-                                          IsChecked="{Binding Source={x:Static octgn:Program.GameEngine}, Path=StopTurn}" 
+                            <Button VerticalAlignment="Center" Click="NextTurnClicked" Focusable="False" Margin="5,0,-8,0"
                                           IsEnabled="{Binding Source={x:Static octgn:Program.GameEngine},Path=Spectator, Converter={StaticResource BooleanInverterConverter}}">
-                                <ToggleButton.Style>
+                                <Button.Style>
                                     <MultiBinding Converter="{StaticResource CanPlay}">
                                         <Binding Source="{x:Static octgn:Program.GameEngine}" Path="TurnPlayer" />
                                         <Binding />
+                                        <Binding Source="{x:Static octgn:Program.GameEngine}" Path="StopTurn" />
                                     </MultiBinding>
-                                </ToggleButton.Style>
-                            </ToggleButton>
+                                </Button.Style>
+                            </Button>
                         </StackPanel>
                     </DataTemplate>
                 </TabControl.ItemTemplate>

--- a/octgnFX/Octgn/Play/PlayWindow.xaml
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml
@@ -305,63 +305,74 @@
             </Grid>
         </Border>
 
-		<Border x:Name="PhaseControl" Grid.Column="0" Grid.Row="2" Canvas.ZIndex="3" HorizontalAlignment="Right">
-			<Border.Resources>
-				<Storyboard x:Key="ShowPhaseStoryboard">
-					<DoubleAnimation Storyboard.TargetName="PhaseToolBar" Storyboard.TargetProperty="Opacity" From="0.5" To="1.0" Duration="0:0:0.250"/>
-					<ThicknessAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="Margin" From="0, 0, -300, 0" To="0 0 0 0" Duration="0:0:0.250"/>
-					<DoubleAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="0:0:0.250"/>
-				</Storyboard>
-				<Storyboard x:Key="HidePhaseStoryboard">
-					<DoubleAnimation Storyboard.TargetName="PhaseToolBar" Storyboard.TargetProperty="Opacity" From="1.0" To="0.5" Duration="0:0:0.250"/>
-					<ThicknessAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="Margin" From="0 0 0 0" To="0, 0, -300, 0" Duration="0:0:0.250"/>
-					<DoubleAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="0:0:0.250"/>
-				</Storyboard>
-			</Border.Resources>
-			<StackPanel Orientation="Vertical" MouseEnter="ShowPhaseStoryboard" MouseLeave="HidePhaseStoryboard" >
-                <Border BorderThickness="2" BorderBrush="{StaticResource GlassPanelBorder}" >
-                    <StackPanel x:Name="PhaseToolBar" Background="{StaticResource GlassPanelBrush}" Orientation="Vertical" Cursor="Hand" MinWidth="100" Opacity="0.5" Height="45" MouseLeftButtonUp="LockPhaseStoryboard"
-                            DataContext="{Binding Source={x:Static octgn:Program.GameEngine}}">
+        <Border x:Name="PhaseControl" Grid.Column="0" Grid.Row="2" Canvas.ZIndex="3" HorizontalAlignment="Right">
+            <Border.Resources>
+                <Storyboard x:Key="ShowPhaseStoryboard">
+                    <DoubleAnimation Storyboard.TargetName="PhaseToolBar" Storyboard.TargetProperty="Opacity" To="1.0" Duration="0:0:0.250"/>
+                    <DoubleAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="(Border.LayoutTransform).(ScaleTransform.ScaleX)" To="1" Duration="0:0:0.250"/>
+                    <DoubleAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="Opacity" To="1.0" Duration="0:0:0.250"/>
+                </Storyboard>
+                <Storyboard x:Key="HidePhaseStoryboard">
+                    <DoubleAnimation Storyboard.TargetName="PhaseToolBar" Storyboard.TargetProperty="Opacity" To="0.5" Duration="0:0:0.250"/>
+                    <DoubleAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="(Border.LayoutTransform).(ScaleTransform.ScaleX)" To="0" Duration="0:0:0.250"/>
+                    <DoubleAnimation Storyboard.TargetName="PhaseListBorder" Storyboard.TargetProperty="Opacity" To="0.0" Duration="0:0:0.250"/>
+                </Storyboard>
+            </Border.Resources>
+            <StackPanel MouseEnter="ShowPhaseStoryboard" MouseLeave="HidePhaseStoryboard" >
+                <Border x:Name="PhaseToolBar" HorizontalAlignment="Right" BorderThickness="2" Cursor="Hand" MinWidth="100" Height="45" Opacity="0.5"
+                        BorderBrush="{StaticResource GlassPanelBorder}" Background="{StaticResource GlassPanelBrush}" DataContext="{Binding Source={x:Static octgn:Program.GameEngine}}"
+                        MouseLeftButtonUp="LockPhaseStoryboard">
+                    <StackPanel Orientation="Vertical">
                         <TextBlock Style="{StaticResource PanelText}" Padding="5,2,5,0" HorizontalAlignment="Right" VerticalAlignment="Top"  >
-                        <Run Text="Turn" />
-                        <Run Text="{Binding TurnNumber}" />
-                        <Run Text=":" />
-                        <Run Text="{Binding TurnPlayer.Name}" Foreground="{Binding TurnPlayer.Color}" />
+                            <Run Text="Turn" />
+                            <Run Text="{Binding TurnNumber}" />
+                            <Run Text=":" />
+                            <Run Text="{Binding TurnPlayer.Name}" Foreground="{Binding TurnPlayer.Color}" />
                         </TextBlock>
                         <TextBlock Style="{StaticResource PanelText}" Padding="5,0,5,2" HorizontalAlignment="Right" VerticalAlignment="Bottom" Text="{Binding CurrentPhase.Name}" />
                     </StackPanel>
                 </Border>
-                <Border x:Name="PhaseListBorder" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0, 0, -300, 0"  >
-					<ItemsControl Name="PhaseList" DataContext="{x:Static octgn:Program.GameEngine}" ItemsSource="{Binding AllPhases}" >
-						<ItemsControl.ItemTemplate>
-							<DataTemplate>
-								<StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-									<TextBlock Text="{Binding Name}" Visibility="{Binding IsMouseOver, ElementName=PhaseButton, Converter={StaticResource BooleanToVisibilityHiddenConverter}}" 
+                <Border x:Name="PhaseListBorder" HorizontalAlignment="Right" VerticalAlignment="Top">
+                    <Border.LayoutTransform>
+                        <ScaleTransform ScaleX="0"/>
+                    </Border.LayoutTransform>
+                    <ItemsControl DataContext="{x:Static octgn:Program.GameEngine}" ItemsSource="{Binding AllPhases}" Grid.IsSharedSizeScope="True" >
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                    <TextBlock Text="{Binding Name}" Visibility="{Binding IsMouseOver, ElementName=PhaseButton, Converter={StaticResource BooleanToVisibilityHiddenConverter}}" 
                                           Background="#444444" Foreground="WhiteSmoke" FontWeight="Bold" VerticalAlignment="Center" />
-									<Button x:Name="PhaseButton" Click="PhaseClicked" Focusable="False" BorderThickness="3" >
-										<Button.Style>
-											<Style TargetType="Button">
-												<Style.Triggers>
-													<DataTrigger Binding="{Binding IsActive}" Value="True">
-														<Setter Property="Background" Value="Red"></Setter>
-													</DataTrigger>
-													<DataTrigger Binding="{Binding Hold}" Value="True">
-														<Setter Property="BorderBrush" Value="Blue" />
-													</DataTrigger>
-												</Style.Triggers>
-											</Style>
-										</Button.Style>
-										<Image Source="{Binding Icon}" HorizontalAlignment="Right" />
-									</Button>
-								</StackPanel>
-							</DataTemplate>
-						</ItemsControl.ItemTemplate>
-					</ItemsControl>
-				</Border>
-			</StackPanel>
-		</Border>
+                                    <Button x:Name="PhaseButton" Click="PhaseClicked" Focusable="False" BorderThickness="3" Background="Black" >
+                                        <Button.Style>
+                                            <Style TargetType="Button">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Hold}" Value="True">
+                                                        <Setter Property="BorderBrush" Value="Yellow" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Button.Style>
+                                        <Image Source="{Binding Icon}" HorizontalAlignment="Right">
+                                            <Image.Style>
+                                                <Style TargetType="Image">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsActive}" Value="False">
+                                                            <Setter Property="Opacity" Value="0.5"></Setter>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Image.Style>
+                                        </Image>
+                                    </Button>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Border>
+            </StackPanel>
+        </Border>
 
-		<StackPanel Grid.Row="1" x:Name="LimitedBackstage" Visibility="Collapsed" Background="#333">
+        <StackPanel Grid.Row="1" x:Name="LimitedBackstage" Visibility="Collapsed" Background="#333">
             <Border Padding="10,5,10,5">
                 <StackPanel Orientation="Horizontal">
                     <Button Padding="10,5,10,5" Margin="0,0,10,0" Click="LimitedOkClicked">
@@ -439,15 +450,15 @@
                 <GridSplitter.Template>
                     <ControlTemplate TargetType="{x:Type GridSplitter}">
                         <Grid Background="#55333333" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Stretch">
-                                    <Image Source="pack://application:,,,/OCTGN;component/Resources/greybullet.png" />
-                                    <Image Source="pack://application:,,,/OCTGN;component/Resources/greybullet.png" />
-                                    <Image Source="pack://application:,,,/OCTGN;component/Resources/greybullet.png" />
-                                    <Image Source="pack://application:,,,/OCTGN;component/Resources/greybullet.png" />
-                                    <Image Source="pack://application:,,,/OCTGN;component/Resources/greybullet.png" />
-                                </StackPanel>
-                            </Grid>
-                        </ControlTemplate>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Stretch">
+                                <Image Source="pack://application:,,,/OCTGN;component/Resources/greybullet.png" />
+                                <Image Source="pack://application:,,,/OCTGN;component/Resources/greybullet.png" />
+                                <Image Source="pack://application:,,,/OCTGN;component/Resources/greybullet.png" />
+                                <Image Source="pack://application:,,,/OCTGN;component/Resources/greybullet.png" />
+                                <Image Source="pack://application:,,,/OCTGN;component/Resources/greybullet.png" />
+                            </StackPanel>
+                        </Grid>
+                    </ControlTemplate>
                 </GridSplitter.Template>
             </GridSplitter>
             <Border Margin="0,0,0,2" Grid.Row="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">

--- a/octgnFX/Octgn/Play/PlayWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml.cs
@@ -779,7 +779,7 @@ namespace Octgn.Play
 
         private void NextTurnClicked(object sender, RoutedEventArgs e)
         {
-            var btn = (ToggleButton)sender;
+            var btn = (Button)sender;
             var targetPlayer = (Player)btn.DataContext;
             if (Program.GameEngine.TurnPlayer == null || Program.GameEngine.TurnPlayer == Player.LocalPlayer)
             {
@@ -788,13 +788,26 @@ namespace Octgn.Play
                     Program.GameEngine.EventProxy.OverrideTurnPassed_3_1_0_2(targetPlayer);
                     return;
                 }
-                Program.Client.Rpc.NextTurn(targetPlayer, false);
+                Program.Client.Rpc.NextTurn(targetPlayer, true, false);
             }
             else
             {
-                Program.Client.Rpc.StopTurnReq(Program.GameEngine.TurnNumber, btn.IsChecked != null && btn.IsChecked.Value);
-                if (btn.IsChecked != null) Program.GameEngine.StopTurn = btn.IsChecked.Value;
+                Program.GameEngine.StopTurn = !Program.GameEngine.StopTurn;
+                Program.Client.Rpc.StopTurnReq(Program.GameEngine.TurnNumber, Program.GameEngine.StopTurn);
             }
+        }
+
+        public void PhaseClicked(object sender, RoutedEventArgs e)
+        {
+            var btn = (Button)sender;
+            var phase = (Phase)btn.DataContext;
+            if (Program.GameEngine.Definition.Events.ContainsKey("OverridePhaseClicked"))
+            {
+                Program.GameEngine.EventProxy.OverridePhaseClicked_3_1_0_2(phase.Name, phase.Id);
+                return;
+            }
+            phase.Hold = !phase.Hold;
+            Program.Client.Rpc.StopPhaseReq(phase.Id, phase.Hold);
         }
 
         private bool LockPhaseList = false;
@@ -821,29 +834,7 @@ namespace Octgn.Play
         {
             LockPhaseList = !LockPhaseList;
         }
-
-        public void PhaseClicked(object sender, RoutedEventArgs e)
-        {
-            var btn = (Button)sender;
-            var phase = (Phase)btn.DataContext;
-            if (Program.GameEngine.TurnPlayer == Player.LocalPlayer)
-            {
-                if (Program.GameEngine.Definition.Events.ContainsKey("OverridePhasePassed"))
-                {
-                    Program.GameEngine.EventProxy.OverridePhasePassed_3_1_0_2(phase.Name, phase.Id);
-                    return;
-                }
-                // turnplayer can change phases
-                Program.Client.Rpc.SetPhase(Program.GameEngine.CurrentPhase == null ? (byte)0 : Program.GameEngine.CurrentPhase.Id, phase.Id, false);
-            }
-            else
-            {
-                // other players can pause the phase change
-                Program.Client.Rpc.StopPhaseReq(Program.GameEngine.TurnNumber, phase.Id, !phase.Hold);
-                phase.Hold = !phase.Hold;
-            }
-        }
-
+        
         private void ActivateChat(object sender, ExecutedRoutedEventArgs e)
         {
             e.Handled = true;
@@ -1119,6 +1110,7 @@ namespace Octgn.Play
         {
             var turnPlayer = values[0] as Player;
             var player = values[1] as Player;
+            var stopped = values[2] as bool?;
 
             string styleKey;
             if (player == Player.GlobalPlayer)
@@ -1127,8 +1119,12 @@ namespace Octgn.Play
                 styleKey = "PlayButton";
             else if (turnPlayer == Player.LocalPlayer)
                 styleKey = "PlayButton";
+            else if (turnPlayer != player)
+                styleKey = "InvisibleButton";
+            else if (stopped == true)
+                styleKey = "HeldPauseButton";
             else
-                styleKey = turnPlayer == player ? "PauseButton" : "InvisibleButton";
+                styleKey = "PauseButton";
             return Application.Current.FindResource(styleKey);
         }
 

--- a/octgnFX/Octgn/Play/State/GameEngine.cs
+++ b/octgnFX/Octgn/Play/State/GameEngine.cs
@@ -59,6 +59,7 @@ namespace Octgn
         //wouldn't a heap be best for these caches? 
         private bool _stopTurn;
         private Play.Player _turnPlayer;
+        private int _turnNumber;
         private readonly List<Phase> _allPhases = new List<Phase>();
         private Phase _currentPhase;
         //private ushort _uniqueId;
@@ -191,7 +192,16 @@ namespace Octgn
 
         public GameBoard GameBoard { get; set; }
 
-        public int TurnNumber { get; set; }
+        public int TurnNumber
+        {
+            get { return _turnNumber; }
+            set
+            {
+                if (_turnNumber == value) return;
+                _turnNumber = value;
+                OnPropertyChanged("TurnNumber");
+            }
+        }
 
         public Octgn.Play.Player TurnPlayer
         {

--- a/octgnFX/Octgn/Resources/Themes/BlueGlass/Button.xaml
+++ b/octgnFX/Octgn/Resources/Themes/BlueGlass/Button.xaml
@@ -121,10 +121,10 @@
     </Setter>
   </Style>-->
 
-    <Style x:Key="PlayButton" TargetType="{x:Type ToggleButton}">
+    <Style x:Key="PlayButton" TargetType="{x:Type Button}">
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                <ControlTemplate TargetType="{x:Type Button}">
                     <Border x:Name="fillRec" Padding="4,2,4,2" BorderThickness="1,1,1,1" CornerRadius="4,4,4,4">
                         <Path Stretch="Fill" StrokeThickness="1" StrokeLineJoin="Round" Stroke="#FF248D04"
 							Data="F1 M 307.547,210.667C 307.547,206.384 252.44,174.307 249.56,177.188C 246.679,180.068 246.208,240.793 249.56,244.146C 252.912,247.498 307.547,214.95 307.547,210.667 Z "
@@ -184,10 +184,10 @@
         </Setter>
     </Style>
 
-    <Style x:Key="PauseButton" TargetType="{x:Type ToggleButton}">
+    <Style x:Key="PauseButton" TargetType="{x:Type Button}">
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                <ControlTemplate TargetType="{x:Type Button}">
                     <Border x:Name="fillRec" Padding="4,2,4,2" BorderThickness="1,1,1,1" CornerRadius="4,4,4,4">
                         <Path Stretch="Fill" StrokeThickness="1" StrokeLineJoin="Round" Stroke="#FFE3B603"
 							Data="F1 M 249.972,176.967L 267.139,176.967C 268.795,176.967 270.139,178.31 270.139,179.967L 270.139,241.3C 270.139,242.957 268.795,244.3 267.139,244.3L 249.972,244.3C 248.315,244.3 246.972,242.957 246.972,241.3L 246.972,179.967C 246.972,178.31 248.315,176.967 249.972,176.967 Z M 288.13,176.967L 305.297,176.967C 306.954,176.967 308.297,178.31 308.297,179.967L 308.297,241.3C 308.297,242.957 306.954,244.3 305.297,244.3L 288.13,244.3C 286.474,244.3 285.13,242.957 285.13,241.3L 285.13,179.967C 285.13,178.31 286.474,176.967 288.13,176.967 Z "
@@ -247,7 +247,70 @@
                                 </Setter.Value>
                             </Setter>
                         </Trigger>
-                        <Trigger Property="IsChecked" Value="True">
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="HeldPauseButton" TargetType="{x:Type Button}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Border x:Name="fillRec" Padding="4,2,4,2" BorderThickness="1,1,1,1" CornerRadius="4,4,4,4">
+                        <Border.BorderBrush>
+                            <LinearGradientBrush EndPoint="0.504,1.01" StartPoint="0.501,-0.01">
+                                <GradientStop Color="#FF153899" Offset="0" />
+                                <GradientStop Color="#FF669CE4" Offset="1" />
+                            </LinearGradientBrush>
+                        </Border.BorderBrush>
+                        <Border.Background>
+                            <LinearGradientBrush EndPoint="0.491,1.203" StartPoint="0.509,-0.203">
+                                <GradientStop Color="#7F6F85EC" Offset="0.005" />
+                                <GradientStop Color="#BF5B6EC5" Offset="1" />
+                            </LinearGradientBrush>
+                        </Border.Background>
+                        <Path Stretch="Fill" StrokeThickness="1" StrokeLineJoin="Round" Stroke="#FFE3B603"
+							Data="F1 M 249.972,176.967L 267.139,176.967C 268.795,176.967 270.139,178.31 270.139,179.967L 270.139,241.3C 270.139,242.957 268.795,244.3 267.139,244.3L 249.972,244.3C 248.315,244.3 246.972,242.957 246.972,241.3L 246.972,179.967C 246.972,178.31 248.315,176.967 249.972,176.967 Z M 288.13,176.967L 305.297,176.967C 306.954,176.967 308.297,178.31 308.297,179.967L 308.297,241.3C 308.297,242.957 306.954,244.3 305.297,244.3L 288.13,244.3C 286.474,244.3 285.13,242.957 285.13,241.3L 285.13,179.967C 285.13,178.31 286.474,176.967 288.13,176.967 Z "
+							Width="14" Height="14">
+                            <Path.Fill>
+                                <LinearGradientBrush StartPoint="0.360512,0.0260379" EndPoint="1.35835,0.0260379">
+                                    <LinearGradientBrush.RelativeTransform>
+                                        <TransformGroup>
+                                            <SkewTransform CenterX="0.360512" CenterY="0.0260379" AngleX="-2.47444" AngleY="0" />
+                                            <RotateTransform CenterX="0.360512" CenterY="0.0260379" Angle="74.4977" />
+                                        </TransformGroup>
+                                    </LinearGradientBrush.RelativeTransform>
+                                    <GradientStop Color="#FFFFFC2D" Offset="0" />
+                                    <GradientStop Color="#FFF7D816" Offset="0.60274" />
+                                    <GradientStop Color="#FFEFB400" Offset="1" />
+                                </LinearGradientBrush>
+                            </Path.Fill>
+                        </Path>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Visibility" Value="Hidden" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="fillRec" Property="BorderBrush">
+                                <Setter.Value>
+                                    <LinearGradientBrush EndPoint="0.513,1.203" StartPoint="0.487,-0.203">
+                                        <GradientStop Color="#FFAECDE6" Offset="0" />
+                                        <GradientStop Color="#FF7297B7" Offset="1" />
+                                    </LinearGradientBrush>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="Background" TargetName="fillRec">
+                                <Setter.Value>
+                                    <LinearGradientBrush EndPoint="0.479,1.202" StartPoint="0.521,-0.202">
+                                        <GradientStop Color="#4FABD9EA" Offset="1" />
+                                        <GradientStop Color="#4FD2E7F0" Offset="0" />
+                                    </LinearGradientBrush>
+                                </Setter.Value>
+                            </Setter>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
                             <Setter Property="BorderBrush" TargetName="fillRec">
                                 <Setter.Value>
                                     <LinearGradientBrush EndPoint="0.504,1.01" StartPoint="0.501,-0.01">
@@ -270,8 +333,8 @@
             </Setter.Value>
         </Setter>
     </Style>
-
-    <Style x:Key="InvisibleButton" TargetType="{x:Type ToggleButton}">
+    
+    <Style x:Key="InvisibleButton" TargetType="{x:Type Button}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate>

--- a/octgnFX/Octgn/Scripting/GameEvents.cs
+++ b/octgnFX/Octgn/Scripting/GameEvents.cs
@@ -147,6 +147,9 @@ namespace Octgn.Scripting
 								eventCache.Add("OverridePhasePassed",new DataNew.Entities.GameEvent[0]);
 			if(gameEngine.Definition.Events.ContainsKey("OverridePhasePassed"))
 				eventCache["OverridePhasePassed"] = gameEngine.Definition.Events["OverridePhasePassed"];
+								eventCache.Add("OverridePhaseClicked",new DataNew.Entities.GameEvent[0]);
+			if(gameEngine.Definition.Events.ContainsKey("OverridePhaseClicked"))
+				eventCache["OverridePhaseClicked"] = gameEngine.Definition.Events["OverridePhaseClicked"];
 							}
 		private static readonly Version C_3_1_0_0 = Version.Parse("3.1.0.0");
 		public void OnTableLoad_3_1_0_0()
@@ -1165,7 +1168,7 @@ namespace Octgn.Scripting
 				}
 			}
 		}
-		public void OnTurnPassed_3_1_0_2(Player player)
+		public void OnTurnPassed_3_1_0_2(Player player, int turn, bool force)
 		{
 			if(Player.LocalPlayer.Spectator)return;
 			if(MuteEvents)return;
@@ -1176,11 +1179,13 @@ namespace Octgn.Scripting
 			if(thisVersion >= BASEOBJECTVERSION)
 			{
 				args.player = player;
+				args.turn = turn;
+				args.force = force;
 			}
 			foreach(var e in eventCache["OnTurnPassed"])
 			{
 				if(thisVersion < BASEOBJECTVERSION)
-					engine.ExecuteFunction(e.PythonFunction,player);
+					engine.ExecuteFunction(e.PythonFunction,player, turn, force);
 				else
 				{
 					engine.ExecuteFunction(e.PythonFunction, args);
@@ -1447,7 +1452,7 @@ namespace Octgn.Scripting
 				}
 			}
 		}
-		public void OnPhasePassed_3_1_0_2(string name, int id)
+		public void OnPhasePassed_3_1_0_2(string name, int id, bool force)
 		{
 			if(Player.LocalPlayer.Spectator)return;
 			if(MuteEvents)return;
@@ -1459,11 +1464,12 @@ namespace Octgn.Scripting
 			{
 				args.name = name;
 				args.id = id;
+				args.force = force;
 			}
 			foreach(var e in eventCache["OnPhasePassed"])
 			{
 				if(thisVersion < BASEOBJECTVERSION)
-					engine.ExecuteFunction(e.PythonFunction,name, id);
+					engine.ExecuteFunction(e.PythonFunction,name, id, force);
 				else
 				{
 					engine.ExecuteFunction(e.PythonFunction, args);
@@ -1575,6 +1581,29 @@ namespace Octgn.Scripting
 				args.id = id;
 			}
 			foreach(var e in eventCache["OverridePhasePassed"])
+			{
+				if(thisVersion < BASEOBJECTVERSION)
+					engine.ExecuteFunction(e.PythonFunction,name, id);
+				else
+				{
+					engine.ExecuteFunction(e.PythonFunction, args);
+				}
+			}
+		}
+		public void OverridePhaseClicked_3_1_0_2(string name, int id)
+		{
+			if(Player.LocalPlayer.Spectator)return;
+			if(MuteEvents)return;
+			if(gameEngine.Definition.ScriptVersion != C_3_1_0_2 )
+				return;
+			var thisVersion = Version.Parse("3.1.0.2");
+			dynamic args = new System.Dynamic.ExpandoObject();
+			if(thisVersion >= BASEOBJECTVERSION)
+			{
+				args.name = name;
+				args.id = id;
+			}
+			foreach(var e in eventCache["OverridePhaseClicked"])
 			{
 				if(thisVersion < BASEOBJECTVERSION)
 					engine.ExecuteFunction(e.PythonFunction,name, id);

--- a/octgnFX/Octgn/Scripting/Versions/3.1.0.0.py
+++ b/octgnFX/Octgn/Scripting/Versions/3.1.0.0.py
@@ -428,7 +428,7 @@ class Player(object):
   def __format__(self, format_spec): return self.name
   @property
   def isActivePlayer(self): return _api.IsActivePlayer(self._id)
-  def setActivePlayer(self, force = False): _api.setActivePlayer(self._id, force)
+  def setActivePlayer(self, force = False): _api.SetActivePlayer(self._id, force)
   @property
   def name(self): return _api.PlayerName(self._id)
   @property

--- a/octgnFX/Octgn/Scripting/Versions/3.1.0.1.py
+++ b/octgnFX/Octgn/Scripting/Versions/3.1.0.1.py
@@ -425,7 +425,7 @@ class Player(object):
   def __format__(self, format_spec): return self.name
   @property
   def isActivePlayer(self): return _api.IsActivePlayer(self._id)
-  def setActivePlayer(self, force = False): _api.setActivePlayer(self._id, force)
+  def setActivePlayer(self, force = False): _api.SetActivePlayer(self._id, force)
   @property
   def isSubscriber(self): return _api.IsSubscriber(self._id)
   @property

--- a/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
+++ b/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
@@ -49,12 +49,36 @@ def playSound(name):
 def turnNumber():
 	return _api.TurnNumber()
 
+def nextTurn(player = None, force = False):
+	if player == None:
+		_api.NextTurn(force)
+	else:
+		_api.SetActivePlayer(player._id, force)
+
+def getActivePlayer():
+	id = _api.GetTurnPlayer()
+	if id == None:
+		return None
+	return Player(id)
+
+def setActivePlayer(player = None):
+	if player == None:
+		 _api.ClearTurnPlayer()
+	else:
+		_api.SetTurnPlayer(player._id)
+
 def currentPhase():
 	apiResult = _api.GetCurrentPhase()
 	return (apiResult.Item1, apiResult.Item2)
 
 def setPhase(id, force = False):
-	_api.SetCurrentPhase(id, force)
+	_api.SetPhase(id, force)
+
+def getStop(id):
+	return _api.GetStop(id)
+
+def setStop(id, stop):
+	_api.SetStop(id, stop)
 
 def openUrl(url):
 	return _api.Open_URL(url)
@@ -475,8 +499,9 @@ class Player(object):
 		object.__setattr__(self, name, value)
 	def __format__(self, format_spec): return self.name
 	@property
-	def isActive(self): return _api.IsActivePlayer(self._id)
-	def setActive(self, force = False): _api.setActivePlayer(self._id, force)
+	def isActive(self):
+		return self._id == _api.GetTurnPlayer()
+	def setActive(self, force = False): _api.SetActivePlayer(self._id, force)
 	@property
 	def isSubscriber(self): return _api.IsSubscriber(self._id)
 	@property

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_0.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_0.cs
@@ -65,10 +65,10 @@ namespace Octgn.Scripting.Versions
             return (Program.GameEngine.TurnPlayer.Id == id);
         }
 
-        public void setActivePlayer(int id, bool force)
+        public void SetActivePlayer(int id, bool force)
         {
             if (Program.GameEngine.TurnPlayer == null || Program.GameEngine.TurnPlayer == Player.LocalPlayer)
-                Program.Client.Rpc.NextTurn(Player.Find((byte)id), force);
+                Program.Client.Rpc.NextTurn(Player.Find((byte)id), true, force);
         }
 
         public List<KeyValuePair<int, string>> PlayerCounters(int id)

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_1.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_1.cs
@@ -68,10 +68,10 @@ namespace Octgn.Scripting.Versions
             return (Program.GameEngine.TurnPlayer.Id == id);
         }
 
-        public void setActivePlayer(int id, bool force)
+        public void SetActivePlayer(int id, bool force)
         {
             if (Program.GameEngine.TurnPlayer == null || Program.GameEngine.TurnPlayer == Player.LocalPlayer)
-                Program.Client.Rpc.NextTurn(Player.Find((byte)id), force);
+                Program.Client.Rpc.NextTurn(Player.Find((byte)id), true, force);
         }
 
         public bool IsSubscriber(int id)

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
@@ -102,7 +102,7 @@ namespace Octgn.Scripting.Versions
         public void SetPhase(int phase, bool force)
         {
             if (Phase.Find((byte)phase) == null) return;
-            if (Program.GameEngine.TurnPlayer == Player.LocalPlayer)
+            if (Program.GameEngine.TurnPlayer == null || Program.GameEngine.TurnPlayer == Player.LocalPlayer)
                 Program.Client.Rpc.SetPhaseReq((byte)phase, force);
         }
 

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,7 @@
-
+Major changes to the Phase system
+Phases now cycle sequentially, active player will set stops on phases instead of jumping between them
+Phase stops will persist between turns
+Clicking the "Pass turn" green arrow button on the player tab will sequentially scan through phases and pause on the first phase that has a stop set.  If there are no stopped phases, it will pass the turn to the next player (old functionality)
+Added OverridePhaseClicked and OverrideTurnPassed override events to control the functionality of the Pass Turn and phase buttons
+Added several python API calls to provide greater control over changing turns, changing phases, changing active player, toggling stops
+Fixed a visual bug involving the play/pause turn buttons on the player tab


### PR DESCRIPTION
- Phases now cycle sequentially, active player will set stops on phases instead of jumping between them
- Phase stops will persist between turns
- Clicking the "Pass turn" green arrow button on the player tab will sequentially scan through phases and pause on the first phase that has a stop set.  If there are no stopped phases, it will pass the turn to the next player (old functionality)
- Added OverridePhaseClicked and OverrideTurnPassed override events to control the functionality of the Pass Turn and phase buttons
- Added several python API calls to provide greater control over changing turns, changing phases, changing active player, toggling stops
- Fixed a visual bug involving the play/pause turn buttons on the player tab