### PR TITLE
better handling of deck loading

### DIFF
--- a/octgnFX/Octgn/Play/State/GameEngine.cs
+++ b/octgnFX/Octgn/Play/State/GameEngine.cs
@@ -791,7 +791,9 @@ namespace Octgn
                     for (int i = 0; i < element.Quantity; i++)
                     {
                         //for every card in the deck, generate a unique key for it, ID for it
-                        var card = element.ToPlayCard(player);
+                        var id = element.GenerateCardId();
+                        var card = new Card(player, id, new DataNew.Entities.Card(element), true, element.Size.Name);
+                     //   var card = element.ToPlayCard(player);
                         ids[j] = card.Id;
                         keys[j] = card.Type.Model.Id;
                         //keys[j] = card.GetEncryptedKey();


### PR DESCRIPTION
With these changes, a deck which previously took ~10 seconds to load now loads in under 3 seconds.

Essentially, we have the Deck.Load() deck extension method that does the heavy lifting in translating a deck file into OCTGN.  It does all the DB querying to locate the matching cards, then stores them in the IDeck object.  This gets passed into the game engine.

So the game engine takes this IDeck file, iterates through the cards in each deck section, then ...queries the DB again to locate the card's image from its GUID?  Why are we querying for the card data when we already have it?

So I got rid of that section.

I've tested this with a bunch of different scenarios and it seems to work flawlessly.  Which makes me wonder... it can't be this simple, right?