### PR TITLE
fix editor card counts and improve scaling in game manager

### DIFF
--- a/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml
+++ b/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml
@@ -50,7 +50,7 @@
                           CanUserAddRows="False" HorizontalScrollBarVisibility="Hidden" AlternatingRowBackground="#e1ffd7"
                           VerticalGridLinesBrush="LightGray" HorizontalGridLinesBrush="LightGray" SelectionChanged="ElementSelected"
                           Keyboard.PreviewKeyDown="DeckKeyDownHandler" CellEditEnding="ElementEditEnd" AllowDrop="True" x:Name="sectionGrid"
-                          CanUserSortColumns="False" CanUserReorderColumns="False">
+                          CanUserSortColumns="False" CanUserReorderColumns="False" DataContextChanged="SectionGrid_DataContextChanged">
                     <DataGrid.RowStyle>
                         <Style>
                             <EventSetter Event="DataGridRow.MouseLeave" Handler="PickUpDeckCard" />

--- a/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml.cs
+++ b/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml.cs
@@ -890,8 +890,11 @@ namespace Octgn.DeckBuilder
                     ActiveSection.Cards.RemoveCard(item);
                 }
             }
-            InvokeDeckChangedEvent();
+        }
 
+        private void SectionGrid_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            InvokeDeckChangedEvent();
         }
 
         private void SetActiveSection(object sender, RoutedEventArgs e)

--- a/octgnFX/Octgn/Tabs/GameManagement/GameManagement.xaml
+++ b/octgnFX/Octgn/Tabs/GameManagement/GameManagement.xaml
@@ -56,7 +56,7 @@
                             <ColumnDefinition Width="100*"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <Image Source="{Binding Path=ImageUri}"/>
+                        <Image Source="{Binding Path=ImageUri}" RenderOptions.BitmapScalingMode="HighQuality" />
                         <StackPanel Grid.Column="1" Margin="5,0,5,0">
                             <StackPanel.Resources>
                                 <Style TargetType="{x:Type TextBlock}">

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+Fixed incorrect totals for player/global sections when editing card counts directly - Ben

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,2 @@
 Fixed incorrect totals for player/global sections when editing card counts directly - Ben
+Improve scaling quality for images in game manager - Ben


### PR DESCRIPTION
turns out that card count was being set by a pre-update event, so now it updates after the change.

set high quality scaling for game images in the game manager tab.