### PR TITLE
Game board updates

### DIFF
--- a/octgnFX/Octgn.Server/BinaryParser.cs
+++ b/octgnFX/Octgn.Server/BinaryParser.cs
@@ -697,12 +697,20 @@ namespace Octgn.Server
 				}
 				case 103:
 				{
-					string arg0 = reader.ReadString();
+					byte arg0 = reader.ReadByte();
+					string arg1 = reader.ReadString();
 					Log.Debug($"SERVER IN:  SetBoard");
-					_socket.Handler.SetBoard(arg0);
+					_socket.Handler.SetBoard(arg0, arg1);
 					break;
 				}
 				case 104:
+				{
+					byte arg0 = reader.ReadByte();
+					Log.Debug($"SERVER IN:  RemoveBoard");
+					_socket.Handler.RemoveBoard(arg0);
+					break;
+				}
+				case 105:
 				{
 					byte arg0 = reader.ReadByte();
 					string arg1 = reader.ReadString();

--- a/octgnFX/Octgn.Server/BinaryStubs.cs
+++ b/octgnFX/Octgn.Server/BinaryStubs.cs
@@ -1357,7 +1357,7 @@ namespace Octgn.Server
 		}
 	}
 
-    public void SetBoard(string name)
+    public void SetBoard(byte player, string name)
     {
 		Log.Debug($"SERVER OUT: {nameof(SetBoard)}");
 		using(var stream = new MemoryStream(512)) {
@@ -1365,7 +1365,25 @@ namespace Octgn.Server
 			using(var writer = new BinaryWriter(stream)) {
 				writer.Write(_socket?.Server.Context.State.IsMuted ?? 0);
 				writer.Write((byte)103);
+				writer.Write(player);
 				writer.Write(name);
+				writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+				writer.Write((int)stream.Length);
+				writer.Close();
+				Send(stream.ToArray());
+			}
+		}
+	}
+
+    public void RemoveBoard(byte player)
+    {
+		Log.Debug($"SERVER OUT: {nameof(RemoveBoard)}");
+		using(var stream = new MemoryStream(512)) {
+			stream.Seek(4, SeekOrigin.Begin);
+			using(var writer = new BinaryWriter(stream)) {
+				writer.Write(_socket?.Server.Context.State.IsMuted ?? 0);
+				writer.Write((byte)104);
+				writer.Write(player);
 				writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 				writer.Write((int)stream.Length);
 				writer.Close();
@@ -1381,7 +1399,7 @@ namespace Octgn.Server
 			stream.Seek(4, SeekOrigin.Begin);
 			using(var writer = new BinaryWriter(stream)) {
 				writer.Write(_socket?.Server.Context.State.IsMuted ?? 0);
-				writer.Write((byte)104);
+				writer.Write((byte)105);
 				writer.Write(player);
 				writer.Write(color);
 				writer.Flush(); writer.Seek(0, SeekOrigin.Begin);

--- a/octgnFX/Octgn.Server/Broadcaster.cs
+++ b/octgnFX/Octgn.Server/Broadcaster.cs
@@ -631,11 +631,20 @@ namespace Octgn.Server
 		}
 	}
 
-	public void SetBoard(string name)
+	public void SetBoard(byte player, string name)
 	{
 		foreach(var ply in _players.Players){
 			if(ply.Connected){
-				ply.Rpc.SetBoard(name);
+				ply.Rpc.SetBoard(player, name);
+			}
+		}
+	}
+
+	public void RemoveBoard(byte player)
+	{
+		foreach(var ply in _players.Players){
+			if(ply.Connected){
+				ply.Rpc.RemoveBoard(player);
 			}
 		}
 	}

--- a/octgnFX/Octgn.Server/Handler.cs
+++ b/octgnFX/Octgn.Server/Handler.cs
@@ -590,8 +590,11 @@ namespace Octgn.Server
             _context.Broadcaster.ResetCardProperties(card, player);
         }
 
-        public void SetBoard(string name) {
-            _context.Broadcaster.SetBoard(name);
+        public void SetBoard(byte player, string name) {
+            _context.Broadcaster.SetBoard(player, name);
+        }
+        public void RemoveBoard(byte player) {
+            _context.Broadcaster.RemoveBoard(player);
         }
 
         public void SetPlayerColor(byte player, string colorHex) {

--- a/octgnFX/Octgn.Server/IClientCalls.cs
+++ b/octgnFX/Octgn.Server/IClientCalls.cs
@@ -76,7 +76,8 @@ namespace Octgn.Server
 		void SetCardProperty(int id, byte player, string name, string val, string valtype);
 		void ResetCardProperties(int id, byte player);
 		void Filter(int card, string color);
-		void SetBoard(string name);
+		void SetBoard(byte player, string name);
+		void RemoveBoard(byte player);
 		void SetPlayerColor(byte player, string color);
 	}
 }

--- a/octgnFX/Octgn.Server/Protocol.xml
+++ b/octgnFX/Octgn.Server/Protocol.xml
@@ -523,7 +523,11 @@
     <param name="color" type="Color?" />
   </msg>
   <msg name="SetBoard" client="true" server="true">
+    <param name="player" type="Player" />
     <param name="name" type="string" />
+  </msg>
+  <msg name="RemoveBoard" client="true" server="true">
+    <param name="player" type="Player" />
   </msg>
 	<msg name="SetPlayerColor" client="true" server="true">
 		<param name="player" type="Player"/>

--- a/octgnFX/Octgn/Networking/BinaryParser.cs
+++ b/octgnFX/Octgn/Networking/BinaryParser.cs
@@ -892,12 +892,24 @@ namespace Octgn.Networking
 				}
 				case 103:
 				{
-					var arg0 = reader.ReadString();
+					var arg0 = Player.Find(reader.ReadByte());
+					if (arg0 == null)
+					{ Debug.WriteLine("[SetBoard] Player not found."); return; }
+					var arg1 = reader.ReadString();
 					Log.Debug($"OCTGN IN: SetBoard");
-					handler.SetBoard(arg0);
+					handler.SetBoard(arg0, arg1);
 					break;
 				}
 				case 104:
