### PR TITLE
Overhauled custom card property management, card name is a dedicated alt property

### DIFF
--- a/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
+++ b/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
@@ -171,6 +171,13 @@ namespace Octgn.Core.DataExtensionMethods
             return ret;
         }
 
+        public static IDictionary<PropertyDef, object> GetFullCardProperties(this ICard card)
+        {
+            var ret = GetCardProperties(card);
+            ret.Add(GameExtensionMethods.NameProperty, card.Name);
+            return ret;
+        }
+
         public static void SetPropertySet(this Card card, string propertyType = "")
         {
             if (String.IsNullOrWhiteSpace(propertyType)) propertyType = "";

--- a/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
+++ b/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
@@ -146,6 +146,7 @@ namespace Octgn.Core.DataExtensionMethods
                 ret.Add(kvi.Key.Name, kvi.Value.ToString());
             }
             ret.Add("SetName", card.GetSet().Name);
+            ret.Add("Name", GetName(card));
             ret.Add("CardSizeName", card.Size.Name);
             ret.Add("CardSizeHeight", card.Size.Height.ToString());
             ret.Add("CardSizeWidth", card.Size.Width.ToString());
@@ -179,7 +180,7 @@ namespace Octgn.Core.DataExtensionMethods
                 card.Size = card.PropertySets[propertyType].Size;
             }
         }
-        public static string GetName(this Card card)
+        public static string GetName(this ICard card)
         {
             return card.PropertySets[card.Alternate].Name;
         }

--- a/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
+++ b/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
@@ -114,7 +114,7 @@ namespace Octgn.Core.DataExtensionMethods
 
         public static bool HasProperty(this Card card, string name)
         {
-            return card.Properties[card.Alternate].Properties.Any(x => x.Key.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase) && x.Key.IsUndefined == false);
+            return card.GetCardProperties().Any(x => x.Key.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
         }
 
         private static void GenerateProxyImage(this ICard card, Set set, string uri)
@@ -141,7 +141,7 @@ namespace Octgn.Core.DataExtensionMethods
         public static Dictionary<string, string> GetProxyMappings(this ICard card)
         {
             Dictionary<string, string> ret = new Dictionary<string, string>();
-            foreach (KeyValuePair<PropertyDef, object> kvi in card.PropertySet())
+            foreach (KeyValuePair<PropertyDef, object> kvi in card.GetCardProperties())
             {
                 ret.Add(kvi.Key.Name, kvi.Value.ToString());
             }
@@ -152,37 +152,44 @@ namespace Octgn.Core.DataExtensionMethods
             return (ret);
         }
 
-
-        public static IDictionary<PropertyDef, object> PropertySet(this ICard card)
+        public static IDictionary<PropertyDef, object> GetBaseCardProperties(this ICard card)
         {
-            var ret = card.Properties[card.Alternate].Properties.Where(x => x.Key.IsUndefined == false).ToDictionary(x => x.Key, x => x.Value);
+            var ret = card.PropertySets[""].Properties.ToDictionary(x => x.Key, x => x.Value);
+            return ret;
+        }
+        public static IDictionary<PropertyDef, object> GetCardProperties(this ICard card)
+        {
+            var ret = GetBaseCardProperties(card);
+            if (card.Alternate != "")
+            {
+                foreach (var altProperty in card.PropertySets[card.Alternate].Properties)
+                {
+                    ret[altProperty.Key] = altProperty.Value;
+                }
+            }
             return ret;
         }
 
         public static void SetPropertySet(this Card card, string propertyType = "")
         {
             if (String.IsNullOrWhiteSpace(propertyType)) propertyType = "";
-            if (card.Properties.Any(x => x.Key.Equals(propertyType, StringComparison.InvariantCultureIgnoreCase)))
+            if (card.PropertySets.Any(x => x.Key.Equals(propertyType, StringComparison.InvariantCultureIgnoreCase)))
             {
                 card.Alternate = propertyType;
-                card.Size = card.Properties[propertyType].Size;
+                card.Size = card.PropertySets[propertyType].Size;
             }
         }
-
-        public static string PropertyName(this Card card)
+        public static string GetName(this Card card)
         {
-            return
-                card.PropertySet()
-                    .First(x => x.Key.Name.Equals("name", StringComparison.InvariantCultureIgnoreCase))
-                    .Value as string;
+            return card.PropertySets[card.Alternate].Name;
         }
 
         public static MultiCard Clone(this MultiCard card)
         {
             var ret = new MultiCard(card);
-            foreach (var p in card.Properties)
+            foreach (var p in card.PropertySets)
             {
-                ret.Properties.Add(p.Key, p.Value);
+                ret.PropertySets.Add(p.Key, p.Value);
             }
             return ret;
         }

