### PR TITLE
Undock options (Undock Chat)

### DIFF
--- a/octgnFX/Octgn.Core/Prefs.cs
+++ b/octgnFX/Octgn.Core/Prefs.cs
@@ -251,6 +251,18 @@ namespace Octgn.Core
             }
         }
 
+        public static Rect ChatWindowLocation
+        {
+            get
+            {
+                return Rect.Parse(Config.Instance.ReadValue("ChatWindowLoc", ("100, 100, 200, 300")));
+            }
+            set
+            {
+                Config.Instance.WriteValue("ChatWindowLoc", value.ToString());
+            }
+        }
+
         public static int LoginTimeout
         {
             get

--- a/octgnFX/Octgn/Play/Dialogs/ChatWindow.xaml
+++ b/octgnFX/Octgn/Play/Dialogs/ChatWindow.xaml
@@ -1,0 +1,15 @@
+﻿<!--
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.s
+-->
+<Window x:Class="Octgn.Play.Dialogs.PreviewCardWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+        xmlns:gui="clr-namespace:Octgn.Play.Gui"
+        Title="Chat Window" ShowInTaskbar="True" MinWidth="350" MinHeight="400"
+        Icon="/OCTGN;component/Resources/search.png"  Closed="Window_Closed" Background="{StaticResource WindowBackgroundBrush}">
+    <DockPanel LastChildFill="True">
+        <gui:ChatControl x:Name="chat"     DockPanel.Dock="Left" DisplayKeyboardShortcut="True" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Background="#55333333" />
+    </DockPanel>
+</Window>

--- a/octgnFX/Octgn/Play/Dialogs/ChatWindow.xaml
+++ b/octgnFX/Octgn/Play/Dialogs/ChatWindow.xaml
@@ -3,12 +3,12 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/.s
 -->
-<Window x:Class="Octgn.Play.Dialogs.PreviewCardWindow"
+<Window x:Class="Octgn.Play.Dialogs.ChatWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
         xmlns:gui="clr-namespace:Octgn.Play.Gui"
         Title="Chat Window" ShowInTaskbar="True" MinWidth="350" MinHeight="400"
-        Icon="/OCTGN;component/Resources/search.png"  Closed="Window_Closed" Background="{StaticResource WindowBackgroundBrush}">
+        Icon="/OCTGN;component/Resources/chaticon.png"  Closed="Window_Closed" Background="{StaticResource WindowBackgroundBrush}">
     <DockPanel LastChildFill="True">
         <gui:ChatControl x:Name="chat"     DockPanel.Dock="Left" DisplayKeyboardShortcut="True" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Background="#55333333" />
     </DockPanel>

--- a/octgnFX/Octgn/Play/Dialogs/ChatWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/Dialogs/ChatWindow.xaml.cs
@@ -1,0 +1,49 @@
+﻿// /* This Source Code Form is subject to the terms of the Mozilla Public
+//  * License, v. 2.0. If a copy of the MPL was not distributed with this
+//  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+using Octgn.Core;
+using Octgn.DataNew.Entities;
+using Octgn.Utils;
+using Octgn.Core.DataExtensionMethods;
+using System.Windows;
+using System.Windows.Media.Imaging;
+using System.Linq;
+using System.Collections.Generic;
+using Octgn.Play.Gui;
+
+namespace Octgn.Play.Dialogs
+{
+
+    public partial class ChatWindow : Window
+    {
+
+        public ChatWindow()
+        {
+            this.InitializeComponent();
+            var size = Prefs.ChatWindowLocation;
+            Left = size.Left;
+            Top = size.Top;
+            Height = size.Height;
+            Width = size.Width;
+        }
+
+
+
+        private void Window_Closed(object sender, System.EventArgs e)
+        {
+            Prefs.ChatWindowLocation = new Rect(Left, Top, ActualWidth, ActualHeight);
+        }
+
+        private void RightButton_Click(object sender, RoutedEventArgs e)
+        {
+
+        }
+
+        private void LeftButton_Click(object sender, RoutedEventArgs e)
+        {
+
+        }
+
+
+}

--- a/octgnFX/Octgn/Play/Dialogs/ChatWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/Dialogs/ChatWindow.xaml.cs
@@ -35,15 +35,12 @@ namespace Octgn.Play.Dialogs
             Prefs.ChatWindowLocation = new Rect(Left, Top, ActualWidth, ActualHeight);
         }
 
-        private void RightButton_Click(object sender, RoutedEventArgs e)
+        public void FocusInput()
         {
-
+            this.chat.FocusInput();
         }
+    }
 
-        private void LeftButton_Click(object sender, RoutedEventArgs e)
-        {
-
-        }
 
 
 }

