### PR TITLE
End the launching process when using the -e parameter

### DIFF
--- a/octgnFX/Octgn/CommandLineHandler.cs
+++ b/octgnFX/Octgn/CommandLineHandler.cs
@@ -96,7 +96,7 @@ namespace Octgn
 
                 if (deckPath != null || editorOnly)
                 {
-                    return new DeckEditorLauncher(deckPath);
+                    return new DeckEditorLauncher(deckPath, true);
                 }
             }
             catch (Exception e)

--- a/octgnFX/Octgn/Launchers/DeckEditorLauncher.cs
+++ b/octgnFX/Octgn/Launchers/DeckEditorLauncher.cs
@@ -10,11 +10,12 @@ namespace Octgn.Launchers
         internal string DeckPath;
         internal IDeck Deck;
 
-        public DeckEditorLauncher(string deckPath = null) {
+        public DeckEditorLauncher(string deckPath = null, bool shutdown = false) {
             // This way Deck == null instead of an empty string
             Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
             this.DeckPath = string.IsNullOrWhiteSpace(deckPath) ? null : deckPath;
+            this.Shutdown = shutdown;
         }
 
         public ILog Log { get; private set; }

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+fixed zombie OCTGN process running when launching the deck editor with -e


### PR DESCRIPTION
Added a parameter to the launcher constructor so that the Shutdown property can be set by the caller.

Would be more self-documenting if this property could be set directly though, e.g.:
```
launcher = new DeckEditorLauncher(deckPath) { Shutdown = true };
```