### PR TITLE
add script properties to cards

### DIFF
--- a/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
+++ b/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
@@ -265,6 +265,7 @@ class Card(object):
 		self._id = id
 		self._props = CardProperties(id)
 		self._markers = None
+		self._scriptProperties = dict()
 	def __cmp__(self, other):
 		if other == None: return 1
 		elif not hasattr(other, "_id"): return 1
@@ -380,6 +381,15 @@ class Card(object):
 		return (x + delta, y + delta)
 	def resetProperties(self):
 		_api.CardResetProperties(self._id)
+	@property
+	def scriptProperties(self):
+		return self._scriptProperties
+	@scriptProperties.setter
+	def scriptProperties(self, propertiesDict):
+		if type(propertiesDict) is dict:
+			self._scriptProperties = propertiesDict
+		else:
+			raise TypeError('scriptProperties must be set to a dictionary')
 
 class NamedObject(object):
 	def __init__(self, id, name):


### PR DESCRIPTION
allows adding arbitrary info to cards since iron python doesn't support adding attributes at will like regular python.

I have no idea if this is the right way to change the API, and it could probably just be added to all the versions, just wanted to get it out there.