+				{
+					var arg0 = Player.Find(reader.ReadByte());
+					if (arg0 == null)
+					{ Debug.WriteLine("[RemoveBoard] Player not found."); return; }
+					Log.Debug($"OCTGN IN: RemoveBoard");
+					handler.RemoveBoard(arg0);
+					break;
+				}
+				case 105:
 				{
 					var arg0 = Player.Find(reader.ReadByte());
 					if (arg0 == null)

--- a/octgnFX/Octgn/Networking/BinaryStubs.cs
+++ b/octgnFX/Octgn/Networking/BinaryStubs.cs
@@ -1324,7 +1324,7 @@ namespace Octgn.Networking
 			Send(stream.ToArray());
 		}
 
-		public void SetBoard(string name)
+		public void SetBoard(Player player, string name)
 		{
 			Log.Debug($"OCTGN OUT: {nameof(SetBoard)}");
 		    if(Program.Client == null)return;
@@ -1334,7 +1334,25 @@ namespace Octgn.Networking
 
 			writer.Write(Program.Client.Muted);
 			writer.Write((byte)103);
+			writer.Write(player.Id);
 			writer.Write(name);
+			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
+			writer.Write((int)stream.Length);
+			writer.Close();
+			Send(stream.ToArray());
+		}
+
+		public void RemoveBoard(Player player)
+		{
+			Log.Debug($"OCTGN OUT: {nameof(RemoveBoard)}");
+		    if(Program.Client == null)return;
+			MemoryStream stream = new MemoryStream(512);
+			stream.Seek(4, SeekOrigin.Begin);
+			BinaryWriter writer = new BinaryWriter(stream);
+
+			writer.Write(Program.Client.Muted);
+			writer.Write((byte)104);
+			writer.Write(player.Id);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);
 			writer.Write((int)stream.Length);
 			writer.Close();