--- a/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
+++ b/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
@@ -577,11 +577,6 @@ namespace Octgn.Play.Gui
             return ret;
         }
 
-        public bool DisplayKeyboardShortcut
-        {
-            set { if (value) watermark.Text += "  (Ctrl+T)"; }
-        }
-
         private void KeyDownHandler(object sender, KeyEventArgs e)
         {
             switch (e.Key)

--- a/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
+++ b/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
@@ -577,6 +577,11 @@ namespace Octgn.Play.Gui
             return ret;
         }
 
+        public bool DisplayKeyboardShortcut
+        {
+            set { if (value) watermark.Text += "  (Ctrl+T)"; }
+        }
+
         private void KeyDownHandler(object sender, KeyEventArgs e)
         {
             switch (e.Key)

--- a/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
+++ b/octgnFX/Octgn/Play/Gui/ChatControl.xaml.cs
@@ -579,6 +579,7 @@ namespace Octgn.Play.Gui
 
         public bool DisplayKeyboardShortcut
         {
+            get { return true; }
             set { if (value) watermark.Text += "  (Ctrl+T)"; }
         }
 

--- a/octgnFX/Octgn/Play/PlayWindow.xaml
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml
@@ -105,6 +105,7 @@
             <MenuItem Header="Card List" IsCheckable="True" IsChecked="{Binding Source={x:Static octgn:Program.GameEngine}, Path=DeckStats.IsVisible}"></MenuItem>            
             <MenuItem Header="Undock Options">
                 <MenuItem Header="Undock Card Preview" Click="UndockCardPreview"></MenuItem>
+                <MenuItem x:Name="ChatToggleChecked" Header="Undock Chat" Click="ToggleChatDockPanel" IsCheckable="True"></MenuItem>
             </MenuItem>
             <MenuItem Header="Help">
                 <MenuItem Header="About Octgn" Click="ShowAboutWindow" />
@@ -365,7 +366,7 @@
         <ctrl:ChildWindowManager x:Name="wndManager" Grid.Row="1" Grid.RowSpan="4" Panel.ZIndex="53" />
         <Decorator Grid.Row="2"  x:Name="backstage" Visibility="Collapsed"/>
 
-        <Grid x:Name="chatGrid" Grid.Row="2" Grid.RowSpan="3" ZIndex="5" Width="300" HorizontalAlignment="Left" VerticalAlignment="Stretch">
+        <Grid x:Name="chatGrid"   Grid.Row="2" Grid.RowSpan="3" Width="300" ZIndex="5" HorizontalAlignment="Left" VerticalAlignment="Stretch">
             <Grid.RowDefinitions>
                 <RowDefinition Height="100*" x:Name="ChatGridEmptyPart"/>
                 <RowDefinition Height="5"/>
@@ -389,8 +390,8 @@
                     </ControlTemplate>
                 </GridSplitter.Template>
             </GridSplitter>
-            <Border Margin="0,0,0,2" Grid.Row="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
-                <gui:ChatControl x:Name="chat" DockPanel.Dock="Left" DisplayKeyboardShortcut="True" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Background="#55333333" />
+            <Border Margin="0,0,0,2" Grid.Row="2"  VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+                <gui:ChatControl x:Name="chat"     DockPanel.Dock="Left" DisplayKeyboardShortcut="True" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Background="#55333333" />
             </Border>
         </Grid>
         <GridSplitter Grid.Row="3" x:Name="playerAreaGridSplitter" VerticalAlignment="Center" Height="5" HorizontalAlignment="Stretch" ResizeDirection="Rows" 
@@ -411,7 +412,7 @@
         </GridSplitter>
         <Grid Grid.Row="4" Background="Transparent">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="300" />
+                <ColumnDefinition x:Name="Column4ChatWidth" Width="300" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <TabControl x:Name="playerTabs" Margin="0,2,2,2" Padding="0" Grid.Column="1"  Background="#55333333" 

--- a/octgnFX/Octgn/Play/PlayWindow.xaml
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml
@@ -102,8 +102,10 @@
 
                 </MenuItem>
             </MenuItem>
-            <MenuItem Header="Card List" IsCheckable="True" IsChecked="{Binding Source={x:Static octgn:Program.GameEngine}, Path=DeckStats.IsVisible}"></MenuItem>
-            <MenuItem Header="Undock Card Preview" Click="UndockCardPreview"></MenuItem>
+            <MenuItem Header="Card List" IsCheckable="True" IsChecked="{Binding Source={x:Static octgn:Program.GameEngine}, Path=DeckStats.IsVisible}"></MenuItem>            
+            <MenuItem Header="Undock Options">
+                <MenuItem Header="Undock Card Preview" Click="UndockCardPreview"></MenuItem>
+            </MenuItem>
             <MenuItem Header="Help">
                 <MenuItem Header="About Octgn" Click="ShowAboutWindow" />
                 <MenuItem Header="Console" Click="ConsoleClicked" Visibility="Collapsed" x:Name="MenuConsole"/>

--- a/octgnFX/Octgn/Play/PlayWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml.cs
@@ -179,8 +179,8 @@ namespace Octgn.Play
             this.chat.MouseLeave += ChatOnMouseLeave;
             this.playerTabs.MouseEnter += PlayerTabsOnMouseEnter;
             this.playerTabs.MouseLeave += PlayerTabsOnMouseLeave;
-            this.chatOpen = true;
-            this.ChatToggleChecked.IsChecked = true;
+            this.chatIsDocked = true;
+            this.ChatToggleChecked.IsChecked = false;
             this.PreGameLobby.OnClose += delegate
             {
                 if (this.PreGameLobby.StartingGame)
@@ -888,13 +888,13 @@ namespace Octgn.Play
         {
             e.Handled = true;
             if (this.PreGameLobby.Visibility == Visibility.Visible) return;
-            if (this.chatOpen)
+            if (this.chatIsDocked)
             {
-                chatWindow.FocusInput();
+                chat.FocusInput();
             }
             else
             {
-                chat.FocusInput();
+                this.chatWindow.FocusInput();
             }
             
         }
@@ -1066,38 +1066,48 @@ namespace Octgn.Play
             }
         }
 
