### PR TITLE
Feature: Timeout and parallel processing in GameFeedManager

### DIFF
--- a/octgnFX/Octgn.Core/GameFeedManager.cs
+++ b/octgnFX/Octgn.Core/GameFeedManager.cs
@@ -174,6 +174,10 @@ namespace Octgn.Core
             {
                 Log.Warn("Error fetching updates from feed", e);
             }
+            finally
+            {
+                cancellationSource.Dispose();
+            }
 
             try
             {

--- a/octgnFX/Octgn/AppConfig.cs
+++ b/octgnFX/Octgn/AppConfig.cs
@@ -16,6 +16,7 @@ namespace Octgn
         public static readonly string GameServerPath;
         public static readonly string UpdateInfoPath;
         public static readonly string GameFeed;
+        public static readonly int GameFeedTimeoutSeconds;
         public static readonly bool UseGamePackageManagement;
         public static readonly string StaticWebsitePath;
         public static readonly string NewsFeedPath;
@@ -36,6 +37,12 @@ namespace Octgn
             ChatServerHost = ConfigurationManager.AppSettings["ChatServerHost"];
             GameServerPath = ConfigurationManager.AppSettings["GameServerPath"];
             GameFeed = ConfigurationManager.AppSettings["GameFeed"];
+            GameFeedTimeoutSeconds = 60;
+            if (int.TryParse(ConfigurationManager.AppSettings["GameFeedTimeoutSeconds"], out var parsedSeconds))
+            {
+                GameFeedTimeoutSeconds = parsedSeconds;
+            }
+
             UseGamePackageManagement = bool.Parse(ConfigurationManager.AppSettings["UseGamePackageManagement"]);
             if (Program.IsReleaseTest)
                 UpdateInfoPath = ConfigurationManager.AppSettings["UpdateCheckPathTest"];

--- a/octgnFX/Octgn/GameUpdater.cs
+++ b/octgnFX/Octgn/GameUpdater.cs
@@ -119,7 +119,7 @@
                     return;
                 }
                 Log.Info("Checking for updates");
-                GameFeedManager.Get().CheckForUpdates(true);
+                GameFeedManager.Get().CheckInstallUpdates(true);
                 Log.InfoFormat("Update check complete");
             }
             Log.Info("Exited timer lock");

--- a/octgnFX/Octgn/Program.cs
+++ b/octgnFX/Octgn/Program.cs
@@ -99,6 +99,10 @@ namespace Octgn
 
             Log.Info("Setting api path");
             Octgn.Site.Api.ApiClient.DefaultUrl = new Uri(AppConfig.WebsitePath);
+
+            Log.Info("Configuring game feeds");
+            ConfigureGameFeedTimeout();
+
             try
             {
                 Log.Debug("Setting rendering mode.");
@@ -527,6 +531,12 @@ namespace Octgn
                 Log.Error(e);
             }
             return defaultBrowserPath;
+        }
+
+        public static void ConfigureGameFeedTimeout()
+        {
+            var manager = GameFeedManager.Get();
+            manager.FeedUpdateTimeout = TimeSpan.FromSeconds(AppConfig.GameFeedTimeoutSeconds);
         }
 
         public static void DoCrazyException(Exception e, string action)

--- a/octgnFX/Octgn/Windows/UpdateChecker.xaml.cs
+++ b/octgnFX/Octgn/Windows/UpdateChecker.xaml.cs
@@ -286,7 +286,7 @@ namespace Octgn.Windows
             var gr = GameFeedManager.Get();
             gr.OnUpdateMessage += GrOnUpdateMessage;
             Dispatcher.Invoke(new Action(() => { this.progressBar1.IsIndeterminate = false; }));
-            GameFeedManager.Get().CheckForUpdates(localOnly,
+            GameFeedManager.Get().CheckInstallUpdates(localOnly,
                 (cur, max) => this.Dispatcher.Invoke(
                     new Action(
                         () => {


### PR DESCRIPTION
The ambition of this pull request is both to speed up the initial update check and to set a cap on how long the nuget feed scan is allowed to take.

It adds an AppSetting for "GameFeedTimeoutSeconds" which defaults to 60 seconds.
The nuget feed scanning is rewritten to be executed in parallel and has a maximum execution time set to "GameFeedTimeoutSeconds".