### PR TITLE
Test restoration project

### DIFF
--- a/octgnFX/Octgn.Core/GameFeedManager.cs
+++ b/octgnFX/Octgn.Core/GameFeedManager.cs
@@ -388,7 +388,8 @@ namespace Octgn.Core
         /// <returns><see cref="FeedValidationResult"/></returns>
         public FeedValidationResult ValidateFeedUrl( string feed, string username, string password ) {
             Log.InfoFormat( "Validating feed url {0}", feed );
-            if( PathValidator.IsValidUrl( feed ) && PathValidator.IsValidSource( feed ) ) {
+            bool isValidUrl = PathValidator.IsValidUrl( feed );
+            if( isValidUrl && PathValidator.IsValidSource( feed ) ) {
                 Log.InfoFormat( "Path Validator says feed {0} is valid", feed );
                 OctgnFeedCredentialProvider.AddTemp( feed, username, password );
                 try {
@@ -410,10 +411,8 @@ namespace Octgn.Core
                     Log.WarnFormat( "{0} is an invalid feed.", feed );
                 }
                 OctgnFeedCredentialProvider.RemoveTemp( feed );
-                return FeedValidationResult.InvalidUrl;
-            } else {
-                return FeedValidationResult.InvalidFormat;
             }
+            return isValidUrl ? FeedValidationResult.InvalidFormat : FeedValidationResult.InvalidUrl;
             //Log.InfoFormat("Path validator failed for feed {0}", feed);
             //return FeedValidationResult.Unknown;
         }

--- a/octgnFX/Octgn.Core/Versioned.cs
+++ b/octgnFX/Octgn.Core/Versioned.cs
@@ -105,7 +105,7 @@ namespace Octgn.Scripting
 				    continue;
 				}
                 // the version directly below the most recent version should not expire (we will always allow at least 2 API versions at any given time)
-                if (prevLive.Version == version)
+                if (prevLive?.Version == version)
                 {
                     v.Value.DeleteDate = DateTime.MaxValue;
                     prevLive = v.Value;

--- a/octgnFX/Octgn.Library/Utils/NetworkHelper.cs
+++ b/octgnFX/Octgn.Library/Utils/NetworkHelper.cs
@@ -13,9 +13,9 @@ namespace Octgn.Library.Utils
         public static bool IsPortAvailable(int port)
         {
             var ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
-            var tcpConnInfoArray = ipGlobalProperties.GetActiveTcpConnections();
+            var tcpConnInfoArray = ipGlobalProperties.GetActiveTcpListeners();
 
-            return tcpConnInfoArray.All(tcpi => tcpi.LocalEndPoint.Port != port);
+            return tcpConnInfoArray.All(tcpi => tcpi.Port != port);
         }
     }
 }

--- a/octgnFX/Octgn.Online.Test/GameService/NetworkHelperTests.cs
+++ b/octgnFX/Octgn.Online.Test/GameService/NetworkHelperTests.cs
@@ -47,7 +47,7 @@ namespace Octgn.Online.Test.GameService
                 // Wait for all the threads to be started before beginning work
                 startEvent.WaitOne();
 
