### PR TITLE
Fix deckbuilder crash after loading a saved search

### DIFF
--- a/octgnFX/Octgn.JodsEngine/DeckBuilder/DeckBuilderWindow.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/DeckBuilder/DeckBuilderWindow.xaml.cs
@@ -1296,7 +1296,10 @@ namespace Octgn.DeckBuilder
                 }
                 else
                 {
-                    var ctrl = new SearchControl(Game, search) { SearchIndex = Searches.Count == 0 ? 1 : Searches.Max(x => x.SearchIndex) + 1 };
+                    var ctrl = new SearchControl(Game, search, this)
+                    {
+                        SearchIndex = Searches.Count == 0 ? 1 : Searches.Max(x => x.SearchIndex) + 1,
+                    };
                     ctrl.CardAdded += AddResultCard;
                     ctrl.CardRemoved += RemoveResultCard;
                     ctrl.CardSelected += CardSelected;

--- a/octgnFX/Octgn.JodsEngine/DeckBuilder/SearchControl.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/DeckBuilder/SearchControl.xaml.cs
@@ -73,8 +73,9 @@ namespace Octgn.DeckBuilder
             UpdateCount();
         }
 
-        public SearchControl(DataNew.Entities.Game loadedGame, SearchSave save)
+        public SearchControl(DataNew.Entities.Game loadedGame, SearchSave save, DeckBuilderWindow deckWindow)
         {
+            _deckWindow = deckWindow;
             NumMod = "";
             var game = GameManager.Get().GetById(save.GameId);
             if (game == null)

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+fixes a deck editor crash handling keypresses after loading a saved search


### PR DESCRIPTION
After loading a search, the newly constructed object has a null _deckWindow, so just pass it in like with the other constructor.