### PR TITLE
Undockable card preview window

### DIFF
--- a/octgnFX/Octgn.Core/Prefs.cs
+++ b/octgnFX/Octgn.Core/Prefs.cs
@@ -239,6 +239,18 @@ namespace Octgn.Core
             }
         }
 
+        public static Rect PreviewCardWindowLocation
+        {
+            get
+            {
+                return Rect.Parse(Config.Instance.ReadValue("PreviewCardLoc", ("100, 100, 200, 300")));
+            }
+            set
+            {
+                Config.Instance.WriteValue("PreviewCardLoc", value.ToString());
+            }
+        }
+
         public static int LoginTimeout
         {
             get

--- a/octgnFX/Octgn/Octgn.csproj
+++ b/octgnFX/Octgn/Octgn.csproj
@@ -304,6 +304,9 @@
     <Compile Include="Controls\WaitingDialog.xaml.cs">
       <DependentUpon>WaitingDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Play\Dialogs\PreviewCardWindow.xaml.cs">
+      <DependentUpon>PreviewCardWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Play\Gui\DeckStats.xaml.cs">
       <DependentUpon>DeckStats.xaml</DependentUpon>
     </Compile>
@@ -893,6 +896,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\WaitingDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Play\Dialogs\PreviewCardWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/octgnFX/Octgn/Play/Dialogs/PreviewCardWindow.xaml
+++ b/octgnFX/Octgn/Play/Dialogs/PreviewCardWindow.xaml
@@ -7,8 +7,15 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
         Title="Card Preview" ShowInTaskbar="True" MinWidth="100" MinHeight="200"
-        Icon="/OCTGN;component/Resources/search.png"  Closed="Window_Closed">
+        Icon="/OCTGN;component/Resources/search.png"  Closed="Window_Closed" Background="{StaticResource WindowBackgroundBrush}">
     <DockPanel LastChildFill="True">
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Height="30" >
+            <CheckBox Margin="5 0 5 0"  Content="Show Proxy" VerticalAlignment="Center" HorizontalAlignment="Right" x:Name="ProxyCheckbox" Click="ProxyCheckbox_Click" />
+            <Button x:Name="LeftButton" Width="30" Style="{StaticResource FlatDarkButtonStyle}" Content="&#x1f844;" Click="LeftButton_Click" />
+            <TextBlock x:Name="AltLabel" Text="Alternate: " VerticalAlignment="Center" Style="{StaticResource PanelText}" />
+            <TextBlock x:Name="AltName" MinWidth="50" FontWeight="Bold" VerticalAlignment="Center" Style="{StaticResource PanelText}" />
+            <Button x:Name="RightButton" Width="30" Style="{StaticResource FlatDarkButtonStyle}" Content="&#x1f846;" Click="RightButton_Click" />
+        </StackPanel>
         <Image x:Name="cardViewer" Stretch="Uniform" />
     </DockPanel>
 </Window>

--- a/octgnFX/Octgn/Play/Dialogs/PreviewCardWindow.xaml
+++ b/octgnFX/Octgn/Play/Dialogs/PreviewCardWindow.xaml
@@ -1,0 +1,14 @@
+﻿<!--
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.s
+-->
+<Window x:Class="Octgn.Play.Dialogs.PreviewCardWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+        Title="Card Preview" ShowInTaskbar="True" MinWidth="100" MinHeight="200"
+        Icon="/OCTGN;component/Resources/search.png"  Closed="Window_Closed">
+    <DockPanel LastChildFill="True">
+        <Image x:Name="cardViewer" Stretch="Uniform" />
+    </DockPanel>
+</Window>

--- a/octgnFX/Octgn/Play/Dialogs/PreviewCardWindow.xaml
+++ b/octgnFX/Octgn/Play/Dialogs/PreviewCardWindow.xaml
@@ -6,15 +6,16 @@
 <Window x:Class="Octgn.Play.Dialogs.PreviewCardWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
-        Title="Card Preview" ShowInTaskbar="True" MinWidth="100" MinHeight="200"
+        Title="Card Preview" ShowInTaskbar="True" MinWidth="350" MinHeight="400"
         Icon="/OCTGN;component/Resources/search.png"  Closed="Window_Closed" Background="{StaticResource WindowBackgroundBrush}">
     <DockPanel LastChildFill="True">
-        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Height="30" >
-            <CheckBox Margin="5 0 5 0"  Content="Show Proxy" VerticalAlignment="Center" HorizontalAlignment="Right" x:Name="ProxyCheckbox" Click="ProxyCheckbox_Click" />
-            <Button x:Name="LeftButton" Width="30" Style="{StaticResource FlatDarkButtonStyle}" Content="&#x1f844;" Click="LeftButton_Click" />
-            <TextBlock x:Name="AltLabel" Text="Alternate: " VerticalAlignment="Center" Style="{StaticResource PanelText}" />
-            <TextBlock x:Name="AltName" MinWidth="50" FontWeight="Bold" VerticalAlignment="Center" Style="{StaticResource PanelText}" />
-            <Button x:Name="RightButton" Width="30" Style="{StaticResource FlatDarkButtonStyle}" Content="&#x1f846;" Click="RightButton_Click" />
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Height="30" ClipToBounds="True" >
+            <CheckBox Margin="5 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Right" x:Name="ProxyCheckbox" Click="ProxyCheckbox_Click" />
+            <TextBlock Text="Show Proxy" FontSize="14" Foreground="WhiteSmoke" VerticalAlignment="Center" />
+            <Button Margin="25 0 5 0" x:Name="LeftButton" Width="30" Style="{StaticResource FlatDarkButtonStyle}" Content="&#x1f844;" Click="LeftButton_Click" />
+            <TextBlock x:Name="AltLabel" Text="Alternate: " FontSize="14" Foreground="WhiteSmoke" VerticalAlignment="Center"/>
+            <TextBlock x:Name="AltName" MinWidth="50" FontSize="14" Foreground="WhiteSmoke" FontWeight="Bold" VerticalAlignment="Center" />
+            <Button Margin="5 0 0 0" x:Name="RightButton" Width="30" Style="{StaticResource FlatDarkButtonStyle}" Content="&#x1f846;" Click="RightButton_Click" />
         </StackPanel>
         <Image x:Name="cardViewer" Stretch="Uniform" />
     </DockPanel>

--- a/octgnFX/Octgn/Play/Dialogs/PreviewCardWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/Dialogs/PreviewCardWindow.xaml.cs
@@ -3,17 +3,23 @@
 //  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 using Octgn.Core;
-using Octgn.Play.Gui;
-using System.ComponentModel;
-using System.Drawing;
+using Octgn.DataNew.Entities;
+using Octgn.Utils;
+using Octgn.Core.DataExtensionMethods;
 using System.Windows;
 using System.Windows.Media.Imaging;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Octgn.Play.Dialogs
 {
 
     public partial class PreviewCardWindow : Window
     {
+        public DataNew.Entities.Card VisualCard;
+        public List<string> alternates;
+        public bool isVisible;
+        public bool showProxy;
         public PreviewCardWindow()
         {
             this.InitializeComponent();
@@ -22,16 +28,109 @@ namespace Octgn.Play.Dialogs
             Top = size.Top;
             Height = size.Height;
             Width = size.Width;
+            AltName.Visibility = Visibility.Collapsed;
+            AltLabel.Visibility = Visibility.Collapsed;
+            LeftButton.Visibility = Visibility.Collapsed;
+            RightButton.Visibility = Visibility.Collapsed;
+            UpdateCardImage();
         }
 
-        public void DisplayImage(BitmapSource image)
+        public void SetCard(Card card, bool up, bool isProxy = false)
         {
-            cardViewer.Source = image;
+            isVisible = up;
+            showProxy = isProxy;
+            VisualCard = new DataNew.Entities.Card(card.Type.Model);
+            if (VisualCard == null || up == false || VisualCard.PropertySets.Count < 2)
+            {
+                AltName.Visibility = Visibility.Collapsed;
+                AltLabel.Visibility = Visibility.Collapsed;
+                LeftButton.Visibility = Visibility.Collapsed;
+                RightButton.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                AltName.Visibility = Visibility.Visible;
+                AltLabel.Visibility = Visibility.Visible;
+                LeftButton.Visibility = Visibility.Visible;
+                RightButton.Visibility = Visibility.Visible;
+                alternates = VisualCard.PropertySets.Keys.ToList();
+                AltName.Text = VisualCard.Alternate;
+            }
+            UpdateCardImage();
+        }
+
+        public void SetCard(ICard card, bool up, bool isProxy = false)
+        {
+            isVisible = up;
+            showProxy = isProxy;
+            VisualCard = new DataNew.Entities.Card(card);
+            if (VisualCard == null || up == false || VisualCard.PropertySets.Count < 2)
+            {
+                AltName.Visibility = Visibility.Collapsed;
+                AltLabel.Visibility = Visibility.Collapsed;
+                LeftButton.Visibility = Visibility.Collapsed;
+                RightButton.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                AltName.Visibility = Visibility.Visible;
+                AltLabel.Visibility = Visibility.Visible;
+                LeftButton.Visibility = Visibility.Visible;
+                RightButton.Visibility = Visibility.Visible;
+                alternates = VisualCard.PropertySets.Keys.ToList();
+                AltName.Text = VisualCard.Alternate;
+            }
+            UpdateCardImage();
+
+        }
+
+        public void UpdateCardImage()
+        {
+            if (!isVisible || VisualCard == null) //if the player doesn't have visibility of the card
+            {
+                cardViewer.Source = Program.GameEngine.GetCardFront(VisualCard?.Size ?? Program.GameEngine.Definition.DefaultSize());
+            }
+            else
+            {
+                BitmapImage image = null;
+                ImageUtils.GetCardImage(VisualCard, x => image = x, ProxyCheckbox.IsChecked == true || showProxy);
+                cardViewer.Source = image ?? Program.GameEngine.GetCardFront(VisualCard.Size);
+            }
+
         }
 
         private void Window_Closed(object sender, System.EventArgs e)
         {
             Prefs.PreviewCardWindowLocation = new Rect(Left, Top, ActualWidth, ActualHeight);
+        }
+
+        private void RightButton_Click(object sender, RoutedEventArgs e)
+        {
+            var index = alternates.IndexOf(VisualCard.Alternate);
+            index++;
+            if (index >= alternates.Count)
+                index = 0;
+            VisualCard.Alternate = alternates[index];
+            AltName.Text = VisualCard.Alternate;
+            UpdateCardImage();
+        }
+
+        private void LeftButton_Click(object sender, RoutedEventArgs e)
+        {
+            var index = alternates.IndexOf(VisualCard.Alternate);
+            if (index == 0)
+            {
+                index = alternates.Count;
+            }
+            VisualCard.Alternate = alternates[index - 1];
+            AltName.Text = VisualCard.Alternate;
+            UpdateCardImage();
+
+        }
+
+        private void ProxyCheckbox_Click(object sender, RoutedEventArgs e)
+        {
+            UpdateCardImage();
         }
     }
 }

--- a/octgnFX/Octgn/Play/Dialogs/PreviewCardWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/Dialogs/PreviewCardWindow.xaml.cs
@@ -1,0 +1,37 @@
+﻿// /* This Source Code Form is subject to the terms of the Mozilla Public
+//  * License, v. 2.0. If a copy of the MPL was not distributed with this
+//  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+using Octgn.Core;
+using Octgn.Play.Gui;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows;
+using System.Windows.Media.Imaging;
+
+namespace Octgn.Play.Dialogs
+{
+
+    public partial class PreviewCardWindow : Window
+    {
+        public PreviewCardWindow()
+        {
+            this.InitializeComponent();
+            var size = Prefs.PreviewCardWindowLocation;
+            Left = size.Left;
+            Top = size.Top;
+            Height = size.Height;
+            Width = size.Width;
+        }
+
+        public void DisplayImage(BitmapSource image)
+        {
+            cardViewer.Source = image;
+        }
+
+        private void Window_Closed(object sender, System.EventArgs e)
+        {
+            Prefs.PreviewCardWindowLocation = new Rect(Left, Top, ActualWidth, ActualHeight);
+        }
+    }
+}

--- a/octgnFX/Octgn/Play/PlayWindow.xaml
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml
@@ -102,6 +102,7 @@
                 </MenuItem>
             </MenuItem>
             <MenuItem Header="Card List" IsCheckable="True" IsChecked="{Binding Source={x:Static octgn:Program.GameEngine}, Path=DeckStats.IsVisible}"></MenuItem>
+            <MenuItem Header="Undock Card Preview" Click="UndockCardPreview"></MenuItem>
             <MenuItem Header="Help">
                 <MenuItem Header="About Octgn" Click="ShowAboutWindow" />
                 <MenuItem Header="Console" Click="ConsoleClicked" Visibility="Collapsed" x:Name="MenuConsole"/>

--- a/octgnFX/Octgn/Play/PlayWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml.cs
@@ -614,11 +614,13 @@ namespace Octgn.Play
                 && Prefs.ZoomOption == Prefs.ZoomType.ProxyOnKeypress
                 && _newCard)
             {
-                var img = _currentCard.GetBitmapImage(_currentCardUpStatus, true);
                 if (_previewCardWindow == null)
+                {
+                    var img = _currentCard.GetBitmapImage(_currentCardUpStatus, true);
                     ShowCardPicture(_currentCard, img);
+                }
                 else
-                    _previewCardWindow.DisplayImage(img);
+                    _previewCardWindow.SetCard(_currentCard, _currentCardUpStatus, true);
                 _newCard = false;
             }
 
