### PR TITLE
AskCard and QueryCard uses the same filter logic as the limited pack generator

### DIFF
--- a/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
+++ b/octgnFX/Octgn.Core/DataExtensionMethods/CardExtensionMethods.cs
@@ -274,7 +274,7 @@ namespace Octgn.Core.DataExtensionMethods
             {
                 if (string.IsNullOrWhiteSpace(cardProperties[prop]?.ToString()) && string.IsNullOrWhiteSpace(value?.ToString()))
                     return true;
-                return cardProperties[prop].ToString().Equals(value.ToString(), StringComparison.InvariantCultureIgnoreCase);
+                return cardProperties[prop].ToString().Equals(value?.ToString(), StringComparison.InvariantCultureIgnoreCase);
             }
             else
             {
@@ -296,16 +296,23 @@ namespace Octgn.Core.DataExtensionMethods
             {
                 return card.GetName().Equals(value.ToString(), StringComparison.InvariantCultureIgnoreCase);
             }
+            else if (prop.Equals("model", StringComparison.InvariantCultureIgnoreCase))
+            {
+                if (Guid.TryParse(value?.ToString(), out Guid guid))
+                    return card.Id.Equals(guid);
+                else
+                    return false;
+            }
             var matchedProperty = cardProperties.Keys.FirstOrDefault(x => x.Name.Equals(prop, StringComparison.InvariantCultureIgnoreCase));
             if (matchedProperty == null)
             {
                 // if the property is missing then its treated as null for match requests
-                return string.IsNullOrWhiteSpace(value.ToString());
+                return string.IsNullOrWhiteSpace(value?.ToString());
             }
 
             if (string.IsNullOrWhiteSpace(cardProperties[matchedProperty]?.ToString()) && string.IsNullOrWhiteSpace(value?.ToString()))
                 return true;
-            return cardProperties[matchedProperty].ToString().Equals(value.ToString(), StringComparison.InvariantCultureIgnoreCase);
+            return cardProperties[matchedProperty].ToString().Equals(value?.ToString(), StringComparison.InvariantCultureIgnoreCase);
         }
 
         /// <summary>

--- a/octgnFX/Octgn.JodsEngine/Scripting/Controls/CardDlg.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Controls/CardDlg.xaml.cs
@@ -46,28 +46,8 @@ namespace Octgn.Scripting.Controls
                         _allCards = new List<Card>();
                         foreach (var p in properties)
                         {
-                            if (p.Key.Equals("model", StringComparison.InvariantCultureIgnoreCase))
-                                foreach (var v in p.Value)
-                                {
-                                    var tlist = game.AllCards()
-                                        .Where(y => y.Id.ToString().ToLower() == v.ToLower()).ToList();
-                                    _allCards.AddRange(tlist);
-                                }
-                            else if (p.Key.Equals("name", StringComparison.InvariantCultureIgnoreCase))
-                                foreach (var v in p.Value)
-                                {
-                                    var tlist = game.AllCards().Where(x => x.GetName().Equals(v, StringComparison.InvariantCultureIgnoreCase));
-                                    _allCards.AddRange(tlist);
-                                }
-                            else
-                                foreach (var v in p.Value)
-                                {
-                                    var tlist = game.AllCards()
-                                        .Where(x => x.GetCardProperties()
-                                            .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
-                                                && y.Value.ToString().ToLower() == v.ToLower())).ToList();
-                                    _allCards.AddRange(tlist);
-                                }
+                            foreach (var v in p.Value)
+                                _allCards.AddRange(game.AllCards().Where(x => x.MatchesPropertyValue(p.Key, v)));
                         }
                         break;
                     default:
@@ -75,21 +55,8 @@ namespace Octgn.Scripting.Controls
                         foreach (var p in properties)
                         {
                             var tlist = new List<Card>();
-                            if (p.Key.Equals("model", StringComparison.InvariantCultureIgnoreCase))
-                                foreach (var v in p.Value)
-                                    tlist.AddRange(query
-                                        .Where(y => y.Id.ToString().ToLower() == v.ToLower()).ToList());
-                            else if (p.Key.Equals("name", StringComparison.InvariantCultureIgnoreCase))
-                                foreach (var v in p.Value)
-                                    tlist.AddRange(query = query.Where(x => x.GetName().Equals(v, StringComparison.InvariantCultureIgnoreCase)));
-                            else
-                                foreach (var v in p.Value)
-                                {
-                                    tlist.AddRange(query
-                                        .Where(x => x.GetCardProperties()
-                                            .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
-                                                && y.Value.ToString().ToLower() == v.ToLower())).ToList());
-                                }
+                            foreach (var v in p.Value)
+                                tlist.AddRange(query.Where(x => x.MatchesPropertyValue(p.Key, v)));
                             query = tlist;
                         }
                         _allCards = query.ToList();