-                var nh = new NetworkHelper(21000, 31000, "NetworkHelperTest");
+                var nh = new NetworkHelper(15000, 45000, "NetworkHelperTest");
                 var ports = new List<int>();
                 for(var i = 0; i < 1000; i++) {
                     var port = nh.NextPort;

--- a/octgnFX/Octgn.Test/Core/GameFeedManagerTests.cs
+++ b/octgnFX/Octgn.Test/Core/GameFeedManagerTests.cs
@@ -16,6 +16,12 @@ namespace Octgn.Test.Core
 
     public class GameFeedManagerTests
     {
+        [SetUp]
+        public void CreateConfiguration()
+        {
+            Config.Instance = new Config();
+        }
+
         [Test]
         public void GetPackages_NoDuplicates() {
             //var ret = (GameFeedManager.Get() as GameFeedManager).GetPackages();
@@ -33,14 +39,14 @@ namespace Octgn.Test.Core
         public void ValidateFeedUrl_FailsOnBadUri() {
             var ret = GameFeedManager.Get();
             var badUri = "sdflakwejfasw";
-            Assert.AreEqual( FeedValidationResult.InvalidFormat, ret.ValidateFeedUrl( badUri, null, null ) );
+            Assert.AreEqual( FeedValidationResult.InvalidUrl, ret.ValidateFeedUrl( badUri, null, null ) );
         }
 
         [Test]
         public void ValidateFeedUrl_FailsOnNotARepo() {
             var ret = GameFeedManager.Get();
             var goodUriButNotAFeed = "http://en.wikipedia.org/wiki/Human_feces/";
-            Assert.AreEqual( FeedValidationResult.InvalidUrl, ret.ValidateFeedUrl( goodUriButNotAFeed, null, null ) );
+            Assert.AreEqual( FeedValidationResult.InvalidFormat, ret.ValidateFeedUrl( goodUriButNotAFeed, null, null ) );
         }
 
         #region AddFeed
@@ -72,8 +78,8 @@ namespace Octgn.Test.Core
             bool pass = false;
             try {
                 fake.AddFeed( "asdf", "asdf", null, null );
-            } catch( TargetInvocationException ex ) {
-                if( ex.InnerException is UserMessageException ) pass = true;
+            } catch( UserMessageException ex ) {
+                if( ex.Message.Contains("not a valid feed") ) pass = true;
             }
 
             GameFeedManager.SingletonContext = cur;
@@ -106,8 +112,8 @@ namespace Octgn.Test.Core
 
                 try {
                     fakeGf.AddFeed( "asdf", "asdf", null, null );
-                } catch( TargetInvocationException e ) {
-                    if( e.InnerException is UserMessageException ) pass = true;
+                } catch( UserMessageException e ) {
+                    if (e.Message.Contains("already exists")) pass = true;
                 }
             } finally {
                 FeedProvider.SingletonContext = curFeedProvider;
@@ -159,7 +165,7 @@ namespace Octgn.Test.Core
                 FeedProvider.SingletonContext = fake;
 
                 var res = GameFeedManager.Get().GetFeeds();
-                Assert.IsNull( res );
+                Assert.IsEmpty( res );
                 A.CallTo( () => fake.AllFeeds ).MustHaveHappened( Repeated.Exactly.Once );
             } finally {
                 FeedProvider.SingletonContext = curFeedProvider;

--- a/octgnFX/Octgn.Test/Library/Networking/GameBroadcastingTests.cs
+++ b/octgnFX/Octgn.Test/Library/Networking/GameBroadcastingTests.cs
@@ -17,7 +17,8 @@ namespace Octgn.Test.Library.Networking
         public async Task Test() {
             var game = new HostedGame() {
                 Id = Guid.NewGuid(),
-                HostUser = new User("id", "name")
+                HostUser = new User("id", "name"),
+                HostAddress = "0.0.0.0:5000",   // needed to avoid a parsing error
             };
             using(var broadcaster = new GameBroadcaster(game, 3456)) {
                 using(var listener = new GameBroadcastListener(3456)) {


### PR DESCRIPTION
This PR gets all the active tests in the main solution passing again.  Apart from minor changes in the tests themselves, there are three changes in the code under test:

1) The feed validator method did not return results that matched with what was being described (e.g. InvalidUrl when the URL was fine, but did not point to a real feed)
2) The API RegisterVersion method was failing when a test version was registered instead of a live one
3) The NetworkHelper IsPortAvailable method was checking established sockets rather than listening sockets, which could cause port numbers to be misdiagnosed as valid or invalid.  For example, a browser holding a connection open with a local port number of 54321 would report that port invalid.

If any of these changes are unwelcome (especially item 1), I will adjust the tests to match the old behaviour instead.  The last one was not necessary to get tests running, but I fixed it because I initially thought it was contributing to the failure of the NoConflicts NetworkHelper test.

I have not reviewed the tests themselves for usefulness.  I know there are a lot of tests commented out that may also be useful to restore, but I am still unfamiliar with almost all of the project.