### PR TITLE
Avoid a null reference with Program.Dispatcher

### DIFF
--- a/octgnFX/Octgn.JodsEngine/Play/State/GameEngine.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/State/GameEngine.cs
@@ -242,11 +242,11 @@ namespace Octgn
                 this.Nickname = Prefs.Nickname;
                 if (string.IsNullOrWhiteSpace(this.Nickname)) this.Nickname = Randomness.GrabRandomNounWord() + new Random().Next(30);
                 var retNick = this.Nickname;
-                Program.Dispatcher.Invoke(new Action(() =>
-                    {
-                        var i = new InputDlg("Choose a nickname", "Choose a nickname", this.Nickname);
-                        retNick = i.GetString();
-                    }));
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    var i = new InputDlg("Choose a nickname", "Choose a nickname", Nickname);
+                    retNick = i.GetString();
+                });
                 this.Nickname = retNick;
             }
             // Init fields

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+Fixed a crash for new users joining a game when they don't have a nickname set


### PR DESCRIPTION
Possibly the existing logic is a bit unsound re: when to prompt for a new nickname, but this prevents the crash at least.