@@ -1350,7 +1368,7 @@ namespace Octgn.Networking
 			BinaryWriter writer = new BinaryWriter(stream);
 
 			writer.Write(Program.Client.Muted);
-			writer.Write((byte)104);
+			writer.Write((byte)105);
 			writer.Write(player.Id);
 			writer.Write(color);
 			writer.Flush(); writer.Seek(0, SeekOrigin.Begin);

--- a/octgnFX/Octgn/Networking/ClientHandler.cs
+++ b/octgnFX/Octgn/Networking/ClientHandler.cs
@@ -233,10 +233,17 @@ namespace Octgn.Networking
             Program.GameEngine.EventProxy.OnTurnPassed_3_1_0_2(lastPlayer, Program.GameEngine.TurnNumber, false);
         }
 
-        public void SetBoard(string name)
+        public void SetBoard(Player player, string name)
+        {
+            WriteReplayAction(); 
+            Program.GameMess.PlayerEvent(player, "changes the game board to `{0}`", name == "" ? "default" : name);
+            Program.GameEngine.ChangeGameBoard(name);
+        }
+        public void RemoveBoard(Player player)
         {
             WriteReplayAction();
-            Program.GameEngine.ChangeGameBoard(name);
+            Program.GameMess.PlayerEvent(player, "removes the game board");
+            Program.GameEngine.ChangeGameBoard(null);
         }
 
         public void Chat(Player player, string text)

--- a/octgnFX/Octgn/Networking/IServerCalls.cs
+++ b/octgnFX/Octgn/Networking/IServerCalls.cs
@@ -77,7 +77,8 @@ namespace Octgn.Networking
 		void SetCardProperty(Card id, Player player, string name, string val, string valtype);
 		void ResetCardProperties(Card id, Player player);
 		void Filter(Card card, Color? color);
-		void SetBoard(string name);
+		void SetBoard(Player player, string name);
+		void RemoveBoard(Player player);
 		void SetPlayerColor(Player player, string color);
 	}
 }

--- a/octgnFX/Octgn/Play/Gui/TableControl.xaml.cs
+++ b/octgnFX/Octgn/Play/Gui/TableControl.xaml.cs
@@ -89,7 +89,7 @@ namespace Octgn.Play.Gui
                 if (tableDef.Background != null)
                     SetBackground(tableDef);
             }
-            Program.GameEngine.BoardImage = Program.GameEngine.GameBoard.Source;
+            Program.GameEngine.BoardImage = Program.GameEngine.GameBoard?.Source;
             //if (!Program.GameSettings.HideBoard)
             //    if (tableDef.Board != null)
             //        SetBoard(tableDef);

--- a/octgnFX/Octgn/Play/State/GameEngine.cs
+++ b/octgnFX/Octgn/Play/State/GameEngine.cs
@@ -692,6 +692,17 @@ namespace Octgn
             CardIdentity.Reset();
             Selection.Clear();
 
+            if (Definition.GameBoards.ContainsKey(""))
+            {
+                GameBoard = Definition.GameBoards[""];
+                BoardImage = GameBoard.Source;
+            }
+            else
+            {
+                GameBoard = null;
+                BoardImage = null;
+            }
+
             foreach (var g in Definition.GlobalVariables)
                 GlobalVariables[g.Key] = g.Value.Value;
 

--- a/octgnFX/Octgn/Play/State/GameEngine.cs
+++ b/octgnFX/Octgn/Play/State/GameEngine.cs
@@ -162,7 +162,8 @@ namespace Octgn
             // Init fields
             CurrentUniqueId = 1;
             TurnNumber = 0;