@@ -678,11 +680,13 @@ namespace Octgn.Play
                 && (Keyboard.GetKeyStates(Key.LeftCtrl) & KeyStates.Down) == 0
                 && Prefs.ZoomOption == Prefs.ZoomType.ProxyOnKeypress)
             {
-                var img = _currentCard.GetBitmapImage(_currentCardUpStatus);
                 if (_previewCardWindow == null)
+                {
+                    var img = _currentCard.GetBitmapImage(_currentCardUpStatus);
                     ShowCardPicture(_currentCard, img);
+                }
                 else
-                    _previewCardWindow.DisplayImage(img);
+                    _previewCardWindow.SetCard(_currentCard, _currentCardUpStatus, false);
                 _newCard = true;
             }
         }
@@ -713,9 +717,9 @@ namespace Octgn.Play
 
                     _currentCardUpStatus = up;
 
-                    var img = e.Card.GetBitmapImage(up);
                     if (_previewCardWindow == null)
                     {
+                        var img = e.Card.GetBitmapImage(up);
                         double width = ShowCardPicture(e.Card, img);
 
                         if (up && Prefs.ZoomOption == Prefs.ZoomType.OriginalAndProxy && !e.Card.IsProxy())
@@ -725,17 +729,19 @@ namespace Octgn.Play
                         }
                     }
                     else
