### PR TITLE
Added API calls for system save/load dialogs for use from scripts.

### DIFF
--- a/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
+++ b/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
@@ -95,11 +95,11 @@ def askInteger(question, defaultAnswer):
 def askString(question, defaultAnswer):
 	return _api.AskString(question, defaultAnswer)
 
-def saveFile(title, defaultPath, fileFilter):
-    return _api.SaveFile(title, defaultPath, fileFilter)
+def saveFileDlg(title, defaultPath, fileFilter):
+    return _api.SaveFileDlg(title, defaultPath, fileFilter)
 
-def loadFile(title, defaultPath, fileFilter):
-	return _api.LoadFile(title, defaultPath, fileFilter)
+def openFileDlg(title, defaultPath, fileFilter):
+	return _api.OpenFileDlg(title, defaultPath, fileFilter)
 
 def askChoice(question, choices = [], colors = [], customButtons = []):
 	choiceList = List[String](choices)

--- a/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
+++ b/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
@@ -95,6 +95,12 @@ def askInteger(question, defaultAnswer):
 def askString(question, defaultAnswer):
 	return _api.AskString(question, defaultAnswer)
 
+def saveFile(title, defaultPath, fileFilter):
+    return _api.SaveFile(title, defaultPath, fileFilter)
+
+def loadFile(title, defaultPath, fileFilter):
+	return _api.LoadFile(title, defaultPath, fileFilter)
+
 def askChoice(question, choices = [], colors = [], customButtons = []):
 	choiceList = List[String](choices)
 	if len(colors) != len(choices):

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
@@ -1020,6 +1020,43 @@ namespace Octgn.Scripting.Versions
             });
         }
 
+        public string SaveFile(string title, string defaultValue, string fileFilter)
+        {
+            return QueueAction<string>(() =>
+            {
+                using (SaveFileDialog saveFileDialog = new SaveFileDialog())
+                {
+                    saveFileDialog.Filter = fileFilter;
+                    saveFileDialog.Title = title;
+                    saveFileDialog.ShowDialog();
+                    return saveFileDialog.FileName;
+                };
+            });
+        }
+
+        public string LoadFile(string title, string defaultValue, string fileFilter)
+        {
+            return QueueAction<string>(() =>
+            {
+                var filePath = string.Empty;
+                using (OpenFileDialog openFileDialog = new OpenFileDialog())
+                {
+                    openFileDialog.InitialDirectory = "c:\\";
+                    openFileDialog.Filter = fileFilter;
+                    openFileDialog.FilterIndex = 2;
+                    openFileDialog.Title = title;
+                    openFileDialog.RestoreDirectory = true;
+
+                    if (openFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                    {
+                        //Get the path of specified file
+                        filePath = openFileDialog.FileName;
+                    }
+                    return filePath;
+                }
+            });
+        }
+
         //public Tuple<string, int> AskCard(string restriction)
         //{
         //    return QueueAction<Tuple<string, int>>(() =>

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
@@ -14,6 +14,7 @@ using Octgn.Core.DataExtensionMethods;
 using Octgn.Core.Util;
 using Octgn.DataNew.Entities;
 using Octgn.Extentions;
+using Octgn.Library;
 using Octgn.Networking;
 using Octgn.Play;
 using Octgn.Play.Actions;
@@ -1020,41 +1021,41 @@ namespace Octgn.Scripting.Versions
             });
         }
 
-        public string SaveFile(string title, string defaultValue, string fileFilter)
+        public string SaveFileDlg(string title, string defaultValue, string fileFilter)
         {
             return QueueAction<string>(() =>
             {
                 using (SaveFileDialog saveFileDialog = new SaveFileDialog())
                 {
-                    saveFileDialog.Filter = fileFilter;
-                    saveFileDialog.Title = title;
-                    saveFileDialog.ShowDialog();
-                    return saveFileDialog.FileName;
+                    return FileDlg(title, defaultValue, fileFilter, saveFileDialog);
                 };
             });
         }
 
-        public string LoadFile(string title, string defaultValue, string fileFilter)
+        public string OpenFileDlg(string title, string defaultValue, string fileFilter)
         {
             return QueueAction<string>(() =>
             {
-                var filePath = string.Empty;
                 using (OpenFileDialog openFileDialog = new OpenFileDialog())
                 {
-                    openFileDialog.InitialDirectory = "c:\\";
-                    openFileDialog.Filter = fileFilter;
-                    openFileDialog.FilterIndex = 2;
-                    openFileDialog.Title = title;
-                    openFileDialog.RestoreDirectory = true;
-
-                    if (openFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
-                    {
-                        //Get the path of specified file
-                        filePath = openFileDialog.FileName;
-                    }
-                    return filePath;
+                    return FileDlg(title, defaultValue, fileFilter, openFileDialog);
                 }
             });
+        }
+
+        private string FileDlg(string title, string defaultValue, string fileFilter, FileDialog fileDialog)
+        {
+            fileDialog.InitialDirectory = Config.Instance.DataDirectory;
+            fileDialog.Filter = fileFilter;
+            fileDialog.Title = title;
+            fileDialog.RestoreDirectory = true;
+
+            var filePath = string.Empty;
+            if (fileDialog.ShowDialog() == DialogResult.OK)
+            {
+                filePath = fileDialog.FileName;
+            }
+            return filePath;
         }
 
         //public Tuple<string, int> AskCard(string restriction)


### PR DESCRIPTION
I plan to use this for the save/load table state functionality in the Lord of the Rings plugin. I wanted to make it possible to use the system dialogs to choose the location to save the table state and the file to load it from.

I went for the simplest solution of exposing the system SaveFileDialog and OpenFileDialog via the script without adding another Control to Octgn/Scripting/Controls, which I tried initially, but ultimately wasn't necessary for my use case.