### PR TITLE
fix #1868

### DIFF
--- a/octgnFX/Octgn/Tabs/GameHistory/GameHistoryTab.xaml
+++ b/octgnFX/Octgn/Tabs/GameHistory/GameHistoryTab.xaml
@@ -103,7 +103,7 @@
                                     DisplayMemberBinding="{Binding Path=GameName}" Width="200"></GridViewColumn>
                     <GridViewColumn Header="Start Time"
                                     utils:GridViewSort.PropertyName="StartTime"
-                                    DisplayMemberBinding="{Binding Path=StartTime}" Width="200"></GridViewColumn>
+                                    DisplayMemberBinding="{Binding Path=StartTime, StringFormat='{}{0:f}'}" Width="200"></GridViewColumn>
                     <GridViewColumn Header="Run Time"
                                     utils:GridViewSort.PropertyName="RunTime"
                                     DisplayMemberBinding="{Binding Path=RunTime}" Width="Auto"></GridViewColumn>

--- a/octgnFX/Octgn/Tabs/GameHistory/GameHistoryViewModel.cs
+++ b/octgnFX/Octgn/Tabs/GameHistory/GameHistoryViewModel.cs
@@ -56,7 +56,7 @@ namespace Octgn.Tabs.GameHistory
         }
         private string _name;
 
-        public string StartTime {
+        public DateTime StartTime {
             get => _startTime;
             private set {
                 if (value.Equals(_startTime)) {
@@ -66,7 +66,7 @@ namespace Octgn.Tabs.GameHistory
                 OnPropertyChanged(nameof(StartTime));
             }
         }
-        private string _startTime;
+        private DateTime _startTime;
 
         public string RunTime {
             get => _runTime;
@@ -140,7 +140,7 @@ namespace Octgn.Tabs.GameHistory
             Id = history.Id;
             GameId = history.GameId;
             Name = history.Name;
-            StartTime = history.DateStarted.LocalDateTime.ToString("f");
+            StartTime = history.DateStarted.LocalDateTime;
             var runTime = (history.DateSaved.LocalDateTime - history.DateStarted.LocalDateTime);
             RunTime = string.Format("{0}h {1}m", Math.Floor(runTime.TotalHours), runTime.Minutes);
             GameName = gameName;

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+Fix game replay ordering - Ben


### PR DESCRIPTION
format datetime in the grid rather than before to allow proper ordering.

Haven't tested if this breaks anything watching the actual replay itself since I don't actually have a sub account. 😛 it looks like it gets generated fine though, and any previous existing replays show up in the list no problem.