### PR TITLE
Update twitch API to v5

### DIFF
--- a/octgnFX/Octgn/Tabs/Watch/WatchList.xaml.cs
+++ b/octgnFX/Octgn/Tabs/Watch/WatchList.xaml.cs
@@ -71,9 +71,9 @@ namespace Octgn.Tabs.Watch
             {
                 RefreshTimer.Enabled = false;
                 using( WebClient wc = new WebClient() ) {
-                    wc.Headers[HttpRequestHeader.Accept] = "application/vnd.twitchtv.v3+json";
+                    wc.Headers[HttpRequestHeader.Accept] = "application/vnd.twitchtv.v5+json";
                     wc.Headers["Client-ID"] = "pct1bdpnuccp6dd5ie9iqbwjas1oc1u";
-                    var jsonString = wc.DownloadString( "https://api.twitch.tv/kraken/search/streams?q=octgn" );
+                    var jsonString = wc.DownloadString( "https://api.twitch.tv/kraken/streams?game=octgn" );
                     var obj = (JObject)JsonConvert.DeserializeObject( jsonString );
 
                     var streams = new List<StreamModel>();


### PR DESCRIPTION
v3 has been deprecated in 2018 and will be removed at the end of 2018
This also fixes the incorrect results (old API returned items matching "octane" when searching for "octgn")
https://dev.twitch.tv/docs/v5