### PR TITLE
fixed uninstalling games bug when graveyard path is in a different volume from the game database

### DIFF
--- a/octgnFX/Octgn.Core/DataManagers/GameManager.cs
+++ b/octgnFX/Octgn.Core/DataManagers/GameManager.cs
@@ -480,8 +480,8 @@ namespace Octgn.Core.DataManagers
                         if (DbContext.Get() is IDbContextCaching dbWithCaching)
                             dbWithCaching.Invalidate(game);
 
-                        gamePathDi.ClearReadonlyFlag();
-                        gamePathDi.MoveTo(Config.Instance.Paths.GraveyardPath);
+                        var gravePath = Config.Instance.Paths.GraveyardPath;
+                        gamePathDi.MoveDirectory(gravePath);
                         break;
                     }
                     catch

--- a/octgnFX/Octgn.Library/ExtensionMethods/FileInfoExtensionMethods.cs
+++ b/octgnFX/Octgn.Library/ExtensionMethods/FileInfoExtensionMethods.cs
@@ -34,5 +34,42 @@
                 f.ClearReadonlyFlag();
             }
         }
+
+        public static void MoveDirectory(this DirectoryInfo source, string target)
+        {
+            var targetDirectory = new DirectoryInfo(target);
+            source.MoveDirectory(targetDirectory);
+        }
+
+        public static void MoveDirectory(this DirectoryInfo source, DirectoryInfo target)
+        {
+            source.ClearReadonlyFlag();
+            if (source.Root == target.Root)
+            {
+                source.MoveTo(target.FullName);
+            }
+            else
+            {
+                source.MoveContents(target);
+                source.Delete(true);
+            }
+        }
+
+        private static void MoveContents(this DirectoryInfo source, DirectoryInfo target)
+        {
+            if (!target.Exists)
+            {
+                target.Create();
+            }
+            foreach (FileInfo file in source.GetFiles())
+            {
+                file.CopyTo(Path.Combine(target.FullName, file.Name), true);
+            }
+            foreach (DirectoryInfo sourceSubdirectory in source.GetDirectories())
+            {
+                DirectoryInfo targetSubdirectory = target.CreateSubdirectory(sourceSubdirectory.Name);
+                MoveContents(sourceSubdirectory, targetSubdirectory);
+            }
+        }
     }
 }


### PR DESCRIPTION
If the volumes are different, then Directory.MoveTo doesn't work.  This adds an extension method which handles this case by performing a traditional copy+delete alternative