-                        _previewCardWindow.DisplayImage(img);
+                        _previewCardWindow.SetCard(e.Card, up);
                     _newCard = true;
                 }
                 else
                 {
-                    //probably for hovering in the deck editor
-                    var img = ImageUtils.CreateFrozenBitmap(new Uri(e.CardModel.GetPicture()));
+                    //probably for hovering in the limited deck editor
                     if (_previewCardWindow == null)
+                    {
+                        var img = ImageUtils.CreateFrozenBitmap(new Uri(e.CardModel.GetPicture()));
                         this.ShowCardPicture(e.Card, img);
+                    }
                     else
-                        _previewCardWindow.DisplayImage(img);
+                        _previewCardWindow.SetCard(e.CardModel, true);
                 }
             }
         }
@@ -775,7 +781,7 @@ namespace Octgn.Play
                 ShowCardPicture(e.CardModel.GameCard, ImageUtils.CreateFrozenBitmap(new Uri(e.CardModel.Card.GetPicture())));
             else
             {
-                _previewCardWindow.DisplayImage(ImageUtils.CreateFrozenBitmap(new Uri(e.CardModel.Card.GetPicture())));
+                _previewCardWindow.SetCard(e.CardModel.Card, true);
             }
         }
 


### PR DESCRIPTION
Adds a button in the play window to undock the card hover preview into its own resizeable window.  While active, the hover-over image overlay won't appear.

![image](https://user-images.githubusercontent.com/1373820/80929000-b6c14c00-8d76-11ea-809f-c7f818b1aae6.png)

- additional controls within the window to scroll through the images of any alternates on the card (controls are hidden when there are no alternates)
- A checkbox to force proxy images to be shown
- The sizing and location of the window is saved into OCTGN's preferences
- respects the "hold CTRL to show proxy" mode from the hover preview options

Works with hovering card names in the chat, hovering over cards in piles, hovering cards in the Limited deck editor, and hovering cards within the "look at" group window.  Does not work with the Deck Stats sidebar (because that has its own image overlay (??)