### PR TITLE
Fix for StandAloneServer not closing

### DIFF
--- a/octgnFX/Octgn.Online.StandAloneServer/App.config
+++ b/octgnFX/Octgn.Online.StandAloneServer/App.config
@@ -12,6 +12,7 @@
     <add key="SasManagerServiceHost" value="http://localhost:5890/SasManager" />
     <add key="LOGENTRIES_TOKEN" value="a4249a9e-93073-4884-b85f-d403448e9e81" />
     <add key="SiteApiKey" value="##SITEAPIKEY##" />
+    <add key="WaitForKeyToExit" value="false" />
   </appSettings>
   <UpdateManagerConfig Enabled="false" UpdateFrequency="60000" UpdateFeed="https://www.myget.org/F/octgn/" PackageName="Octgn.Online.StandAloneServer" />
   <log4net>

--- a/octgnFX/Octgn.Online.StandAloneServer/Program.cs
+++ b/octgnFX/Octgn.Online.StandAloneServer/Program.cs
@@ -29,9 +29,13 @@ namespace Octgn.Online.StandAloneServer
 
         internal static State State;
         static void Main(string[] args) {
+            bool waitForKeyOnExit = false;
+
             try {
                 LoggerFactory.DefaultMethod = (con) => new Log4NetLogger(con.Name);
                 Log.Info("Startup");
+
+                waitForKeyOnExit = bool.Parse(ConfigurationManager.AppSettings["WaitForKeyOnExit"]);
 
                 HandleArguments(IsDebug, args);
 
@@ -46,6 +50,12 @@ namespace Octgn.Online.StandAloneServer
                 Log.Error($"{nameof(Main)}", ex);
             } finally {
                 Log.Info("Shutting down");
+            }
+
+            if (waitForKeyOnExit) {
+                Console.WriteLine();
+                Console.WriteLine("Press any key to exit.");
+                Console.ReadKey();
             }
 
             LogManager.Shutdown();

--- a/octgnFX/Octgn.WindowsDesktopUtilities/Octgn.WindowsDesktopUtilities.csproj
+++ b/octgnFX/Octgn.WindowsDesktopUtilities/Octgn.WindowsDesktopUtilities.csproj
@@ -50,10 +50,10 @@
       <Link>Version.cs</Link>
     </Compile>
     <Compile Include="ConsoleUtils.cs" />
+    <Compile Include="OctgnProgram.cs" />
     <Compile Include="OctgnServiceBase.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Don't built in key waiting into the OctgnProgram file, instead rely on a appconfig setting. Waiting for a key to exit is only useful for developers, so there's no need to have fancy switching logic for it, or even a command line switch.

Renamed the file Program to OctgnProgram