### PR TITLE
Undockchatpreviewfix

### DIFF
--- a/octgnFX/Octgn/Play/PlayWindow.xaml.cs
+++ b/octgnFX/Octgn/Play/PlayWindow.xaml.cs
@@ -1092,6 +1092,7 @@ namespace Octgn.Play
                 if(this._chatWindow == null) // create a new chat window
                 {
                     this._chatWindow = new ChatWindow() { Owner = this };
+                    this._chatWindow.AddHandler(CardRun.ViewCardModelEvent, new EventHandler<CardModelEventArgs>(ViewCardModel));
                     this._chatWindow.Closed += (a, b) =>
                     {
                         this._chatWindow = null;


### PR DESCRIPTION
This fixes the issue reported by Mitch below.
I added the event handler to the ChatWindow and tested that it works when docker or undocked. I'm not sure if there are anymore event handlers for the ChatControl. But think that is the only one it raises that I saw.


MitchYesterday at 4:02 PM
Found an issue with the "undock chat" it works fine except the preview when you hover in the chat box doesn't work
![](https://cdn.discordapp.com/attachments/707979545109856347/716396124482830577/unknown.png)
