### PR TITLE
resolve crash when activeSection was not on current tab

### DIFF
--- a/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml
+++ b/octgnFX/Octgn/DeckBuilder/DeckBuilderWindow.xaml
@@ -111,8 +111,8 @@
         <GridSplitter Grid.Row="2" ResizeDirection="Rows" Height="4" VerticalAlignment="Center"
                   HorizontalAlignment="Stretch" Background="Transparent" Grid.ColumnSpan="2" />
         <Border Grid.Row="3" Margin="4,0,0,4" Padding="6" Style="{StaticResource Panel}">
-            <TabControl DragLeave="TabControl_DragLeave" IsEnabled="{Binding IsGameLoaded, ElementName=self}">
-                <TabItem>
+            <TabControl x:Name="DeckTabs" DragLeave="TabControl_DragLeave" IsEnabled="{Binding IsGameLoaded, ElementName=self}">
+                <TabItem x:Name="PlayerTab">
                     <TabItem.Header>
                         <TextBlock Text="{Binding Path=DeckSectionsTotalCards, ElementName=self, StringFormat='Player({0})', FallbackValue=Player, TargetNullValue=Player}" 
                                    Style="{Binding Parent.Header.Style, RelativeSource={RelativeSource Self}}" />
@@ -124,7 +124,7 @@
                         <!--This ItemControl should have its bindings changeble according to the user's desires (V)_V-->
                     </ScrollViewer>
                 </TabItem>
-                <TabItem>
+                <TabItem x:Name="GlobalTab">
                     <TabItem.Header>
                         <TextBlock Text="{Binding Path=DeckSharedSectionsTotalCards, ElementName=self, StringFormat='Global({0})', FallbackValue=Global, TargetNullValue=Global}" 
                                    Style="{Binding Parent.Header.Style, RelativeSource={RelativeSource Self}}" />

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+Fix a crash that occoured when the active deck section was not on the current tab in the deck editor - Ben


### PR DESCRIPTION
also cleaned up and generalized focusing things in the deck area.