### PR TITLE
Remove invalid filename characters from hosted game names, so they do…

### DIFF
--- a/octgnFX/Octgn.JodsEngine/Play/State/GameEngine.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/State/GameEngine.cs
@@ -503,7 +503,7 @@ namespace Octgn
                 return;
             }
 
-            Program.GameEngine.History.Name = _gameName;
+            Program.GameEngine.History.Name = string.Concat(_gameName.Split(Path.GetInvalidFileNameChars()));
 
             if (_historyPath == null) {
                 var dir = new DirectoryInfo(Config.Instance.Paths.GameHistoryPath);

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+Fixed a bug causing OCTGN to hang if trying to join a game with invalid characters in the lobby name


### PR DESCRIPTION
…n't freeze OCTGN when trying to join an affected game.