### PR TITLE
Changes how OCTGN handles game-bundled deck files

### DIFF
--- a/octgnFX/Octgn.Core/DataManagers/GameManager.cs
+++ b/octgnFX/Octgn.Core/DataManagers/GameManager.cs
@@ -170,40 +170,11 @@ namespace Octgn.Core.DataManagers
                 {
                     Directory.CreateDirectory(imageSetsDir);
                 }
-
-                Log.InfoFormat("Installing decks {0} {1}", package.Id, package.Title);
+                
                 var game = GameManager.Get().GetById(new Guid(package.Id));
                 if (game == null)
                     throw new UserMessageException(L.D.Exception__CanNotInstallGameTryRestart_Format, package.Title);
-                if (Directory.Exists(Path.Combine(game.InstallPath, "Decks")))
-                {
-                    var deckFiles = new DirectoryInfo(Path.Combine(game.InstallPath, "Decks")).GetFiles("*.o8d", SearchOption.AllDirectories).ToArray();
-                    var curDeckFileNum = 0;
-                    onProgressUpdate(curDeckFileNum, deckFiles.Length);
-                    foreach (var f in deckFiles)
-                    {
-                        try
-                        {
-                            Log.DebugFormat("Found deck file {0} {1} {2}", f.FullName, package.Id, package.Title);
-                            var relPath = f.FullName.Replace(new DirectoryInfo(Path.Combine(game.InstallPath, "Decks")).FullName, "").TrimStart('\\');
-                            var newPath = Path.Combine(Config.Instance.Paths.DeckPath, game.Name, relPath);
-                            Log.DebugFormat("Creating directories {0} {1} {2}", f.FullName, package.Id, package.Title);
-                            if (new DirectoryInfo(newPath).Exists)
-                                Directory.Move(newPath, Config.Instance.Paths.GraveyardPath);
-                            Directory.CreateDirectory(new FileInfo(newPath).Directory.FullName);
-                            Log.DebugFormat("Copying deck to {0} {1} {2} {3}", f.FullName, newPath, package.Id, package.Title);
-                            f.MegaCopyTo(newPath);
-                            curDeckFileNum++;
-                            onProgressUpdate(curDeckFileNum, deckFiles.Length);
-
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Warn(String.Format("InstallGame 2 {0} {1} {2}", f.FullName, package.Id, package.Title), e);
-                            throw;
-                        }
-                    }
-                }
+                
                 Log.InfoFormat("Installing plugins {0} {1}", package.Id, package.Title);
                 if (Directory.Exists(Path.Combine(game.InstallPath, "Plugins")))
                 {

--- a/octgnFX/Octgn/Play/Gui/Commands.cs
+++ b/octgnFX/Octgn/Play/Gui/Commands.cs
@@ -5,7 +5,7 @@ namespace Octgn.Play.Gui
     public static class Commands
     {
         public static readonly RoutedUICommand Quit, FullScreen, ResetGame, Chat, ResetScreen;
-        public static readonly RoutedUICommand LoadDeck, NewDeck, SaveDeck, SaveDeckAs, ExportDeckAs;
+        public static readonly RoutedUICommand LoadDeck, LoadPrebuiltDeck, NewDeck, SaveDeck, SaveDeckAs, ExportDeckAs;
         public static readonly RoutedUICommand LimitedGame, AlwaysShowProxy;
 
         static Commands()
@@ -14,6 +14,8 @@ namespace Octgn.Play.Gui
 
             LoadDeck = new RoutedUICommand("Load a deck", "LoadDeck", typeof (Commands));
             LoadDeck.InputGestures.Add(new KeyGesture(Key.L, ModifierKeys.Control));
+
+            LoadPrebuiltDeck = new RoutedUICommand("Load a pre-built deck", "LoadPrebuiltDeck", typeof(Commands));
 
             NewDeck = new RoutedUICommand("Create a new empty deck", "NewDeck", typeof (Commands));
             NewDeck.InputGestures.Add(new KeyGesture(Key.N, ModifierKeys.Control));

--- a/octgnFX/Octgn/Play/PlayWindow.xaml
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml
@@ -29,6 +29,7 @@
     <ctrl:DecorableWindow.CommandBindings>
         <CommandBinding Command="gui:Commands.Quit" Executed="Close" />
         <CommandBinding Command="gui:Commands.LoadDeck" Executed="Open" />
+        <CommandBinding Command="gui:Commands.LoadPrebuiltDeck" Executed="OpenPrebuilt" />
         <CommandBinding Command="gui:Commands.LimitedGame" Executed="LimitedGame" />
         <CommandBinding Command="gui:Commands.FullScreen" Executed="ToggleFullScreen" />
         <CommandBinding Command="gui:Commands.ResetGame" Executed="ResetGame" />
@@ -50,6 +51,7 @@
         <Menu x:Name="Menu" Canvas.ZIndex="4">
             <MenuItem Header="Game">
                 <MenuItem Header="Load Deck" Command="gui:Commands.LoadDeck" IsEnabled="{Binding Source={x:Static octgn:Program.GameEngine},Path=Spectator, Converter={StaticResource BooleanInverterConverter}}"/>
+                <MenuItem Header="Load Pre-Built Deck" Command="gui:Commands.LoadPrebuiltDeck" x:Name="PrebuiltDeckMenuItem" IsEnabled="{Binding Source={x:Static octgn:Program.GameEngine},Path=Spectator, Converter={StaticResource BooleanInverterConverter}}"/>
                 <MenuItem Header="Save Deck" Click="LimitedSaveClicked" IsEnabled="{Binding Source={x:Static octgn:Program.GameEngine},Path=Spectator, Converter={StaticResource BooleanInverterConverter}}"/>
                 <MenuItem Header="Limited Game" Command="gui:Commands.LimitedGame" x:Name="LimitedGameMenuItem" IsEnabled="{Binding Source={x:Static octgn:Program.GameEngine},Path=Spectator, Converter={StaticResource BooleanInverterConverter}}"/>
                 <Separator></Separator>

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,2 @@
-
+Added "Load Pre-Built deck" in play window game menu, which opens the dialog window into the game install's Decks folder.
+Installing/updating a game will no longer copy the game's bundled decks into OCTGN's decks folder.


### PR DESCRIPTION
The play window now has a "Load Pre-Built Deck" menu item, which opens the file explorer directly inside the game installs Decks directory.

OCTGN will no longer dump the contents of this folder into the OCTGN's default decks folder whenever a game is installed/updated.

Once pushed live I recommend making a discord/twitter post that it's safe to delete all the game folders within OCTGN's default decks directory, as those are no longer used.