-        private bool chatOpen;
+        private bool chatIsDocked;
         public ChatWindow chatWindow;
         private void ToggleChatDockPanel(object sender, RoutedEventArgs e)
         {
             e.Handled = true;
             // toggle visibility
-            if (this.chatOpen)
+            if (this.chatIsDocked)
             {
-                this.chatOpen = false;
+                this.chatIsDocked = false;
                 this.ChatToggleChecked.IsChecked = true;
                 this.chatGrid.Width = 0;
                 this.Column4ChatWidth.Width = new GridLength(0);
-                if(chatWindow == null)
+                if(this.chatWindow == null)
                 {
-                    chatWindow = new ChatWindow() { Owner = this };
-                    chatWindow.Closed += (a, b) => chatWindow = null;
-                    chatWindow.Show();
+                    this.chatWindow = new ChatWindow() { Owner = this };
+                    this.chatWindow.Closed += (a, b) =>
+                    {
+                        this.chatWindow = null;
+                        this.chatIsDocked = true;
+                        this.ChatToggleChecked.IsChecked = false;
+                        this.chatGrid.Width = 300;
+                        this.Column4ChatWidth.Width = new GridLength(300);
+                        Keyboard.Focus(table);
+                    };
+                    this.chatWindow.Show();
+
                 }
             }
             else
             {
-                this.chatOpen = true;
+                this.chatIsDocked = true;
                 this.ChatToggleChecked.IsChecked = false;
                 this.chatGrid.Width = 300;
                 this.Column4ChatWidth.Width = new GridLength(300);
-                if(chatWindow != null && chatWindow.isVisible)
+                if(this.chatWindow != null && chatWindow.IsInitialized)
                 {
-                    chatWindow.Close();
+                    this.chatWindow.Close();
                     
                 }
             }
 
+            Keyboard.Focus(table);
         }
 
         private void KickPlayer(object sender, RoutedEventArgs e)

--- a/octgnFX/Octgn/Play/PlayWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml.cs
@@ -98,7 +98,9 @@ namespace Octgn.Play
 
         public ObservableCollection<IGameMessage> GameMessages { get; set; }
 
-
+        private bool chatIsDocked;
+        public ChatWindow _chatWindow;
+        private const int DefaultChatWidth = 300;
 
 
         public bool IsHost { get; set; }
@@ -894,7 +896,7 @@ namespace Octgn.Play
             }
             else
             {
-                this.chatWindow.FocusInput();
+                this._chatWindow.FocusInput();
             }
             
         }
@@ -1066,8 +1068,7 @@ namespace Octgn.Play
             }
         }
 
