### PR TITLE
Removes movement animation when pile is hidden

### DIFF
--- a/octgnFX/Octgn.JodsEngine/Play/Group.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/Group.cs
@@ -323,6 +323,13 @@ namespace Octgn.Play
             OnCardsChanged();
         }
 
+        internal bool IsVisibleTo(Player player)
+        {
+            return Visibility == GroupVisibility.Everybody
+                || (Visibility == GroupVisibility.Undefined && this is Table)
+                || Viewers.Contains(player);
+        }
+
         internal void OnShuffled()
         {
             // Remove player looking at the cards, if any (doesn't remove the need to remove those from the dictionary!)

--- a/octgnFX/Octgn.JodsEngine/Play/Gui/FanPanel.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/Gui/FanPanel.cs
@@ -43,6 +43,8 @@ namespace Octgn.Play.Gui
 
         public double HandDensity { get; set; } = 0;
 
+        public Pile Pile { get; set; }
+
         #region Dependency properties
 
         private static readonly DependencyProperty XPositionProperty =
@@ -285,24 +287,32 @@ namespace Octgn.Play.Gui
 
                 child.Arrange(new Rect(new Point(xposition, 0), child.DesiredSize));
 
-                // Perform layout to layout animation                
-                double oldPos = GetXPosition(child);
-                if (!double.IsNaN(oldPos) && Math.Abs(xposition - oldPos) > 2)
+                if (Pile?.IsVisibleTo(Player.LocalPlayer) == true)
                 {
-                    var translate2 = (TranslateTransform) group.Children[2];
-                    TimeSpan delay = TimeSpan.FromSeconds(animationDelay);
-                    Animation.FillBehavior = FillBehavior.Stop;
-                    Animation.From = oldPos - xposition;
-                    Animation.To = 0;
-                    Animation.BeginTime = delay;
-                    StaticAnimation.To = StaticAnimation.From = Animation.From;
-                    StaticAnimation.Duration = delay;
-                    if (animationDelay > 0)
-                        translate2.BeginAnimation(TranslateTransform.XProperty, StaticAnimation);
-                    translate2.BeginAnimation(TranslateTransform.XProperty, Animation, HandoffBehavior.Compose);
-                    Animation.From = null;
-                    Animation.BeginTime = TimeSpan.Zero;
-                    animationDelay += perChildDelay;
+                    // We only perform the animation for the local player if we know they can see the pile.
+                    // This is to prevent players from noticing which card in a hidden pile was moved.
+                    // See https://github.com/octgn/OCTGN/issues/1875 for more details.
+                    // (While it shouldn't happen, it's technically possible that Pile is null – we treat it as if the player couldn't see it).
+
+                    // Perform layout to layout animation
+                    double oldPos = GetXPosition(child);
+                    if (!double.IsNaN(oldPos) && Math.Abs(xposition - oldPos) > 2)
+                    {
+                        var translate2 = (TranslateTransform) group.Children[2];
+                        TimeSpan delay = TimeSpan.FromSeconds(animationDelay);
+                        Animation.FillBehavior = FillBehavior.Stop;
+                        Animation.From = oldPos - xposition;
+                        Animation.To = 0;
+                        Animation.BeginTime = delay;
+                        StaticAnimation.To = StaticAnimation.From = Animation.From;
+                        StaticAnimation.Duration = delay;
+                        if (animationDelay > 0)
+                            translate2.BeginAnimation(TranslateTransform.XProperty, StaticAnimation);
+                        translate2.BeginAnimation(TranslateTransform.XProperty, Animation, HandoffBehavior.Compose);
+                        Animation.From = null;
+                        Animation.BeginTime = TimeSpan.Zero;
+                        animationDelay += perChildDelay;
+                    }
                 }
                 SetXPosition(child, xposition);
 

--- a/octgnFX/Octgn.JodsEngine/Play/Gui/PileControl.xaml
+++ b/octgnFX/Octgn.JodsEngine/Play/Gui/PileControl.xaml
@@ -48,7 +48,7 @@
                 <ItemsControl x:Name="list" ItemsSource="{Binding Cards}" Grid.Row="0" Focusable="False">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <gui:FanPanel Loaded="SaveFanPanel" />
+                            <gui:FanPanel Loaded="FanPanelLoaded" />
                         </ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>

--- a/octgnFX/Octgn.JodsEngine/Play/Gui/PileControl.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/Gui/PileControl.xaml.cs
@@ -201,10 +201,12 @@ namespace Octgn.Play.Gui
             return list.ItemContainerGenerator;
         }
 
-        private void SaveFanPanel(object sender, RoutedEventArgs e)
+        private void FanPanelLoaded(object sender, RoutedEventArgs e)
         {
             _fanPanel = (FanPanel)sender;
-            if ((group as Pile).ViewState == GroupViewState.Expanded)
+            Pile pile = Group as Pile;
+            _fanPanel.Pile = pile;
+            if (pile.ViewState == GroupViewState.Expanded)
                 UpdateDensity();
             else
                 Collapse();


### PR DESCRIPTION
Closes #1875.
This change makes it so the expanded view animation when a card is moved to/from a pile is only shown to players which can see the pile.
It makes it impossible to, for example, notice which exactly card from an opponent's hand was played.