### PR TITLE
Fixed multi-set searches

### DIFF
--- a/octgnFX/Octgn/DeckBuilder/FilterControl.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/FilterControl.xaml.cs
@@ -143,7 +143,9 @@ namespace Octgn.DeckBuilder
         public event EventHandler RemoveFilter;
         public event RoutedEventHandler UpdateFilters;
 
-        public bool IsOr;
+        public bool IsOr {
+            get => excludeSetCheck.IsChecked == false;
+        }
         public bool ExcludeSet;
         private bool JustClosed;
         //private string _linkText;
@@ -160,12 +162,10 @@ namespace Octgn.DeckBuilder
             {
                 if (ExcludeSet)
                 {
-                    IsOr = false;
                     return "set_id <> '" + ((DataNew.Entities.Set)comparisonList.SelectedItem).Id.ToString("D") + "'";
                 }
                 else
                 {
-                    IsOr = true;
                     return "set_id = '" + ((DataNew.Entities.Set)comparisonList.SelectedItem).Id.ToString("D") + "'";
                 }
             }

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+Fixed searching multiple sets in the deck editor - BenMatteson


### PR DESCRIPTION
(resubmitted since I accidentally wiped out the original)

turns out all the work was already done to support searching multiple sets as OR conditions, it was just checking a value that wasn't getting set (until immediately after it was read...)
could maybe expanded to a partial solution for #991, with the caveat that or conditions are always at the start