@@ -118,33 +85,15 @@ namespace Octgn.Scripting.Controls
                           _allCards = new List<Card>();
                           foreach (var p in properties)
                           {
-                              if (p.Key.Equals("name", StringComparison.InvariantCultureIgnoreCase))
-                              {
-                                  var tlist = game.AllCards().Where(x => x.GetName().Equals(p.Value, StringComparison.InvariantCultureIgnoreCase));
-                                  _allCards.AddRange(tlist);
-                              }
-                              else
-                              {
-                                  var tlist = game.AllCards()
-                                      .Where(x => x.GetCardProperties()
-                                          .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
-                                              && y.Value.ToString().ToLower() == p.Value.ToLower())).ToList();
-                                  _allCards.AddRange(tlist);
-                              }
+                              _allCards.AddRange(game.AllCards().Where(x => x.MatchesPropertyValue(p.Key, p.Value)));
                           }
                           break;
                       default:
                           var query = game.AllCards();
                           foreach (var p in properties)
                           {
-                              if (p.Key.Equals("name", StringComparison.InvariantCultureIgnoreCase))
-                                  query = query.Where(x => x.GetName().Equals(p.Value, StringComparison.InvariantCultureIgnoreCase));
-                              else
-                                  query = query
-                                    .Where(
-                                    x => x.GetCardProperties()
-                                        .Any(y => y.Key.Name.ToLower() == p.Key.ToLower()
-                                            && y.Value.ToString().ToLower() == p.Value.ToLower()));
+                              query = query
+                               .Where(x => x.MatchesPropertyValue(p.Key, p.Value));
                           }
                           _allCards = query.ToList();
                           break;

--- a/octgnFX/Octgn.JodsEngine/Scripting/Versions/Script_3_1_0_2.cs
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Versions/Script_3_1_0_2.cs
@@ -1140,26 +1140,23 @@ namespace Octgn.Scripting.Versions
                     var tempCardList = new List<DataNew.Entities.Card>();
                     foreach (var propertyValue in property.Value)
                     {
-                        if (property.Key.Equals("name", StringComparison.InvariantCultureIgnoreCase))
+                        if (match)
                         {
-                            if (match)
-                                tempCardList.AddRange(query
-                                    .Where(x => x.GetName().Equals(propertyValue, StringComparison.InvariantCultureIgnoreCase)));
-                            else
-                                tempCardList.AddRange(query
-                                    .Where(x => x.GetName().ToLower().Contains(propertyValue.ToLower()))); 
+                            tempCardList.AddRange(query.Where(x => x.MatchesPropertyValue(property.Key, propertyValue)));
                         }
                         else
                         {
-                            if (match)
+                            if (property.Key.Equals("name", StringComparison.InvariantCultureIgnoreCase))
+                            {
                                 tempCardList.AddRange(query
-                                    .Where(x => x.GetCardProperties()
-                                    .Any(y => y.Key.Name.ToLower() == property.Key.ToLower() && y.Value.ToString().ToLower() == propertyValue.ToLower())).ToList());
+                                    .Where(x => x.GetName().ToLower().Contains(propertyValue.ToLower())));
+                            }
                             else
+                            {
                                 tempCardList.AddRange(query
                                     .Where(x => x.GetCardProperties()
                                     .Any(y => y.Key.Name.ToLower() == property.Key.ToLower() && y.Value.ToString().ToLower().Contains(propertyValue.ToLower()))).ToList());
-
+                            }
                         }
                     }
                     query = tempCardList;

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,2 @@
-
+AskCard and QueryCard python API can now filter for null property values (in line with the limited pack generator logic)
+Card.MatchesPropertyValue extension method can now match card GUID values


### PR DESCRIPTION
This improves the performance of these search filters, allowing them to properly match to null property values.