--- a/octgnFX/Octgn.Core/DataExtensionMethods/GameExtensionMethods.cs
+++ b/octgnFX/Octgn.Core/DataExtensionMethods/GameExtensionMethods.cs
@@ -132,26 +132,25 @@ namespace Octgn.Core.DataExtensionMethods
         {
             DataTable table = new DataTable();
 
-            var values = new object[game.CustomProperties.Count + 6 - 1];
-            var defaultValues = new object[game.CustomProperties.Count + 6 - 1];
+            var values = new object[game.CustomProperties.Count + 6];
+            var defaultValues = new object[game.CustomProperties.Count + 6];
             var indexes = new Dictionary<int, string>();
             var setCache = new Dictionary<Guid, string>();
-            var i = 0 + 6;
+            var i = 6;
             table.Columns.Add("Name", typeof(string));
-            table.Columns.Add("SetName", typeof(string));
-            table.Columns.Add("set_id", typeof(String));
-            table.Columns.Add("img_uri", typeof(String));
-            table.Columns.Add("id", typeof(string));
-            table.Columns.Add("Alternates", typeof(string));
             defaultValues[0] = "";
+            table.Columns.Add("SetName", typeof(string));
             defaultValues[1] = "";
+            table.Columns.Add("set_id", typeof(string));
             defaultValues[2] = "";
+            table.Columns.Add("img_uri", typeof(string));
             defaultValues[3] = "";
+            table.Columns.Add("id", typeof(string));
             defaultValues[4] = "";
+            table.Columns.Add("Alternates", typeof(string));
             defaultValues[5] = "";
             foreach (var prop in game.CustomProperties)
             {
-                if (prop.Name == "Name") continue;
                 switch (prop.Type)
                 {
                     case PropertyType.String:
@@ -193,26 +192,19 @@ namespace Octgn.Core.DataExtensionMethods
                 values[2] = item.SetId;
                 values[3] = item.GetImageUri();
                 values[4] = item.Id;
-                var alternates = item.Properties.Keys;
-                foreach (string alt in alternates)
+                foreach (CardPropertySet alt in item.PropertySets.Values)
                 {
-                    values[5] = alt;
-                    Card altCard = item.Clone();
-                    altCard.Alternate = alt;
-                    foreach (var prop in altCard.PropertySet())
+                    values[5] = alt.Type;
+                    values[0] = alt.Name;
+                    foreach (var prop in alt.Properties)
                     {
-                        if (prop.Key.Name == "Name")
-                        {
-                            values[0] = prop.Value;
-                            continue;
-                        }
-                        var ix = indexes.Where(x => x.Value == prop.Key.Name).Select(x => new { Key = x.Key, Value = x.Value }).FirstOrDefault();
+                        var ix = indexes.Where(x => x.Value == prop.Key.Name).Select(x => new { x.Key, x.Value }).FirstOrDefault();
                         if (ix == null)
                             throw new UserMessageException(L.D.Exception__CanNotCreateDeckMissingCardProperty);
                         if (prop.Key.Type == PropertyType.Integer)
                         {
                             int garbo;
-                            if (prop.Key.IsUndefined || !int.TryParse(prop.Value as string, out garbo))
+                            if (prop.Value == null || !int.TryParse(prop.Value as string, out garbo))
                             {
                                 values[ix.Key] = null;
                                 continue;

--- a/octgnFX/Octgn.Core/DataExtensionMethods/GameExtensionMethods.cs
+++ b/octgnFX/Octgn.Core/DataExtensionMethods/GameExtensionMethods.cs
@@ -32,6 +32,22 @@ namespace Octgn.Core.DataExtensionMethods
         }
         private static IFileSystem io;
 
+        public static PropertyDef _nameProperty;
+
+        public static PropertyDef NameProperty
+        {
+            get
+            {
+                if (_nameProperty == null)
+                    _nameProperty = new PropertyDef()
+                    {
+                        Name = "Name",
+                        Type = PropertyType.String
+                    };
+                return _nameProperty;
+            }
+        }
+
         public static IEnumerable<Set> Sets(this Game game)
         {
             var ret = SetManager.Get().GetByGameId(game.Id);
@@ -111,7 +127,7 @@ namespace Octgn.Core.DataExtensionMethods
         {
             var g = GameManager.Get().GetById(game.Id);
             if (g == null) return new List<PropertyDef>();
-            return Enumerable.Repeat(new PropertyDef { Name = "Name", Type = PropertyType.String }, 1).Union(game.CustomProperties);
+            return Enumerable.Repeat(NameProperty, 1).Union(game.CustomProperties);
         }
 
         public static IEnumerable<Card> AllCards(this Game game)

--- a/octgnFX/Octgn.DataNew/CardPropertyComparer.cs
+++ b/octgnFX/Octgn.DataNew/CardPropertyComparer.cs
@@ -8,13 +8,11 @@
 
     public class CardPropertyComparer : IComparer, IComparer<ICard>
     {
-        private readonly bool _isName;
         private readonly string _propertyName;
 
         public CardPropertyComparer(string propertyName)
         {
             _propertyName = propertyName;
-            _isName = propertyName == "Name";
         }
 
         #region IComparer Members
@@ -30,11 +28,8 @@
 
         public int Compare(ICard x, ICard y)
         {
-            if (_isName)
-                return String.CompareOrdinal(x.Name, y.Name);
-
-            object px = x.Properties[x.Alternate].Properties[new PropertyDef(){Name=_propertyName}];
-            object py = y.Properties[y.Alternate].Properties[new PropertyDef() { Name = _propertyName }];
+            object px = x.PropertySets[x.Alternate].Properties[new PropertyDef(){Name=_propertyName}];
+            object py = y.PropertySets[y.Alternate].Properties[new PropertyDef() { Name = _propertyName }];
             if (px == null) return py == null ? 0 : -1;
             return ((IComparable)px).CompareTo(py);
         }

--- a/octgnFX/Octgn.DataNew/Entities/Card.cs
+++ b/octgnFX/Octgn.DataNew/Entities/Card.cs
@@ -14,7 +14,7 @@ namespace Octgn.DataNew.Entities
         string ImageUri { get; }
         string Alternate { get; }
         CardSize Size { get; }
-        IDictionary<string , CardPropertySet> Properties { get; } 
+        IDictionary<string , CardPropertySet> PropertySets { get; } 
     }
 
     public class Card : ICard
@@ -31,7 +31,7 @@ namespace Octgn.DataNew.Entities
 
         public CardSize Size { get; set; }
 
-        public IDictionary<string , CardPropertySet> Properties { get; set; }
+        public IDictionary<string , CardPropertySet> PropertySets { get; set; }
 
         public Card(Guid id, Guid setId, string name, string imageuri, string alternate, CardSize size, IDictionary<string,CardPropertySet> properties )
         {
@@ -41,8 +41,8 @@ namespace Octgn.DataNew.Entities
             ImageUri = imageuri.Clone() as string;
             Alternate = alternate.Clone() as string;
             Size = size.Clone() as CardSize;
-            Properties = properties;
-            this.Properties = this.CloneProperties();
+            PropertySets = properties;
+            this.PropertySets = this.CloneProperties();
         }
 
         public Card(ICard card)
@@ -54,6 +54,7 @@ namespace Octgn.DataNew.Entities
 
     public class CardPropertySet : ICloneable
     {
+        public string Name { get; set; }
         public string Type { get; set; }
         public CardSize Size { get; set; }
         public IDictionary<PropertyDef, object> Properties { get; set; }
@@ -62,6 +63,7 @@ namespace Octgn.DataNew.Entities
         {
             var ret = new CardPropertySet()
                           {
+                              Name = this.Name.Clone() as string,
                               Type = this.Type.Clone() as string,
                               Size = this.Size.Clone() as CardSize,
                               Properties =

--- a/octgnFX/Octgn.DataNew/Entities/MultiCard.cs
+++ b/octgnFX/Octgn.DataNew/Entities/MultiCard.cs
@@ -122,7 +122,7 @@
             }
         }
 
-        public IDictionary<string, CardPropertySet> Properties
+        public IDictionary<string, CardPropertySet> PropertySets
         {
             get
             {
@@ -173,7 +173,7 @@
             ImageUri = imageuri.Clone() as string;
             Alternate = alternate.Clone() as string;
             Size = size.Clone() as CardSize;
-            Properties = properties;
+            PropertySets = properties;
             this.properties = this.CloneProperties();
         }
 

--- a/octgnFX/Octgn.DataNew/Entities/Pick.cs
+++ b/octgnFX/Octgn.DataNew/Entities/Pick.cs
@@ -53,18 +53,18 @@
 
                 foreach (var p in picked.Include.Properties)
                 {
-                    var key = picked.Card.Properties[""].Properties.Where(x => x.Key.Name.ToLower() == p.Item1.ToLower()).FirstOrDefault().Key;
+                    var key = picked.Card.PropertySets[""].Properties.Where(x => x.Key.Name.ToLower() == p.Item1.ToLower()).FirstOrDefault().Key;
                     if (key != null) // if the include property name isn't a defined custom property, ignore it
                     {
                         if (key.Type is PropertyType.RichText)
                         {
                             var span = new RichSpan();
                             span.Items.Add(new RichText() { Text = p.Item2 });
-                            card.Properties[""].Properties[key] = new RichTextPropertyValue() { Value = span };
+                            card.PropertySets[""].Properties[key] = new RichTextPropertyValue() { Value = span };
                         }
                         else
                         {
-                            card.Properties[""].Properties[key] = p.Item2;
+                            card.PropertySets[""].Properties[key] = p.Item2;
                         }
                     }
                 }
@@ -81,7 +81,7 @@
                 var list = (
                     from card in cardList
                     where
-                        card.Properties.Where(x => x.Key == "").SelectMany(x => x.Value.Properties).Any(
+                        card.PropertySets.Where(x => x.Key == "").SelectMany(x => x.Value.Properties).Any(
                             x =>
                             x.Key.Name.ToLower() == Key.ToLower()
                             && x.Value.ToString().ToLower() == Value.ToLower())

--- a/octgnFX/Octgn.DataNew/Entities/Pick.cs
+++ b/octgnFX/Octgn.DataNew/Entities/Pick.cs
@@ -9,6 +9,7 @@
     using log4net;
 
     using Octgn.Library.ExtensionMethods;
+    using Octgn.Core.DataExtensionMethods;
 
     public class Pick : IPackItem
     {
@@ -53,7 +54,7 @@
 
                 foreach (var p in picked.Include.Properties)
                 {
-                    var key = picked.Card.PropertySets[""].Properties.Where(x => x.Key.Name.ToLower() == p.Item1.ToLower()).FirstOrDefault().Key;
+                    var key = picked.Card.GetFullCardProperties().Where(x => x.Key.Name.ToLower() == p.Item1.ToLower()).FirstOrDefault().Key;
                     if (key != null) // if the include property name isn't a defined custom property, ignore it
                     {
                         if (key.Type is PropertyType.RichText)
@@ -81,7 +82,7 @@
                 var list = (
                     from card in cardList
                     where
-                        card.PropertySets.Where(x => x.Key == "").SelectMany(x => x.Value.Properties).Any(
+                        card.GetFullCardProperties().Any(
                             x =>
                             x.Key.Name.ToLower() == Key.ToLower()
                             && x.Value.ToString().ToLower() == Value.ToLower())

--- a/octgnFX/Octgn.DataNew/Entities/PropertyDef.cs
+++ b/octgnFX/Octgn.DataNew/Entities/PropertyDef.cs
@@ -24,7 +24,6 @@
         public PropertyType Type { get; set; }
         public bool IgnoreText { get; set; }
         public bool Hidden { get; set; }
-        public bool IsUndefined { get; set; }
         public PropertyTextKind TextKind { get; set; }
 
         public bool Equals(PropertyDef other)
@@ -57,7 +56,6 @@
                 Type = this.Type,
                 TextKind = this.TextKind,
                 IgnoreText = this.IgnoreText,
-                IsUndefined = this.IsUndefined
             };
             return newprop;
         }

--- a/octgnFX/Octgn.DataNew/ExtensionMethods.cs
+++ b/octgnFX/Octgn.DataNew/ExtensionMethods.cs
@@ -12,7 +12,7 @@ namespace Octgn.DataNew
         public static IDictionary<string, CardPropertySet> CloneProperties(this ICard card)
         {
             var ret = new Dictionary<string, CardPropertySet>();
-            foreach (var p in card.Properties)
+            foreach (var p in card.PropertySets)
             {
                 ret.Add((string)p.Key.Clone(), p.Value.Clone() as CardPropertySet);
             }

--- a/octgnFX/Octgn.DataNew/GameSerializer.cs
+++ b/octgnFX/Octgn.DataNew/GameSerializer.cs
@@ -349,13 +349,6 @@ namespace Octgn.DataNew
             }
             #endregion deck
             #region card
-            var namepd = new PropertyDef
-            {
-                Name = "Name",
-                TextKind = PropertyTextKind.FreeText,
-                Type = PropertyType.String
-            };
-            ret.CustomProperties.Add(namepd);
             if (g.card != null)
             {
                 if (g.card.property != null)
@@ -971,7 +964,6 @@ namespace Octgn.DataNew
                 var propertyDefList = new List<propertyDef>();
                 foreach (var p in game.CustomProperties)
                 {
-                    if (p.Name == "Name") continue;
                     var propertyDef = new propertyDef
                     {
                         name = p.Name,
@@ -1347,152 +1339,58 @@ namespace Octgn.DataNew
                 if (!Directory.Exists(ret.ImagePackUri)) Directory.CreateDirectory(ret.ImagePackUri);
                 if (!Directory.Exists(ret.ProxyPackUri)) Directory.CreateDirectory(ret.ProxyPackUri);
                 var game = Game ?? DbContext.Get().Games.First(x => x.Id == ret.GameId);
-                foreach (var c in doc.Document.Descendants("card"))
+                foreach (var cardXml in doc.Document.Descendants("card"))
                 {
-                    var card = new Card(new Guid(c.Attribute("id").Value), ret.Id, c.Attribute("name").Value, c.Attribute("id").Value, "", game.CardSizes[""], new Dictionary<string, CardPropertySet>());
+                    var card = new Card(new Guid(cardXml.Attribute("id").Value), ret.Id, cardXml.Attribute("name").Value, cardXml.Attribute("id").Value, "", game.CardSizes[""], new Dictionary<string, CardPropertySet>());
 
-                    var cs = c.Attribute("size");
-                    if (cs != null)
+                    var cardSize = cardXml.Attribute("size");
+                    if (cardSize != null)
                     {
-                        if (game.CardSizes.ContainsKey(cs.Value) == false)
+                        if (game.CardSizes.ContainsKey(cardSize.Value) == false)
                             throw new UserMessageException(Octgn.Library.Localization.L.D.Exception__BrokenGameContactDev_Format, game.Name);
 
-                        card.Size = game.CardSizes[cs.Value];
+                        card.Size = game.CardSizes[cardSize.Value];
                     }
+                    else
+                        card.Size = game.CardSize;
 
-                    var defaultProperties = new CardPropertySet
+                    var baseCardPropertySet = new CardPropertySet
                     {
+                        Name = card.Name,
                         Type = "",
                         Size = card.Size,
                         Properties = new Dictionary<PropertyDef, object>()
                     };
-                    foreach (var p in c.Descendants("property").Where(x => x.Parent.Name == "card"))
-                    {
-                        var gameproperty = game.CustomProperties.FirstOrDefault(x => x.Name == p.Attribute("name").Value);
-                        if (gameproperty == null)
-                        {
-                            throw new UserMessageException(Octgn.Library.Localization.L.D.Exception__BrokenGameContactDev_Format, game.Name);
-                        }
-                        var propertydef = gameproperty.Clone() as PropertyDef;
-                        if (propertydef.Type is PropertyType.RichText)
-                        {
-                            var span = new RichSpan();
-                            DeserializeCardProperty(span, p, game);
-                            var propertydefvalue = new RichTextPropertyValue
-                            {
-                                Value = span
-                            };
-                            defaultProperties.Properties.Add(propertydef, propertydefvalue);
-                        }
-                        else
-                        {
-                            defaultProperties.Properties.Add(propertydef, p.Attribute("value").Value);
-                        }
 
-                    }
-                    foreach (var cp in game.CustomProperties)
-                    {
-                        if (!defaultProperties.Properties.ContainsKey(cp))
-                        {
-                            var blankCardProperty = cp.Clone() as PropertyDef;
-                            blankCardProperty.IsUndefined = true;
-                            if (blankCardProperty.Type is PropertyType.RichText)
-                            {
-                                defaultProperties.Properties.Add(blankCardProperty, new RichTextPropertyValue() { Value = new RichSpan() });
-                            }
-                            else
-                            {
-                                defaultProperties.Properties.Add(blankCardProperty, "");
-                            }
-                        }
-                    }
-                    var nameproperty = new PropertyDef()
-                                 {
-                                     Hidden = false,
-                                     Name = "Name",
-                                     Type = PropertyType.String,
-                                     TextKind = PropertyTextKind.FreeText,
-                                     IgnoreText = false,
-                                     IsUndefined = false
-                                 };
-                    if (defaultProperties.Properties.ContainsKey(nameproperty))
-                        defaultProperties.Properties.Remove(nameproperty);
-                    defaultProperties.Properties.Add(nameproperty, card.Name);
-                    card.Properties.Add("", defaultProperties);
+                    // deserialize the base card properties
+                    var xmlBaseCardProperties = cardXml.Descendants("property").Where(x => x.Parent.Name == "card");
+                    DeserializeCardPropertySet(xmlBaseCardProperties, baseCardPropertySet, game);
+                    card.PropertySets.Add("", baseCardPropertySet);
 
                     // Add all of the other property sets
-                    foreach (var a in c.Descendants("alternate"))
+                    foreach (var altXml in cardXml.Descendants("alternate"))
                     {
-                        var propertySet = new CardPropertySet
+                        var altPropertySet = new CardPropertySet
                         {
+                            Name = altXml.Attribute("name").Value,
                             Properties = new Dictionary<PropertyDef, object>(),
-                            Type = a.Attribute("type").Value
+                            Type = altXml.Attribute("type").Value
                         };
 
-                        var acs = a.Attribute("size");
-                        if (acs != null)
+                        var altSize = altXml.Attribute("size");
+                        if (altSize != null)
                         {
-                            if (game.CardSizes.ContainsKey(acs.Value) == false)
+                            if (game.CardSizes.ContainsKey(altSize.Value) == false)
                                 throw new UserMessageException(Octgn.Library.Localization.L.D.Exception__BrokenGameContactDev_Format, game.Name);
-                            propertySet.Size = game.CardSizes[acs.Value];
-                        }
-                        else propertySet.Size = card.Size;
 
-                        var thisName = a.Attribute("name").Value;
-                        foreach (var p in a.Descendants("property"))
-                        {
-                            var gameProperty = game.CustomProperties.FirstOrDefault(x => x.Name == p.Attribute("name").Value);
-                            if (gameProperty == null)
-                            {
-                                throw new UserMessageException(Octgn.Library.Localization.L.D.Exception__BrokenGameContactDev_Format, game.Name);
-                            }
-
-                            var propertyDef = gameProperty.Clone() as PropertyDef;
-
-                            if (propertyDef.Type is PropertyType.RichText)
-                            {
-                                var span = new RichSpan();
-                                DeserializeCardProperty(span, p, game);
-                                var propertyDefValue = new RichTextPropertyValue
-                                {
-                                    Value = span
-                                };
-                                propertySet.Properties.Add(propertyDef, propertyDefValue);
-                            }
-                            else
-                            {
-                                propertySet.Properties.Add(propertyDef, p.Attribute("value").Value);
-                            }
+                            altPropertySet.Size = game.CardSizes[altSize.Value];
                         }
-                        foreach (var customProperty in game.CustomProperties)
-                        {
-                            if (!propertySet.Properties.ContainsKey(customProperty))
-                            {
-                                var blankCardProperty = customProperty.Clone() as PropertyDef;
-                                blankCardProperty.IsUndefined = true;
-                                if (blankCardProperty.Type is PropertyType.RichText)
-                                {
-                                    propertySet.Properties.Add(blankCardProperty, new RichTextPropertyValue() { Value = new RichSpan() });
-                                }
-                                else
-                                {
-                                    propertySet.Properties.Add(blankCardProperty, "");
-                                }
-                            }
-                        }
-                        var altNameProperty = new PropertyDef()
-                        {
-                            Hidden = false,
-                            Name = "Name",
-                            Type = PropertyType.String,
-                            TextKind = PropertyTextKind.FreeText,
-                            IgnoreText = false,
-                            IsUndefined = false
-                        };
-                        if (propertySet.Properties.ContainsKey(altNameProperty))
-                            propertySet.Properties.Remove(altNameProperty);
-                        propertySet.Properties.Add(altNameProperty, a.Attribute("name").Value);
-                        card.Properties.Add(propertySet.Type, propertySet);
+                        else altPropertySet.Size = game.CardSize;
+
+                        // deserialize the alternate card properties
+                        var xmlAltProperties = altXml.Descendants("property");
+                        DeserializeCardPropertySet(xmlAltProperties, altPropertySet, game);
+                        card.PropertySets.Add(altPropertySet.Type, altPropertySet);
                     }
 
                     (ret.Cards as List<Card>).Add(card);
@@ -1543,7 +1441,52 @@ namespace Octgn.DataNew
             return ret;
         }
 
-        private void DeserializeCardProperty(RichSpan span, XElement xmlNode, Game game)
+        private void DeserializeCardPropertySet(IEnumerable<XElement> cardPropertyElements, CardPropertySet propertySet, Game game)
+        {
+            foreach (var propertyElement in cardPropertyElements)
+            {
+                var gameDefinedProperty = game.CustomProperties.FirstOrDefault(x => x.Name == propertyElement.Attribute("name").Value);
+                if (gameDefinedProperty == null)
+                {
+                    throw new UserMessageException(Octgn.Library.Localization.L.D.Exception__BrokenGameContactDev_Format, game.Name);
+                }
+                var cardPropertyDef = gameDefinedProperty.Clone() as PropertyDef;
+                if (cardPropertyDef.Type is PropertyType.RichText)
+                {
+                    var span = new RichSpan();
+                    DeserializeRichCardProperty(span, propertyElement, game);
+                    var propertyDefValue = new RichTextPropertyValue
+                    {
+                        Value = span
+                    };
+                    propertySet.Properties.Add(cardPropertyDef, propertyDefValue);
+                }
+                else
+                {
+                    propertySet.Properties.Add(cardPropertyDef, propertyElement.Attribute("value").Value);
+                }
+
+            }
+            /* don't add missing properties to the database
+            foreach (var gameProperties in game.CustomProperties)
+            {
+                if (!propertySet.Properties.ContainsKey(gameProperties))
+                {
+                    var blankCardProperty = gameProperties.Clone() as PropertyDef;
+                    blankCardProperty.IsUndefined = true;
+                    if (blankCardProperty.Type is PropertyType.RichText)
+                    {
+                        propertySet.Properties.Add(blankCardProperty, new RichTextPropertyValue() { Value = new RichSpan() });
+                    }
+                    else
+                    {
+                        propertySet.Properties.Add(blankCardProperty, null);
+                    }
+                }
+            }*/
+        }
+
+        private void DeserializeRichCardProperty(RichSpan span, XElement xmlNode, Game game)
         {
             foreach (XNode child in xmlNode.Nodes())
             {
@@ -1559,7 +1502,7 @@ namespace Octgn.DataNew
                         case "BOLD":
                             {
                                 RichSpan boldSpan = new RichSpan();
-                                DeserializeCardProperty(boldSpan, element, game);
+                                DeserializeRichCardProperty(boldSpan, element, game);
                                 boldSpan.Type = RichSpanType.Bold;
                                 span.Items.Add(boldSpan);
                                 break;
@@ -1568,7 +1511,7 @@ namespace Octgn.DataNew
                         case "ITALIC":
                             {
                                 RichSpan italicSpan = new RichSpan();
-                                DeserializeCardProperty(italicSpan, element, game);
+                                DeserializeRichCardProperty(italicSpan, element, game);
                                 italicSpan.Type = RichSpanType.Italic;
                                 span.Items.Add(italicSpan);
                                 break;
@@ -1577,7 +1520,7 @@ namespace Octgn.DataNew
                         case "UNDERLINE":
                             {
                                 RichSpan underlineSpan = new RichSpan();
-                                DeserializeCardProperty(underlineSpan, element, game);
+                                DeserializeRichCardProperty(underlineSpan, element, game);
                                 underlineSpan.Type = RichSpanType.Underline;
                                 span.Items.Add(underlineSpan);
                                 break;
@@ -1586,7 +1529,7 @@ namespace Octgn.DataNew
                         case "COLOR":
                             {
                                 RichColor colorSpan = new RichColor();
-                                DeserializeCardProperty(colorSpan, element, game);
+                                DeserializeRichCardProperty(colorSpan, element, game);
                                 colorSpan.Type = RichSpanType.Color;
                                 var regexColorCode = new Regex.Regex("^#[a-fA-F0-9]{6}$");
                                 var color = element.Attribute("value").Value;
@@ -1708,7 +1651,7 @@ namespace Octgn.DataNew
                     id = c.Id.ToString(),
                 };
                 List<setCardAlternate> alts = new List<setCardAlternate>();
-                foreach (var propset in c.Properties)
+                foreach (var propset in c.PropertySets)
                 {
                     if (propset.Key == c.Alternate)
                     {
@@ -1716,7 +1659,7 @@ namespace Octgn.DataNew
                         foreach (var p in propset.Value.Properties)
                         {
                             if (p.Key.Name == "Name") continue;
-                            if (p.Value == null || p.Key.IsUndefined) continue;
+                            if (p.Value == null) continue;
                             var prop = new property
                             {
                                 name = p.Key.Name,
@@ -1743,7 +1686,7 @@ namespace Octgn.DataNew
                                 alt.name = p.Value.ToString();
                             else
                             {
-                                if (p.Value == null || p.Key.IsUndefined) continue;
+                                if (p.Value == null) continue;
                                 var prop = new property
                                 {
                                     name = p.Key.Name,

--- a/octgnFX/Octgn.DataNew/Octgn.DataNew.csproj
+++ b/octgnFX/Octgn.DataNew/Octgn.DataNew.csproj
@@ -126,6 +126,9 @@
       <HintPath>..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Octgn.Core">
+      <HintPath>..\Octgn\bin\Debug\Octgn.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/octgnFX/Octgn/DeckBuilder/DeckCardsViewer.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/DeckCardsViewer.xaml.cs
@@ -125,7 +125,7 @@ namespace Octgn.DeckBuilder
                     var b1 = c.Name.IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0;
                     if (b1) return true;
                     var b2 =
-                        c.Properties.SelectMany(x => x.Value.Properties)
+                        c.PropertySets.SelectMany(x => x.Value.Properties)
                             .Any(
                                 x => x.Value.ToString().IndexOf(filter, StringComparison.CurrentCultureIgnoreCase) >= 0);
                     return b2;

--- a/octgnFX/Octgn/DeckBuilder/DeckEditorPreviewControl.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/DeckEditorPreviewControl.xaml.cs
@@ -260,7 +260,7 @@ namespace Octgn.DeckBuilder
                 get
                 {
                     if (Card == null) return false;
-                    return Card.Properties.Count != 1;
+                    return Card.PropertySets.Count != 1;
                 }
             }
 
@@ -277,7 +277,7 @@ namespace Octgn.DeckBuilder
                 get
                 {
                     if (Card == null) return 0;
-                    return Card.Properties.Count;
+                    return Card.PropertySets.Count;
                 }
             }
 
@@ -321,7 +321,7 @@ namespace Octgn.DeckBuilder
                     else if (value >= AlternateCount) index = 0;
                     else index = value;
 
-                    Card.SetPropertySet(Card.Properties.ToArray()[index].Key);
+                    Card.SetPropertySet(Card.PropertySets.ToArray()[index].Key);
 
                     for (var i = 0; i < Alternates.Count; i++)
                     {
@@ -352,7 +352,7 @@ namespace Octgn.DeckBuilder
                 Alternates.Clear();
                 if (Card == null) return;
                 var i = 0;
-                foreach (var a in c.Properties)
+                foreach (var a in c.PropertySets)
                 {
                     if (c.Alternate == a.Key)
                         Index = i;

--- a/octgnFX/Octgn/DeckBuilder/MetaDeck.cs
+++ b/octgnFX/Octgn/DeckBuilder/MetaDeck.cs
@@ -165,7 +165,7 @@ namespace Octgn.DeckBuilder
             Name = card.Name;
             ImageUri = card.ImageUri;
             Alternate = card.Alternate;
-            Properties = card.Properties;
+            PropertySets = card.PropertySets;
             Quantity = card.Quantity;
             IsVisible = true;
             Size = card.Size;
@@ -176,7 +176,7 @@ namespace Octgn.DeckBuilder
         public string Name { get; private set; }
         public string ImageUri { get; private set; }
         public string Alternate { get; private set; }
-        public IDictionary<string, CardPropertySet> Properties { get; private set; }
+        public IDictionary<string, CardPropertySet> PropertySets { get; private set; }
         public int Quantity { get; set; }
         public CardSize Size { get; private set; }
         public event PropertyChangedEventHandler PropertyChanged;

--- a/octgnFX/Octgn/DeckBuilder/SearchControl.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/SearchControl.xaml.cs
@@ -61,8 +61,7 @@ namespace Octgn.DeckBuilder
             var source = 
                 Enumerable.Repeat<object>("First", 1)
                      .Union(Enumerable.Repeat<object>(new SetPropertyDef(Game.Sets().Where(x => x.Hidden == false)), 1))
-                     .Union(Enumerable.Repeat<object>(new PropertyDef() { Name = "Name", Type = PropertyType.String}, 1))
-                     .Union(game.CustomProperties.Where(p => !p.Hidden));
+                     .Union(game.AllProperties().Where(p => !p.Hidden));
 
             filtersList.ItemsSource = source;
             GenerateColumns(game);
@@ -93,7 +92,6 @@ namespace Octgn.DeckBuilder
             filtersList.ItemsSource =
                 Enumerable.Repeat<object>("First", 1)
                     .Union(Enumerable.Repeat<object>(new SetPropertyDef(Game.Sets()), 1))
-                    .Union(Enumerable.Repeat<object>(new PropertyDef() { Name = "Name", Type = PropertyType.String }, 1))
                     .Union(game.AllProperties().Where(p => !p.Hidden));
             this.GenerateColumns(game);
             FileName = "";
@@ -112,8 +110,7 @@ namespace Octgn.DeckBuilder
                     }
                     else
                     {
-                        prop =
-                            loadedGame.CustomProperties.FirstOrDefault(
+                        prop = loadedGame.AllProperties().FirstOrDefault(
                                 x => x.Name.Equals(filter.PropertyName, StringComparison.InvariantCultureIgnoreCase));
                     }
                     if (prop == null) continue;

--- a/octgnFX/Octgn/DeckBuilder/SearchControl.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/SearchControl.xaml.cs
@@ -24,6 +24,7 @@ namespace Octgn.DeckBuilder
 
     using Octgn.Core;
     using Octgn.Core.DataManagers;
+    using Octgn.DataNew.Entities;
 
     public partial class SearchControl : INotifyPropertyChanged
     {
@@ -58,9 +59,10 @@ namespace Octgn.DeckBuilder
             Game = game;
             InitializeComponent();
             var source = 
-                Enumerable.Repeat<object>("First", 1).Union(
-                    Enumerable.Repeat<object>(new SetPropertyDef(Game.Sets().Where(x => x.Hidden == false)), 1).Union(
-                        game.CustomProperties.Where(p => !p.Hidden)));
+                Enumerable.Repeat<object>("First", 1)
+                     .Union(Enumerable.Repeat<object>(new SetPropertyDef(Game.Sets().Where(x => x.Hidden == false)), 1))
+                     .Union(Enumerable.Repeat<object>(new PropertyDef() { Name = "Name", Type = PropertyType.String}, 1))
+                     .Union(game.CustomProperties.Where(p => !p.Hidden));
 
             filtersList.ItemsSource = source;
             GenerateColumns(game);
@@ -89,9 +91,10 @@ namespace Octgn.DeckBuilder
             Game = loadedGame;
             InitializeComponent();
             filtersList.ItemsSource =
-                Enumerable.Repeat<object>("First", 1).Union(
-                    Enumerable.Repeat<object>(new SetPropertyDef(Game.Sets()), 1).Union(
-                        game.AllProperties().Where(p => !p.Hidden)));
+                Enumerable.Repeat<object>("First", 1)
+                    .Union(Enumerable.Repeat<object>(new SetPropertyDef(Game.Sets()), 1))
+                    .Union(Enumerable.Repeat<object>(new PropertyDef() { Name = "Name", Type = PropertyType.String }, 1))
+                    .Union(game.AllProperties().Where(p => !p.Hidden));
             this.GenerateColumns(game);
             FileName = "";
             if (save != null)

--- a/octgnFX/Octgn/DeckBuilder/SearchControl.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/SearchControl.xaml.cs
@@ -57,18 +57,18 @@ namespace Octgn.DeckBuilder
             NumMod = "";
             Game = game;
             InitializeComponent();
-            filtersList.ItemsSource =
+            var source = 
                 Enumerable.Repeat<object>("First", 1).Union(
                     Enumerable.Repeat<object>(new SetPropertyDef(Game.Sets().Where(x => x.Hidden == false)), 1).Union(
-                        game.AllProperties().Where(p => !p.Hidden)));
+                        game.CustomProperties.Where(p => !p.Hidden)));
+
+            filtersList.ItemsSource = source;
             GenerateColumns(game);
             //resultsGrid.ItemsSource = game.SelectCards(null).DefaultView;
             UpdateDataGrid(game.AllCards(true).ToDataTable(Game).DefaultView);
             FileName = "";
             UpdateCount();
-        }//Why are we populating the list on load? I'd rather wait until the search is run with no parameters (V)_V
-        // Why are we poluting the code with snide comments instead of fixing the problem or making a generic TODO (V)_V
-        // Actually, the more that I think about it, the more I think that the first comment is actually a bad idea. (V)_V
+        }
 
         public SearchControl(DataNew.Entities.Game loadedGame, SearchSave save)
         {

--- a/octgnFX/Octgn/Play/Card.cs
+++ b/octgnFX/Octgn/Play/Card.cs
@@ -587,20 +587,12 @@ namespace Octgn.Play
                 return PropertyOverrides[name][alternate];
             }
 
-            //TODO: use cardextension to find alt properties
             //check if the card has a default property value from the set data
-            var prop = _type.Model.PropertySets[alternate].Properties.FirstOrDefault(x => x.Key.Name.Equals(name, scompare));
-            if (prop.Key != null && prop.Value != null)
+            //if the alternate didn't have a property defined, it will use the base card's property.
+            var prop = _type.Model.GetCardProperties().FirstOrDefault(x => x.Key.Name.Equals(name, scompare));
+            if (prop.Key != null)
             {
                 return prop.Value;
-            }
-
-            //if the alternate didn't have a property defined, use the base card's property.
-            //note that if the card is already in its base state, it'll just repeat the same code as above to the same end result
-            var baseProp = _type.Model.PropertySets[""].Properties.FirstOrDefault(x => x.Key.Name.Equals(name, scompare));
-            if (baseProp.Key != null && baseProp.Value != null)
-            {
-                return baseProp.Value;
             }
 
             //return the default value if the card didnt have a value for this property

--- a/octgnFX/Octgn/Play/Card.cs
+++ b/octgnFX/Octgn/Play/Card.cs
@@ -255,12 +255,12 @@ namespace Octgn.Play
 
         public override string Name
         {
-            get { return FaceUp && _type.Model != null ? _type.Model.PropertyName() : "Card"; }
+            get { return FaceUp && _type.Model != null ? _type.Model.GetName() : "Card"; }
         }
 
         public string RealName
         {
-            get { return _type.Model != null ? _type.Model.PropertyName() : "Card"; }
+            get { return _type.Model != null ? _type.Model.GetName() : "Card"; }
         }
         public bool CardMoved
         {
@@ -552,7 +552,7 @@ namespace Octgn.Play
         public string[] Alternates()
         {
             if (_type.Model == null) return new string[0];
-            return _type.Model.Properties.Select(x => x.Key).ToArray();
+            return _type.Model.PropertySets.Select(x => x.Key).ToArray();
         }
 
         public string Alternate()
@@ -578,7 +578,7 @@ namespace Octgn.Play
         public object GetProperty(string name, object defaultReturn = null, StringComparison scompare = StringComparison.InvariantCulture,  string alternate = "")
         {
             if (_type.Model == null) return defaultReturn;
-            if (name.Equals("Name", scompare)) return _type.Model.PropertyName();
+            if (name.Equals("Name", scompare)) return _type.Model.GetName();
             if (name.Equals("Id", scompare)) return _type.Model.Id;
 
             //check if python has changed the default property value
@@ -587,17 +587,18 @@ namespace Octgn.Play
                 return PropertyOverrides[name][alternate];
             }
 
+            //TODO: use cardextension to find alt properties
             //check if the card has a default property value from the set data
-            var prop = _type.Model.Properties[alternate].Properties.FirstOrDefault(x => x.Key.Name.Equals(name, scompare));
-            if (prop.Key != null && !prop.Key.IsUndefined)
+            var prop = _type.Model.PropertySets[alternate].Properties.FirstOrDefault(x => x.Key.Name.Equals(name, scompare));
+            if (prop.Key != null && prop.Value != null)
             {
                 return prop.Value;
             }
 
             //if the alternate didn't have a property defined, use the base card's property.
             //note that if the card is already in its base state, it'll just repeat the same code as above to the same end result
-            var baseProp = _type.Model.Properties[""].Properties.FirstOrDefault(x => x.Key.Name.Equals(name, scompare));
-            if (baseProp.Key != null && !baseProp.Key.IsUndefined)
+            var baseProp = _type.Model.PropertySets[""].Properties.FirstOrDefault(x => x.Key.Name.Equals(name, scompare));
+            if (baseProp.Key != null && baseProp.Value != null)
             {
                 return baseProp.Value;
             }

--- a/octgnFX/Octgn/Play/CardIdentity.cs
+++ b/octgnFX/Octgn/Play/CardIdentity.cs
@@ -47,7 +47,7 @@ namespace Octgn.Play
 
         public override string ToString()
         {
-            return Model == null ? "Card" : Model.PropertyName();
+            return Model == null ? "Card" : Model.GetName();
         }
     }
 }

--- a/octgnFX/Octgn/Play/Dialogs/PickCardsDialog.xaml.cs
+++ b/octgnFX/Octgn/Play/Dialogs/PickCardsDialog.xaml.cs
@@ -318,7 +318,7 @@ namespace Octgn.Play.Dialogs
 
             return (from restriction in _activeRestrictions.GroupBy(fv => fv.Property)
                     let prop = restriction.Key
-                    let value = card.PropertySet().ContainsKey(prop) ? card.PropertySet()[prop] : null
+                    let value = card.GetCardProperties().ContainsKey(prop) ? card.GetCardProperties()[prop] : null
                     select restriction.Any(filterValue => filterValue.IsValueMatch(value))).All(isOk => isOk);
         }
 
@@ -407,8 +407,8 @@ namespace Octgn.Play.Dialogs
 
         private string GetCardPropertyValue(ObservableMultiCard card, PropertyDef def)
         {
-            if (!card.PropertySet().ContainsKey(def)) return null;
-            return card.PropertySet()[def].ToString();
+            if (!card.GetCardProperties().ContainsKey(def)) return null;
+            return card.GetCardProperties()[def].ToString();
         }
 
         private void CardPoolChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -551,8 +551,8 @@ namespace Octgn.Play.Dialogs
             public bool IsMatch(ObservableMultiCard c)
             {
 
-                if (!c.PropertySet().ContainsKey(Property)) return false;
-                return IsValueMatch(c.PropertySet()[Property]);
+                if (!c.GetCardProperties().ContainsKey(Property)) return false;
+                return IsValueMatch(c.GetCardProperties()[Property]);
             }
 
             protected void OnPropertyChanged(string propertyName)

--- a/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
+++ b/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
@@ -722,7 +722,7 @@ namespace Octgn.Play.Gui
         {
             if (this.Card == null)
                 return "[?}";
-            return this.Card.PropertyName();
+            return this.Card.GetName();
         }
     }
 
@@ -747,7 +747,7 @@ namespace Octgn.Play.Gui
             _card = card;
             _card.UpdateCardText((model, gamecard) =>
                 {
-                    (this.Inlines.FirstInline as Run).Text = model.PropertyName();
+                    (this.Inlines.FirstInline as Run).Text = model.GetName();
                 });
         }
 

--- a/octgnFX/Octgn/Scripting/Controls/CardDlg.xaml.cs
+++ b/octgnFX/Octgn/Scripting/Controls/CardDlg.xaml.cs
@@ -57,7 +57,7 @@ namespace Octgn.Scripting.Controls
                                 foreach (var v in p.Value)
                                 {
                                     var tlist = game.AllCards()
-                                        .Where(x => x.PropertySets.SelectMany(y => y.Value.Properties)
+                                        .Where(x => x.GetFullCardProperties()
                                             .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
                                                 && y.Value.ToString().ToLower() == v.ToLower())).ToList();
                                     _allCards.AddRange(tlist);
@@ -77,7 +77,7 @@ namespace Octgn.Scripting.Controls
                                 foreach (var v in p.Value)
                                 {
                                     tlist.AddRange(query
-                                        .Where(x => x.PropertySets.SelectMany(y => y.Value.Properties)
+                                        .Where(x => x.GetFullCardProperties()
                                             .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
                                                 && y.Value.ToString().ToLower() == v.ToLower())).ToList());
                                 }
@@ -110,7 +110,7 @@ namespace Octgn.Scripting.Controls
                           foreach (var p in properties)
                           {
                               var tlist = game.AllCards()
-                                  .Where(x => x.PropertySets.SelectMany(y=>y.Value.Properties)
+                                  .Where(x => x.GetFullCardProperties()
                                       .Any(y => y.Key.Name.ToLower() == p.Key.ToLower() 
                                           && y.Value.ToString().ToLower() == p.Value.ToLower())).ToList();
                               _allCards.AddRange(tlist);
@@ -122,7 +122,7 @@ namespace Octgn.Scripting.Controls
                           {
                               query = query
                                   .Where(
-                                  x => x.PropertySets.SelectMany(y=>y.Value.Properties)
+                                  x => x.GetFullCardProperties()
                                       .Any(y => y.Key.Name.ToLower() == p.Key.ToLower() 
                                           && y.Value.ToString().ToLower() == p.Value.ToLower()));
                           }

--- a/octgnFX/Octgn/Scripting/Controls/CardDlg.xaml.cs
+++ b/octgnFX/Octgn/Scripting/Controls/CardDlg.xaml.cs
@@ -57,7 +57,7 @@ namespace Octgn.Scripting.Controls
                                 foreach (var v in p.Value)
                                 {
                                     var tlist = game.AllCards()
-                                        .Where(x => x.Properties.SelectMany(y => y.Value.Properties)
+                                        .Where(x => x.PropertySets.SelectMany(y => y.Value.Properties)
                                             .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
                                                 && y.Value.ToString().ToLower() == v.ToLower())).ToList();
                                     _allCards.AddRange(tlist);
@@ -77,7 +77,7 @@ namespace Octgn.Scripting.Controls
                                 foreach (var v in p.Value)
                                 {
                                     tlist.AddRange(query
-                                        .Where(x => x.Properties.SelectMany(y => y.Value.Properties)
+                                        .Where(x => x.PropertySets.SelectMany(y => y.Value.Properties)
                                             .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
                                                 && y.Value.ToString().ToLower() == v.ToLower())).ToList());
                                 }
@@ -110,7 +110,7 @@ namespace Octgn.Scripting.Controls
                           foreach (var p in properties)
                           {
                               var tlist = game.AllCards()
-                                  .Where(x => x.Properties.SelectMany(y=>y.Value.Properties)
+                                  .Where(x => x.PropertySets.SelectMany(y=>y.Value.Properties)
                                       .Any(y => y.Key.Name.ToLower() == p.Key.ToLower() 
                                           && y.Value.ToString().ToLower() == p.Value.ToLower())).ToList();
                               _allCards.AddRange(tlist);
@@ -122,7 +122,7 @@ namespace Octgn.Scripting.Controls
                           {
                               query = query
                                   .Where(
-                                  x => x.Properties.SelectMany(y=>y.Value.Properties)
+                                  x => x.PropertySets.SelectMany(y=>y.Value.Properties)
                                       .Any(y => y.Key.Name.ToLower() == p.Key.ToLower() 
                                           && y.Value.ToString().ToLower() == p.Value.ToLower()));
                           }

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_0.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_0.cs
@@ -329,7 +329,7 @@ namespace Octgn.Scripting.Versions
 
         public string[] CardProperties()
         {
-            return Program.GameEngine.Definition.CustomProperties.Select(x => x.Name).ToArray();
+            return Program.GameEngine.Definition.AllProperties().Select(x => x.Name).ToArray();
         }
 
         public Tuple<int, int> DefaultCardSize()

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_1.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_1.cs
@@ -337,7 +337,7 @@ namespace Octgn.Scripting.Versions
 
         public string[] CardProperties()
         {
-            return Program.GameEngine.Definition.CustomProperties.Select(x => x.Name).ToArray();
+            return Program.GameEngine.Definition.AllProperties().Select(x => x.Name).ToArray();
         }
 
         public void CardSwitchTo(int id, string alternate)

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
@@ -405,7 +405,7 @@ namespace Octgn.Scripting.Versions
 
         public string[] CardProperties()
         {
-            return Program.GameEngine.Definition.CustomProperties.Select(x => x.Name).ToArray();
+            return Program.GameEngine.Definition.AllProperties().Select(x => x.Name).ToArray();
         }
 
         public void CardSwitchTo(int id, string alternate)

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
@@ -1028,12 +1028,12 @@ namespace Octgn.Scripting.Versions
                     {
                         if (match)
                             tlist.AddRange(query
-                                .Where(x => x.Properties.SelectMany(y => y.Value.Properties)
+                                .Where(x => x.PropertySets.SelectMany(y => y.Value.Properties)
                                 .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
                                 && y.Value.ToString().ToLower() == v.ToLower())).ToList());
                         else
                             tlist.AddRange(query
-                                .Where(x => x.Properties.SelectMany(y => y.Value.Properties)
+                                .Where(x => x.PropertySets.SelectMany(y => y.Value.Properties)
                                 .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
                                 && y.Value.ToString().ToLower().Contains(v.ToLower()))).ToList());
 

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
@@ -1021,24 +1021,22 @@ namespace Octgn.Scripting.Versions
                 var Cards = new List<string>();
 
                 var query = Program.GameEngine.Definition.AllCards();
-                foreach (var p in properties)
+                foreach (var property in properties)
                 {
-                    var tlist = new List<DataNew.Entities.Card>();
-                    foreach (var v in p.Value)
+                    var tempCardList = new List<DataNew.Entities.Card>();
+                    foreach (var propertyValue in property.Value)
                     {
                         if (match)
-                            tlist.AddRange(query
-                                .Where(x => x.PropertySets.SelectMany(y => y.Value.Properties)
-                                .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
-                                && y.Value.ToString().ToLower() == v.ToLower())).ToList());
+                            tempCardList.AddRange(query
+                                .Where(x => x.GetFullCardProperties()
+                                .Any(y => y.Key.Name.ToLower() == property.Key.ToLower() && y.Value.ToString().ToLower() == propertyValue.ToLower())).ToList());
                         else
-                            tlist.AddRange(query
-                                .Where(x => x.PropertySets.SelectMany(y => y.Value.Properties)
-                                .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
-                                && y.Value.ToString().ToLower().Contains(v.ToLower()))).ToList());
+                            tempCardList.AddRange(query
+                                .Where(x => x.GetFullCardProperties()
+                                .Any(y => y.Key.Name.ToLower() == property.Key.ToLower() && y.Value.ToString().ToLower().Contains(propertyValue.ToLower()))).ToList());
 
                     }
-                    query = tlist;
+                    query = tempCardList;
                 }
                 Cards = query.Select(x => x.Id.ToString()).ToList();
 

--- a/octgnFX/Octgn/Windows/ImportImages.xaml.cs
+++ b/octgnFX/Octgn/Windows/ImportImages.xaml.cs
@@ -109,11 +109,11 @@ namespace Octgn.Windows
 
             foreach (var c in selectedSet.Cards)
             {
-                foreach (var alternate in c.Properties)
+                foreach (var alternate in c.PropertySets)
                 {
                     var card = new Card(c);
                     card.Alternate = alternate.Key;
-                    var cardPropertyValue = card.Properties[card.Alternate].Properties[selectedProperty].ToString();
+                    var cardPropertyValue = card.PropertySets[card.Alternate].Properties[selectedProperty].ToString();
                     var sanitizedValue = SanitizeString(cardPropertyValue);
 
                     // first check for exact matches, then if none show up we check for partial matches
@@ -243,7 +243,7 @@ namespace Octgn.Windows
         {
             get
             {
-                return _card.Properties[_card.Alternate].Properties.Where(x => x.Key.Name == "Name").First().Value.ToString();
+                return _card.GetName();
             }
         }
         

--- a/octgnFX/Octide/SetTab/CardTab/SetCardAltItemViewModel.cs
+++ b/octgnFX/Octide/SetTab/CardTab/SetCardAltItemViewModel.cs
@@ -97,19 +97,19 @@ namespace Octide.ItemModel
                 var storedProp = Items.FirstOrDefault(x => x.Property == customProp);
                 if (storedProp == null)
                 {
-                    clonedProp.IsUndefined = true;
+                  //TODO  clonedProp.IsUndefined = true;
                     NewAltPropSet.Add(clonedProp, "");
                 }
                 else
                 {
                     if (storedProp.IsDefined)
                     {
-                        clonedProp.IsUndefined = false;
+                   //TODO     clonedProp.IsUndefined = false;
                         NewAltPropSet.Add(clonedProp, storedProp.Value);
                     }
                     else
                     {
-                        clonedProp.IsUndefined = true;
+                    //TODO    clonedProp.IsUndefined = true;
                         NewAltPropSet.Add(clonedProp, "");
                     }
                 }

--- a/octgnFX/Octide/SetTab/CardTab/SetCardItemViewModel.cs
+++ b/octgnFX/Octide/SetTab/CardTab/SetCardItemViewModel.cs
@@ -66,7 +66,7 @@ namespace Octide.ItemModel
             AddAltCommand = new RelayCommand(AddAlt);
             _card = c;
             Items = new ObservableCollection<IdeListBoxItemBase>();
-            foreach (var alt in c.Properties)
+            foreach (var alt in c.PropertySets)
             {
                 var AltItem = new SetCardAltItemViewModel(alt.Value)
                 {
@@ -152,8 +152,8 @@ namespace Octide.ItemModel
 
         public void UpdateCardAlts()
         {
-            _card.Properties = Items.Select(x => (x as SetCardAltItemViewModel)._altDef).ToDictionary(x => x.Type, x => x);
-            _card.Properties.Add(BaseCardAlt.Name, BaseCardAlt._altDef);
+            _card.PropertySets = Items.Select(x => (x as SetCardAltItemViewModel)._altDef).ToDictionary(x => x.Type, x => x);
+            _card.PropertySets.Add(BaseCardAlt.Name, BaseCardAlt._altDef);
         }
 
         public override object Clone()

--- a/octgnFX/Octide/SetTab/CardTab/SetCardPropertyItemViewModel.cs
+++ b/octgnFX/Octide/SetTab/CardTab/SetCardPropertyItemViewModel.cs
@@ -21,7 +21,7 @@ namespace Octide.ItemModel
         {
             Parent = parent;
             Property = prop;
-            _isDefined = !propDef.Key.IsUndefined;
+          //TODO  _isDefined = !propDef.Key.IsUndefined;
             _value = propDef.Value;
         }
 

--- a/octgnFX/Octide/app.config
+++ b/octgnFX/Octide/app.config
@@ -2,7 +2,6 @@
 <configuration>
   <configSections>
   </configSections>
-  <exceptionless apiKey="a376895a183a4723845fbf69a74ec072" />
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
   </startup>

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,3 @@
-
+Card Name now a standard property within the PropertySet, no longer deserialized as a custom property.
+Cleaned up how OCTGN manages card alternate properties and inheritance
+Added a few extension methods to manage fetching card property sets


### PR DESCRIPTION
The logic behind these changes is to make the card name a dedicated property in the card PropertySet.  Previously card name was stored as a custom property alongside all the other game-defined custom properties.  Which is a bit of an oddity considering the card Name is a mandatory attribute in the set XMLs (in the same category as Size, Type (for alts), and Id)

This required a pretty substantial overhaul in all the various places in the code that use the card's name.  While I was doing this, I decided to also clean up how OCTGN deserializes custom properties, especially with inheritance of the base property for alternates.  This new version no longer uses the ``isUndefined`` property in the PropertyDef objects.  Instead, when a card is missing one or more custom properties, the gameserializer simply skips over that property.  Some extension methods were added to deal with inheritance and searching for missing properties.

This may require extensive testing and proof-checking, to make sure I didn't miss any crucial areas of the code.