### PR TITLE
Update DeckStats.xaml

### DIFF
--- a/octgnFX/Octgn/Play/Gui/DeckStats.xaml
+++ b/octgnFX/Octgn/Play/Gui/DeckStats.xaml
@@ -9,7 +9,7 @@
              d:DataContext="{d:DesignInstance local:DeckStatsViewModel, IsDesignTimeCreatable=False}"
              Background="{DynamicResource ControlBackgroundBrush}">
     <Border Padding="0,0,0,0" BorderThickness="1 0 0 0" BorderBrush="{StaticResource GlassPanelBorder}">
-        <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <ScrollViewer VerticalScrollBarVisibility="Auto" Visibility="{Binding IsVisible, Converter={StaticResource BooleanToVisibilityHiddenConverter}}">
             <ItemsControl ItemsSource="{Binding Cards}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
@@ -30,7 +30,7 @@
                                 </DataTrigger.EnterActions>
                             </DataTrigger>
                         </DataTemplate.Triggers>
-                        <Border CornerRadius="0" Height="30" Margin="0 0 0 1" Visibility="{Binding IsVisible, Converter={StaticResource BooleanToVisibilityHiddenConverter}}">
+                        <Border CornerRadius="0" Height="30" Margin="0 0 0 1">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="45"/>


### PR DESCRIPTION
this binding was failing, for each card, as a deck is loaded, causing slowdown.

now also hides the scrollbar, which was still visible to screen readers even if it did work because hiding that panel still reserves the space, so the scrollbar was just invsible off screen.