-            GameBoard = Definition.GameBoards[""];
+            if (Definition.GameBoards.ContainsKey(""))
+                GameBoard = Definition.GameBoards[""];
             ActivePlayer = null;
 
             foreach (var size in Definition.CardSizes) {
@@ -252,7 +253,8 @@ namespace Octgn
             // Init fields
             CurrentUniqueId = 1;
             TurnNumber = 0;
-            GameBoard = Definition.GameBoards[""];
+            if (Definition.GameBoards.ContainsKey(""))
+                GameBoard = Definition.GameBoards[""];
             ActivePlayer = null;
 
             foreach (var size in Definition.CardSizes)
@@ -386,10 +388,17 @@ namespace Octgn
 
         public void ChangeGameBoard(string name)
         {
-            if (name == null) return;
-            if (!Definition.GameBoards.ContainsKey(name)) return;
-            GameBoard = Definition.GameBoards[name];
-            BoardImage = GameBoard.Source;
+            if (name == null)
+            {
+                GameBoard = null;
+                BoardImage = null;
+            }
+            else
+            {
+                if (!Definition.GameBoards.ContainsKey(name)) return;
+                GameBoard = Definition.GameBoards[name];
+                BoardImage = GameBoard.Source;
+            }
             this.OnPropertyChanged("GameBoard");
             this.OnPropertyChanged("BoardMargin");
         }
@@ -404,7 +413,7 @@ namespace Octgn
             {
                 if (value == boardImage) return;
                 var nw = value;
-                if (!File.Exists(nw))
+                if (nw != null && !File.Exists(nw))
                 {
                     var workingDirectory = Path.Combine(Config.Instance.Paths.DatabasePath, Definition.Id.ToString());
                     if (File.Exists(Path.Combine(workingDirectory, nw)))
@@ -422,14 +431,19 @@ namespace Octgn
             }
         }
 
-        private Thickness? boardMargin;
         public Thickness BoardMargin
         {
             get
             {
-                var pos = new Rect(GameBoard.XPos, GameBoard.YPos, GameBoard.Width, GameBoard.Height);
-                boardMargin = new Thickness(pos.Left, pos.Top, 0, 0);
-                return boardMargin.Value;
+                if (GameBoard == null)
+                {
+                    return new Thickness();
+                }
+                else
+                {
+                    var pos = new Rect(GameBoard.XPos, GameBoard.YPos, GameBoard.Width, GameBoard.Height);
+                    return new Thickness(pos.Left, pos.Top, 0, 0);
+                }
             }
         }
 

--- a/octgnFX/Octgn/Play/State/GameSaveState.cs
+++ b/octgnFX/Octgn/Play/State/GameSaveState.cs
@@ -49,7 +49,7 @@ namespace Octgn.Play.State
             //this.TurnPlayer = engine.TurnPlayer.Id;
             if (engine.ActivePlayer != null) this.ActivePlayer = engine.ActivePlayer.Id;
             this.TurnNumber = engine.TurnNumber;
-            this.GameBoard = engine.GameBoard.Name;
+            this.GameBoard = engine.GameBoard?.Name;
             if (Play.Player.LocalPlayer == fromPlayer)
             {
                 CurrentUniqueId = engine.CurrentUniqueId;

--- a/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
+++ b/octgnFX/Octgn/Scripting/Versions/3.1.0.2.py
@@ -452,7 +452,7 @@ class Table(Group):
 	@property
 	def board(self): return _api.GetBoard()
 	@board.setter
-	def board(self, alt = "Default"): _api.SetBoard(alt)
+	def board(self, key): _api.SetBoard(key)
 	@property
 	def boards(self): return _api.GetBoardList()
 	_twoSided = None

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_1.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_1.cs
@@ -1196,7 +1196,7 @@ namespace Octgn.Scripting.Versions
             if (String.IsNullOrWhiteSpace(name)) return;
             if (!GetBoardList().Contains(name)) return;
             QueueAction(() => Program.GameEngine.ChangeGameBoard(name));
-            Program.Client.Rpc.SetBoard(name);
+            Program.Client.Rpc.SetBoard(Player.LocalPlayer, name);
 
         }
         public string GetBoard()

--- a/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
+++ b/octgnFX/Octgn/Scripting/Versions/Script_3_1_0_2.cs
@@ -1407,15 +1407,24 @@ namespace Octgn.Scripting.Versions
 
         public void SetBoard(string name)
         {
-            if (String.IsNullOrWhiteSpace(name)) return;
-            if (!GetBoardList().Contains(name)) return;
-            QueueAction(() => Program.GameEngine.ChangeGameBoard(name));
-            Program.Client.Rpc.SetBoard(name);
-
+            if (name == null)
+            {
+              //  QueueAction(() => Program.GameEngine.ChangeGameBoard(name));
+                Program.Client.Rpc.RemoveBoard(Player.LocalPlayer);
+            }
+            else if (GetBoardList().Contains(name))
+            {
+            //    QueueAction(() => Program.GameEngine.ChangeGameBoard(name));
+                Program.Client.Rpc.SetBoard(Player.LocalPlayer, name);
+            }
+            else
+            {
+                Program.GameMess.Warning("Cannot find game board with name `{0}`.", name);
+            }
         }
         public string GetBoard()
         {
-            return Program.GameEngine.GameBoard.Name;
+            return Program.GameEngine.GameBoard?.Name;
         }
         public string[] GetBoardList()
         {

--- a/octgnFX/o8build/GameValidator.cs
+++ b/octgnFX/o8build/GameValidator.cs
@@ -210,22 +210,25 @@
             if (game.gameboards != null)
             {
                 // Check for valid attributes
-                if (String.IsNullOrWhiteSpace(game.gameboards.src))
+                if (!string.IsNullOrWhiteSpace(game.gameboards.src))
                 {
-                    throw GenerateEmptyAttributeException("GameBoard", "src");
+                    path = Path.Combine(Directory.FullName, game.gameboards.src);
+
+                    if (!File.Exists(path))
+                    {
+                        throw GenerateFileDoesNotExistException(path, "Default Board", game.gameboards.name, "src", game.gameboards.src);
+                    }
                 }
 
-                path = Path.Combine(Directory.FullName, game.gameboards.src);
-
-                if (!File.Exists(path))
-                {
-                    throw GenerateFileDoesNotExistException(path, "Default Board", game.gameboards.name, "src", game.gameboards.src);
-                }
                 if (game.gameboards.gameboard != null)
                 {
                     foreach (var board in game.gameboards.gameboard)
                     {
                         // Check for valid attributes
+                        if (board.name == "")
+                        {
+                            throw GenerateReservedAttributeValueException("GameBoard", "name", "");
+                        }
                         if (String.IsNullOrWhiteSpace(board.src))
                         {
                             throw GenerateEmptyAttributeException("GameBoard", "src");
@@ -480,8 +483,10 @@
             }
 
             // Check for valid attributes
-            if (String.IsNullOrWhiteSpace(game.table.board) == false)
+            if (!string.IsNullOrWhiteSpace(game.table.board))
             {
+                GenerateWarningMessage("Defining a game board from the `<table>` element has been depreciated.\nPlease use the `<gameboards>` element to define game boards instead.\nsee wiki.octgn.net for more info.");
+
                 path = Path.Combine(Directory.FullName, game.table.board);
 
                 if (!File.Exists(path))

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,4 @@
-
+python can now revert the game board back to its default value ""
+python can remove the board (set the board to None)
+Added chat notifications for changing or removing game board
+Fixed a crash if a game didn't set a default game board

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -2,3 +2,4 @@ python can now revert the game board back to its default value ""
 python can remove the board (set the board to None)
 Added chat notifications for changing or removing game board
 Fixed a crash if a game didn't set a default game board
+Resetting the game reverts back to the default game board state

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -3,3 +3,4 @@ python can remove the board (set the board to None)
 Added chat notifications for changing or removing game board
 Fixed a crash if a game didn't set a default game board
 Resetting the game reverts back to the default game board state
+Added some additional o8build warning messages for game boards


### PR DESCRIPTION
change log has a summary of the updates.

Basically this cleans up some weird situations with game boards, allows python to remove the game board or set to the default board, and allows games to have no board set by default.

This doesn't fix the known issue with big game boards warping the play table's coordinate grids.

fixes #2013