### PR TITLE
fixed an issue with the GetProperty card extension method

### DIFF
--- a/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
+++ b/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
@@ -183,7 +183,7 @@ namespace Octgn.Core.DataExtensionMethods
         /// <param name="alternate">The alternate ID to check.</param>
         public static object GetProperty(this Card card, string name, string alternate)
         {
-            return card.GetCardProperties(alternate).FirstOrDefault(x => x.Key.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+            return card.GetCardProperties(alternate).FirstOrDefault(x => x.Key.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase)).Value;
         }
 
         /// <summary>


### PR DESCRIPTION
Not really a big deal as this method is new and doesn't get used by OCTGN.  For people using our libraries (i.e. deck editor plugins), this should prevent some weird behavior