### PR TITLE
Fixes #2108. Shut down after launching deck editor with -e

### DIFF
--- a/octgnFX/Octgn/Launchers/DeckEditorLauncher.cs
+++ b/octgnFX/Octgn/Launchers/DeckEditorLauncher.cs
@@ -15,6 +15,7 @@ namespace Octgn.Launchers
             Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
             this.DeckPath = string.IsNullOrWhiteSpace(deckPath) ? null : deckPath;
+            Shutdown = true;
         }
 
         public ILog Log { get; private set; }


### PR DESCRIPTION
The DeckEditorLauncher class is only referenced in the code that handles the command line parameters, so this seemed a safe fix.