-        private bool chatIsDocked;
-        public ChatWindow chatWindow;
+
         private void ToggleChatDockPanel(object sender, RoutedEventArgs e)
         {
             e.Handled = true;
@@ -1078,19 +1079,19 @@ namespace Octgn.Play
                 this.ChatToggleChecked.IsChecked = true;
                 this.chatGrid.Width = 0;
                 this.Column4ChatWidth.Width = new GridLength(0);
-                if(this.chatWindow == null)
+                if(this._chatWindow == null) // create a new chat window
                 {
-                    this.chatWindow = new ChatWindow() { Owner = this };
-                    this.chatWindow.Closed += (a, b) =>
+                    this._chatWindow = new ChatWindow() { Owner = this };
+                    this._chatWindow.Closed += (a, b) =>
                     {
-                        this.chatWindow = null;
+                        this._chatWindow = null;
                         this.chatIsDocked = true;
                         this.ChatToggleChecked.IsChecked = false;
-                        this.chatGrid.Width = 300;
-                        this.Column4ChatWidth.Width = new GridLength(300);
+                        this.chatGrid.Width = DefaultChatWidth;
+                        this.Column4ChatWidth.Width = new GridLength(DefaultChatWidth);
                         Keyboard.Focus(table);
                     };
-                    this.chatWindow.Show();
+                    this._chatWindow.Show();
 
                 }
             }
@@ -1098,12 +1099,11 @@ namespace Octgn.Play
             {
                 this.chatIsDocked = true;
                 this.ChatToggleChecked.IsChecked = false;
-                this.chatGrid.Width = 300;
-                this.Column4ChatWidth.Width = new GridLength(300);
-                if(this.chatWindow != null && chatWindow.IsInitialized)
+                this.chatGrid.Width = DefaultChatWidth;
+                this.Column4ChatWidth.Width = new GridLength(DefaultChatWidth);
+                if(this._chatWindow != null && _chatWindow.IsInitialized)
                 {
-                    this.chatWindow.Close();
-                    
+                    this._chatWindow.Close();                    
                 }
             }
 

--- a/octgnFX/Octgn/Play/PlayWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml.cs
@@ -98,6 +98,9 @@ namespace Octgn.Play
 
         public ObservableCollection<IGameMessage> GameMessages { get; set; }
 
+
+
+
         public bool IsHost { get; set; }
 
         public bool ChatVisible
@@ -176,6 +179,8 @@ namespace Octgn.Play
             this.chat.MouseLeave += ChatOnMouseLeave;
             this.playerTabs.MouseEnter += PlayerTabsOnMouseEnter;
             this.playerTabs.MouseLeave += PlayerTabsOnMouseLeave;
+            this.chatOpen = true;
+            this.ChatToggleChecked.IsChecked = true;
             this.PreGameLobby.OnClose += delegate
             {
                 if (this.PreGameLobby.StartingGame)
@@ -883,7 +888,15 @@ namespace Octgn.Play
         {
             e.Handled = true;
             if (this.PreGameLobby.Visibility == Visibility.Visible) return;
-            chat.FocusInput();
+            if (this.chatOpen)
+            {
+                chatWindow.FocusInput();
+            }
+            else
+            {
+                chat.FocusInput();
+            }
+            
         }
 
         private void ShowAboutWindow(object sender, RoutedEventArgs e)
@@ -1051,6 +1064,40 @@ namespace Octgn.Play
                 _previewCardWindow.Closed += (a, b) => _previewCardWindow = null;
                 _previewCardWindow.Show();
             }
+        }
+
+        private bool chatOpen;
+        public ChatWindow chatWindow;
+        private void ToggleChatDockPanel(object sender, RoutedEventArgs e)
+        {
+            e.Handled = true;
+            // toggle visibility
+            if (this.chatOpen)
+            {
+                this.chatOpen = false;
+                this.ChatToggleChecked.IsChecked = true;
+                this.chatGrid.Width = 0;
+                this.Column4ChatWidth.Width = new GridLength(0);
+                if(chatWindow == null)
+                {
+                    chatWindow = new ChatWindow() { Owner = this };
+                    chatWindow.Closed += (a, b) => chatWindow = null;
+                    chatWindow.Show();
+                }
+            }
+            else
+            {
+                this.chatOpen = true;
+                this.ChatToggleChecked.IsChecked = false;
+                this.chatGrid.Width = 300;
+                this.Column4ChatWidth.Width = new GridLength(300);
+                if(chatWindow != null && chatWindow.isVisible)
+                {
+                    chatWindow.Close();
+                    
+                }
+            }
+
         }
 
         private void KickPlayer(object sender, RoutedEventArgs e)


### PR DESCRIPTION
This should  partially answer #1993 

Tested with Playing Cards and DigimonTCG, appears to have no side effects.
For people with large screens/dual screens, this gives plenty of space for the playerTabs.

Summary of changes
- Similar to PreviewCardWindow, the ChatWindow will save it's location in Prefs.
-  Added a new Menu in PlayWindow and moved existing "Undock Card Preview" under the new "Undock Options"
- Added "Undock Chat" in "Undock Options" menu
- Added Get method in chat control because it was causing VS xaml preview to crash
- Modified chat window keyboard focus code to include the new window


