### PR TITLE
closes #2050 - a default shuffle command for piles

### DIFF
--- a/octgnFX/Octgn.DataNew/Entities/Group.cs
+++ b/octgnFX/Octgn.DataNew/Entities/Group.cs
@@ -8,6 +8,7 @@
         public string Name { get; set; }
         public string Icon { get; set; }
         public string Shortcut { get; set; }
+        public string ShuffleShortcut { get; set; }
         public bool MoveTo { get; set; }
         public string Background { get; set; }
         public BackgroundStyle BackgroundStyle { get; set; }

--- a/octgnFX/Octgn.DataNew/GameSerializer.cs
+++ b/octgnFX/Octgn.DataNew/GameSerializer.cs
@@ -602,6 +602,10 @@ namespace Octgn.DataNew
             {
                 ret.Height = 1;
             }
+            if (!string.IsNullOrWhiteSpace(grp.shuffle))
+            {
+                ret.ShuffleShortcut = grp.shuffle;
+            }
             if (grp.Items != null)
             {
                 ret.CardActions = DeserializeGroupActionList(grp.Items, false);
@@ -1277,6 +1281,7 @@ namespace Octgn.DataNew
             ret.icon = group.Icon == null ? null : (group.Icon ?? "").Replace(rootPath, "");
             ret.ordered = group.Ordered ? boolean.True : boolean.False;
             ret.shortcut = group.Shortcut;
+            ret.shuffle = group.ShuffleShortcut;
             ret.moveto = group.MoveTo ? boolean.True : boolean.False;
             List<baseAction> itemList = new List<baseAction>();
             if (group.CardActions != null)

--- a/octgnFX/Octgn.JodsEngine/Play/Group.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/Group.cs
@@ -53,6 +53,8 @@ namespace Octgn.Play
             CardShortcuts = CreateShortcuts(def.CardActions);
             if (def.Shortcut != null)
                 MoveToShortcut = (KeyGesture) KeyConverter.ConvertFromInvariantString(def.Shortcut);
+            if (def.ShuffleShortcut != null)
+                ShuffleShortcut = (KeyGesture)KeyConverter.ConvertFromInvariantString(def.ShuffleShortcut);
         }
 
         public DataNew.Entities.Group Definition
@@ -67,6 +69,7 @@ namespace Octgn.Play
         }
 
         public KeyGesture MoveToShortcut { get; private set; }
+        public KeyGesture ShuffleShortcut { get; private set; }
 
         // Are cards visible when they arrive in this group ?                
         internal GroupVisibility Visibility

--- a/octgnFX/Octgn.JodsEngine/Play/PlayWindow.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/PlayWindow.xaml.cs
@@ -671,11 +671,19 @@ namespace Octgn.Play
             foreach (Group g in Player.LocalPlayer.Groups.Where(g => g.CanManipulate()))
             {
                 ActionShortcut a = g.GroupShortcuts.FirstOrDefault(shortcut => shortcut.Key.Matches(this, e));
-                if (a == null) continue;
-                if (a.ActionDef.AsAction().Execute != null)
-                    ScriptEngine.ExecuteOnGroup(a.ActionDef.AsAction().Execute, g);
-                e.Handled = true;
-                return;
+                if (a != null)
+                {
+                    if (a.ActionDef.AsAction().Execute != null)
+                        ScriptEngine.ExecuteOnGroup(a.ActionDef.AsAction().Execute, g);
+                    e.Handled = true;
+                    return;
+                }
+                else if (g is Pile pile && pile.ShuffleShortcut != null && pile.ShuffleShortcut.Matches(this, e))
+                {
+                    pile.Shuffle();
+                    e.Handled = true;
+                    return;
+                }
             }
         }
 

--- a/octgnFX/Octgn.Library/Schemas/Game.cs
+++ b/octgnFX/Octgn.Library/Schemas/Game.cs
@@ -851,6 +851,8 @@ public partial class group {
     
     private string shortcutField;
     
+    private string shuffleField;
+    
     private boolean movetoField;
     
     private boolean collapsedField;
@@ -940,6 +942,17 @@ public partial class group {
     
     /// <remarks/>
     [System.Xml.Serialization.XmlAttributeAttribute()]
+    public string shuffle {
+        get {
+            return this.shuffleField;
+        }
+        set {
+            this.shuffleField = value;
+        }
+    }
+    
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
     [System.ComponentModel.DefaultValueAttribute(boolean.True)]
     public boolean moveto {
         get {
@@ -1011,7 +1024,7 @@ public enum groupViewState {
 }
 
 /// <remarks/>
-[System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.1055.0")]
+[System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.7.3081.0")]
 [System.SerializableAttribute()]
 [System.Diagnostics.DebuggerStepThroughAttribute()]
 [System.ComponentModel.DesignerCategoryAttribute("code")]

--- a/octgnFX/Octgn.Library/Schemas/Game.xsd
+++ b/octgnFX/Octgn.Library/Schemas/Game.xsd
@@ -1047,10 +1047,17 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="shortcut" type="xs:string">
+    <xs:attribute name="shortcut" type="xs:string" use="optional">
       <xs:annotation>
         <xs:documentation>
           Keyboard shortcut used to move cards to this group.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="shuffle" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Keyboard shortcut used to shuffle this group.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,3 @@
-
+'shuffle' attribute added to group element in game definitions.  It expects a hotkey string.
+If 'shuffle' is defined on a group, it will activate a shuffle action in the group's context menu with the given hotkey.
+'shuffle' by default is null, so the menu action won't appear by default.


### PR DESCRIPTION
optional 'shuffle' attribute for the group element, value is a hotkey string
hotkey follows the same hierarchy patterns as group and card actions
defaults to null, so it won't break existing shuffle python actions in games