### PR TITLE
various fixes for the deck editor

### DIFF
--- a/octgnFX/Octgn/CommandLineHandler.cs
+++ b/octgnFX/Octgn/CommandLineHandler.cs
@@ -68,7 +68,7 @@ namespace Octgn
                     {"g|game=", x => gameid = Guid.Parse(x)},
                     {"d|deck=", x => deckPath = x},
                     {"x|devmode", x => DevMode = true},
-                    {"e|editor", x=> editorOnly = true}
+                    {"e|editor", x => editorOnly = true}
                 };
                 try
                 {

--- a/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml
+++ b/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml
@@ -111,10 +111,10 @@
         <GridSplitter Grid.Row="2" ResizeDirection="Rows" Height="4" VerticalAlignment="Center"
                   HorizontalAlignment="Stretch" Background="Transparent" Grid.ColumnSpan="2" />
         <Border Grid.Row="3" Margin="4,0,0,4" Padding="6" Style="{StaticResource Panel}">
-            <TabControl DragLeave="TabControl_DragLeave">
+            <TabControl DragLeave="TabControl_DragLeave" IsEnabled="{Binding IsGameLoaded, ElementName=self}">
                 <TabItem>
                     <TabItem.Header>
-                        <TextBlock Text="{Binding Path=DeckSectionsTotalCards, ElementName=self, StringFormat='Player({0})', FallbackValue=Player}" 
+                        <TextBlock Text="{Binding Path=DeckSectionsTotalCards, ElementName=self, StringFormat='Player({0})', FallbackValue=Player, TargetNullValue=Player}" 
                                    Style="{Binding Parent.Header.Style, RelativeSource={RelativeSource Self}}" />
                     </TabItem.Header>
                     <ScrollViewer VerticalScrollBarVisibility="Auto" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
@@ -126,7 +126,7 @@
                 </TabItem>
                 <TabItem>
                     <TabItem.Header>
-                        <TextBlock Text="{Binding Path=DeckSharedSectionsTotalCards, ElementName=self, StringFormat='Global({0})', FallbackValue=Global}" 
+                        <TextBlock Text="{Binding Path=DeckSharedSectionsTotalCards, ElementName=self, StringFormat='Global({0})', FallbackValue=Global, TargetNullValue=Global}" 
                                    Style="{Binding Parent.Header.Style, RelativeSource={RelativeSource Self}}" />
                     </TabItem.Header>
                     <ScrollViewer VerticalScrollBarVisibility="Auto" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">

--- a/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml.cs
@@ -691,7 +691,9 @@ namespace Octgn.DeckBuilder
             InvokeDeckChangedEvent();
 
             // Focus section where card was added
-            var cont = PlayerCardSections.ItemContainerGenerator.ContainerFromItem(ActiveSection);
+            var activeGroup = ActiveSection.Shared ? GlobalCardSections : PlayerCardSections;
+            var cont = activeGroup.ItemContainerGenerator.ContainerFromItem(ActiveSection);
+
             Expander presenter = (Expander)VisualTreeHelper.GetChild(cont, 0);
             if (presenter.IsExpanded)
             {
@@ -1397,7 +1399,9 @@ namespace Octgn.DeckBuilder
             else if (e.Key == Key.Enter || e.Key == Key.Escape)
             {
                 e.Handled = true;
-                var cont = PlayerCardSections.ItemContainerGenerator.ContainerFromItem(ActiveSection);
+                var activeGroup = ActiveSection.Shared ? GlobalCardSections : PlayerCardSections;
+                var cont = activeGroup.ItemContainerGenerator.ContainerFromItem(ActiveSection);
+
                 Expander presenter = (Expander)VisualTreeHelper.GetChild(cont, 0);
                 presenter.IsExpanded = !presenter.IsExpanded;
                 if (presenter.IsExpanded)
@@ -1414,13 +1418,14 @@ namespace Octgn.DeckBuilder
 
         public void ChangeActiveSection(int delta)
         {
-            var cont = PlayerCardSections.ItemContainerGenerator.ContainerFromItem(ActiveSection);
-            var idx = PlayerCardSections.ItemContainerGenerator.IndexFromContainer(cont);
+            var activeGroup = ActiveSection.Shared ? GlobalCardSections : PlayerCardSections;
+            var cont = activeGroup.ItemContainerGenerator.ContainerFromItem(ActiveSection);
+            var idx = activeGroup.ItemContainerGenerator.IndexFromContainer(cont);
             // Focus previous section
             idx += delta;
-            if (idx < 0 || idx >= PlayerCardSections.Items.Count)
+            if (idx < 0 || idx >= activeGroup.Items.Count)
                 return;
-            var nc = (ContentPresenter)PlayerCardSections.ItemContainerGenerator.ContainerFromIndex(idx);
+            var nc = (ContentPresenter)activeGroup.ItemContainerGenerator.ContainerFromIndex(idx);
             Expander presenter = (Expander)VisualTreeHelper.GetChild(nc, 0);
             DataGrid grid = (DataGrid)presenter.Content;
             if (presenter.IsExpanded)

--- a/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml.cs
@@ -950,7 +950,6 @@ namespace Octgn.DeckBuilder
         }
         private void PickUpDeckCard(object sender, MouseEventArgs e)
         {
-            _unsaved = true;
             e.Handled = true;
             if (MouseButtonState.Pressed.Equals(e.LeftButton) && activeRow != null && !dragging)
             {
@@ -959,6 +958,7 @@ namespace Octgn.DeckBuilder
                     ObservableMultiCard getCard = (ObservableMultiCard)activeRow.Item;
                     DataObject dragCard = new DataObject("Card", getCard.ToMultiCard(getCard.Quantity));
                     dragging = true;
+                    _unsaved = true;
                     if (System.Windows.Forms.Control.ModifierKeys == System.Windows.Forms.Keys.Shift || getCard.Quantity <= 1)
                     {
                         dragSection.Cards.RemoveCard(getCard);

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+fixed decks being falsely flagged as unsaved when moving the cursor over the deck - Ben

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,3 @@
 fixed decks being falsely flagged as unsaved when moving the cursor over the deck - Ben
+removed card counts from player/global editor tabs if they have no sections - Ben
+disabled editor deck tabs when no deck is loaded - Ben

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,3 +1,4 @@
 fixed decks being falsely flagged as unsaved when moving the cursor over the deck - Ben
 removed card counts from player/global editor tabs if they have no sections - Ben
 disabled editor deck tabs when no deck is loaded - Ben
+Fixed crashes related to shared deck sections in the editor - Ben


### PR DESCRIPTION
- fixed decks being falsely flagged as unsaved when moving the cursor over the deck
- removed card counts from player/global editor tabs if they have no sections
- disabled editor deck tabs when no deck is loaded - #1895 
- Fixed crashes related to shared deck sections in the editor