### PR TITLE
fixed global tab being selected

### DIFF
--- a/octgnFX/Octgn/Play/Gui/PlayerControl.xaml
+++ b/octgnFX/Octgn/Play/Gui/PlayerControl.xaml
@@ -1,6 +1,6 @@
 <UserControl x:Class="Octgn.Play.Gui.PlayerControl" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:gui="clr-namespace:Octgn.Play.Gui"
-             xmlns:ctrl="clr-namespace:Octgn.Controls" xmlns:octgn="clr-namespace:Octgn" xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:ctrl="clr-namespace:Octgn.Controls" xmlns:octgn="clr-namespace:Octgn"
              xmlns:ent="clr-namespace:Octgn.DataNew.Entities;assembly=Octgn.DataNew"
              VerticalContentAlignment="Stretch">
 

--- a/octgnFX/Octgn/Play/PlayWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml.cs
@@ -204,11 +204,6 @@ namespace Octgn.Play
                                                             Program.GameSettings.MuteSpectators);
                             }
                         };
-                    // Select proper player tab
-                    Dispatcher.BeginInvoke(new Action(() =>
-                        {
-                            playerTabs.SelectedIndex = 0;
-                        }));
                 }
                 else
                 {


### PR DESCRIPTION
the tabcontrol already has a selecteditem of the localplayer (and this is now the global player again anyway)