### PR TITLE
Set XAML data triggers for disabling the counter controls if you are …

### DIFF
--- a/octgnFX/Octgn/Play/Counter.cs
+++ b/octgnFX/Octgn/Play/Counter.cs
@@ -23,27 +23,6 @@ namespace Octgn.Play
             Name = def.Name;
             _id = def.Id;
             _defintion = def;
-
-            if (!isReplay) {
-                Player localPlayer = null;
-                if (player.IsLocal) {
-                    localPlayer = player;
-                } else {
-                    localPlayer = Player.LocalPlayer;
-                }
-
-                localPlayer.PropertyChanged += Player_PropertyChanged;
-
-                _canChange = !localPlayer.Spectator;
-            }
-        }
-
-        private void Player_PropertyChanged(object sender, PropertyChangedEventArgs e) {
-            if(e.PropertyName == nameof(Player.Spectator)) {
-                var player = (Player)sender;
-
-                CanChange = !player.Spectator;
-            }
         }
 
         public Player Owner

--- a/octgnFX/Octgn/Play/Gui/PlayerControl.xaml
+++ b/octgnFX/Octgn/Play/Gui/PlayerControl.xaml
@@ -25,7 +25,20 @@
             </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <StackPanel Orientation="Horizontal" IsEnabled="{Binding CanChange}">
+                    <StackPanel Orientation="Horizontal">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="IsEnabled" Value="True" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Source={x:Static octgn:Program.GameEngine},Path=Spectator}" Value="True">
+                                        <Setter Property="IsEnabled" Value="False" />
+                                    </DataTrigger>
+                                    <DataTrigger  Binding="{Binding Source={x:Static octgn:Program.GameEngine},Path=IsReplay}" Value="True">
+                                        <Setter Property="IsEnabled" Value="False" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
                         <ctrl:TextOrIcon Text="{Binding Name}" Icon="{Binding Definition.Icon}" />
                         <ctrl:NumericUpDown Value="{Binding Path=Value, Mode=TwoWay}" Minimum="-1000000" Maximum="1000000"
                                 Width="60" Margin="3,0,8,0" />

--- a/octgnFX/Octgn/Play/State/GameEngine.cs
+++ b/octgnFX/Octgn/Play/State/GameEngine.cs
@@ -266,11 +266,11 @@ namespace Octgn
                 // clear any existing players
                 Play.Player.All.Clear();
                 Player.Spectators.Clear();
-                // Create the local player
-                Play.Player.LocalPlayer = new Player(Definition, this.Nickname, Program.UserId, 255, Crypto.ModExp(Prefs.PrivateKey), specator, true, IsReplay);
                 // Create the global player, if any
                 if (Definition.GlobalPlayer != null)
                     Play.Player.GlobalPlayer = new Play.Player(Definition, IsReplay);
+                // Create the local player
+                Play.Player.LocalPlayer = new Player(Definition, this.Nickname, Program.UserId, 255, Crypto.ModExp(Prefs.PrivateKey), specator, true, IsReplay);
             }));
         }
 


### PR DESCRIPTION
…a spectator or in a game replay

this fixes the global player showing up after the local player in the player tabs