### PR TITLE
gave some love to the image pack installer

### DIFF
--- a/octgnFX/Octgn/Utils/ImportFile.cs
+++ b/octgnFX/Octgn/Utils/ImportFile.cs
@@ -9,6 +9,10 @@ namespace Octgn.Utils
 	{
 		public string Filename { get; set; }
 		public ImportFileStatus Status { get; set; }
+
+		public int Items { get; set; }
+
+		public List<string> ErrorList { get; set; }
 		public string Message { get; set; }
 
 		public string SafeFileName

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,3 @@
-
+Cleaned up logging for o8c image pack installing
+Rework of image pack install code
+Fixed a few weird cases that broke image pack installs


### PR DESCRIPTION
Changed up some of the image pack code.  It'll ignore the misnamed file paths instead of breaking the entire process.  I also cleaned up some of the logging so it's easier to read for debugging.

One design change I made was removing the requirement for only 1 game folder in the root.  It can technically install image packs to multiple games now.  I know this isn't really the intention of the installer, but considering how the image packs are set up to begin with, I dunno if it matters.

This needs some rigorous stress testing since I changed some of the logic for verifying the structure of the zip package.  I've tried a bunch of scenarios already but there are a ton of different possibilities I probably haven't tested yet.