### PR TITLE
Fixing Windows specific characters in the license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,5 +15,6 @@ The terms "reproduce," "reproduction," and "distribution" have the same meaning 
 (B) Patent Grant- Subject to the terms of this license, the Licensor grants you a non-transferable, non-exclusive, worldwide, royalty-free patent license under licensed patents for reference use.
 
 3. Limitations
-(A) No Trademark License- This license does not grant you any rights to use the Licensor’s name, logo, or trademarks.
-(B) If you begin patent litigation against the Licensor over patents that you think may apply to the software (including a cross-claim or counterclaim in a lawsuit), your license to the software ends automatically.(C) The software is licensed "as-is." You bear the risk of using it. The Licensor gives no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the Licensor excludes the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
+(A) No Trademark License- This license does not grant you any rights to use the Licensor's name, logo, or trademarks.
+(B) If you begin patent litigation against the Licensor over patents that you think may apply to the software (including a cross-claim or counterclaim in a lawsuit), your license to the software ends automatically.
+(C) The software is licensed "as-is." You bear the risk of using it. The Licensor gives no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the Licensor excludes the implied warranties of merchantability, fitness for a particular purpose and non-infringement.


### PR DESCRIPTION
There were a couple of Windows-1252 characters in the file, which I've fixed in this change.