### PR TITLE
Assorted fixes

### DIFF
--- a/octgnFX/Octgn.Core/Prefs.cs
+++ b/octgnFX/Octgn.Core/Prefs.cs
@@ -648,5 +648,10 @@ namespace Octgn.Core
             get { return Config.Instance.ReadValue(nameof(DeviceId), Guid.NewGuid().ToString()); }
             set { Config.Instance.WriteValue(nameof(DeviceId), value); }
         }
+        public static bool ShowAltsInDeckEditor
+        {
+            get { return Config.Instance.ReadValue("ShowAltsInDeckEditor", false); }
+            set { Config.Instance.WriteValue("ShowAltsInDeckEditor", value); }
+        }
     }
 }

--- a/octgnFX/Octgn.JodsEngine/DeckBuilder/SearchControl.xaml
+++ b/octgnFX/Octgn.JodsEngine/DeckBuilder/SearchControl.xaml
@@ -73,8 +73,8 @@
                     </Grid.ColumnDefinitions>
                     <Button Content="Hide Filters" FontSize="14" Width="100" Margin="1,10,10,1" Style="{StaticResource FlatDarkButtonStyle}" 
                             Click="ToggleFilterVisibility" IsDefault="False" x:Name="ShowFilterToggleButton" Grid.Column="0" />
-                    <CheckBox Content="Hide Alternates" Margin="1,10,10,1" Foreground="Black" VerticalAlignment="Bottom" HorizontalAlignment="Left" FontWeight="Bold"
-                            Click="RefreshSearch" IsChecked="False" x:Name="HideAltToggleButton" Grid.Column="1" />
+                    <CheckBox Content="Show Alternates" Margin="1,10,10,1" Foreground="Black" VerticalAlignment="Bottom" HorizontalAlignment="Left" FontWeight="Bold"
+                              IsChecked="{Binding ElementName=self,Path=ShowAlternates}" x:Name="ShowAltToggleButton" Grid.Column="1" />
                     <TextBlock x:Name="ResultCount" TextAlignment="Right" VerticalAlignment="Bottom" HorizontalAlignment="Right" FontWeight="Bold" Foreground="Black" 
                                Grid.Column="2" TextWrapping="WrapWithOverflow" Text="0 Results" />
                     <Button Content="Search" FontSize="14" Width="80" Margin="10,10,1,1" Style="{StaticResource FlatDarkGreenButtonStyle}" 

--- a/octgnFX/Octgn.JodsEngine/DeckBuilder/SearchControl.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/DeckBuilder/SearchControl.xaml.cs
@@ -53,6 +53,23 @@ namespace Octgn.DeckBuilder
             }
         }
 
+        public bool ShowAlternates
+        {
+            get
+            {
+                return Prefs.ShowAltsInDeckEditor;
+            }
+            set
+            {
+                if (value != Prefs.ShowAltsInDeckEditor)
+                {
+                    Prefs.ShowAltsInDeckEditor = value;
+                    OnPropertyChanged("ShowAlternates");
+                    RefreshSearch(null, null);
+                }
+            }
+        }
+
         public SearchControl(DataNew.Entities.Game game, DeckBuilderWindow deckWindow)
         {
             _deckWindow = deckWindow;
@@ -68,6 +85,17 @@ namespace Octgn.DeckBuilder
             filtersList.ItemsSource = source;
             GenerateColumns(game);
             //resultsGrid.ItemsSource = game.SelectCards(null).DefaultView;
+
+
+            RoutedEventHandler loadedEvent = null;
+
+            loadedEvent = (sender, args) => {
+                this.Loaded -= loadedEvent;
+                this.RefreshSearch(SearchButton, null);
+            };
+
+            this.Loaded += loadedEvent;
+
             UpdateDataGrid(game.AllCards(true).ToDataTable(Game).DefaultView);
             FileName = "";
             UpdateCount();
@@ -95,7 +123,7 @@ namespace Octgn.DeckBuilder
             filtersList.ItemsSource =
                 Enumerable.Repeat<object>("First", 1)
                     .Union(Enumerable.Repeat<object>(new NamePropertyDef(), 1))
-                    .Union(Enumerable.Repeat<object>(new SetPropertyDef(Game.Sets()), 1))
+                     .Union(Enumerable.Repeat<object>(new SetPropertyDef(Game.Sets().Where(x => x.Hidden == false)), 1))
                     .Union(game.CardProperties.Values.Where(p => !p.Hidden));
             this.GenerateColumns(game);
             FileName = "";
@@ -481,8 +509,7 @@ namespace Octgn.DeckBuilder
                 if (orconditions.Count > 0) filterString += " and ";
                 filterString += String.Format("({0})", String.Join(" and ", conditions));
             }
-
-            if (HideAltToggleButton.IsChecked == true)
+            if (ShowAlternates == false)
             {
                 if (filterString != "") filterString += " and ";
                 filterString += "[Alternates] = ''";

--- a/octgnFX/Octgn.JodsEngine/DeckBuilder/SearchControl.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/DeckBuilder/SearchControl.xaml.cs
@@ -380,7 +380,7 @@ namespace Octgn.DeckBuilder
                         Path = new PropertyPath(prop.Name),
                         Mode = BindingMode.OneTime,
                         Converter = new RichTextConverter(),
-                        ConverterParameter = game
+                        ConverterParameter = game.DeckEditorFont
                     };
 
                     var factory = new FrameworkElementFactory(typeof(RichTextBlock));

--- a/octgnFX/Octgn.JodsEngine/Play/Gui/CardControl.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/Gui/CardControl.xaml.cs
@@ -350,7 +350,7 @@ namespace Octgn.Play.Gui
             // detaches and then re-attaches the control, e.g. when we change Z-order
             // by calling Move on an ObservableCollection.
             /*	if (_card == null)
-              {
+            {
                 _card = DataContext as Card;
                 if (_card != null) _card.PropertyChanged += PropertyChangeHandler;
               }*/
@@ -1205,7 +1205,7 @@ namespace Octgn.Play.Gui
                         tooltipTextBlock.Inlines.Add(new Run(property.Key.Name + ": ") { FontWeight = FontWeights.Bold });
                         if (property.Key.Type == PropertyType.RichText && property.Value is RichTextPropertyValue richText)
                         {
-                            tooltipTextBlock.Inlines.Add(RichTextConverter.ConvertToSpan(richText, Program.GameEngine.Definition));
+                            tooltipTextBlock.Inlines.Add(RichTextConverter.ConvertToSpan(richText, Program.GameEngine.Definition.NoteFont));
                         }
                         else
                         {

--- a/octgnFX/Octgn.JodsEngine/Utils/Converters/RichTextConverter.cs
+++ b/octgnFX/Octgn.JodsEngine/Utils/Converters/RichTextConverter.cs
@@ -20,11 +20,11 @@ namespace Octgn.Utils.Converters
     public class RichTextConverter : IValueConverter
     {
         internal static ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        internal static Game Game;
+        internal static Font Font;
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            Game = parameter as Game;
+            Font = parameter as Font;
             var propval = value as RichTextPropertyValue;
             if (propval == null) return null;
             if (!(propval.Value is IRichText)) throw new InvalidOperationException($"{nameof(RichTextPropertyValue)}.{nameof(value)} is the wrong type");
@@ -34,9 +34,9 @@ namespace Octgn.Utils.Converters
             return span.Inlines.ToList();
         }
 
-        public static Span ConvertToSpan(RichTextPropertyValue value, Game game)
+        public static Span ConvertToSpan(RichTextPropertyValue value, Font font)
         {
-            Game = game;
+            Font = font;
             Span span = new Span();
             InternalProcess(span, value.Value);
             return span;
@@ -90,7 +90,7 @@ namespace Octgn.Utils.Converters
                     var image = new Image
                     {
                         Margin = new Thickness(0, 0, 0, -2),
-                        Height = span.FontSize + 2,
+                        Height = Font.Size + 2,
                         Stretch = Stretch.Uniform,
                         Source = new BitmapImage(new Uri(symbol.Source)),
                         ToolTip = symbol.Name

--- a/octgnFX/o8build/GameValidator.cs
+++ b/octgnFX/o8build/GameValidator.cs
@@ -857,7 +857,7 @@
                     if (childNode.NodeType == XmlNodeType.Text) continue;
                     if (childNode.Name.ToUpper() == "S" || childNode.Name.ToUpper() == "SYMBOL")
                     {
-                        if (!symbols.Any(x => x.id == childNode.Attributes["value"].Value))
+                        if (symbols == null || !symbols.Any(x => x.id == childNode.Attributes["value"].Value))
                         {
                             return "Undefined Symbol '" + childNode.Attributes["value"].Value + "'";
                         }

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+o8build will give a more useful error if you use richtext symbols in a set but don't have a symbols element in the game XML.

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,4 @@
 o8build will give a more useful error if you use richtext symbols in a set but don't have a symbols element in the game XML.
+richtext symbol sizes will properly scale with the font size they are placed in
+changed 'hide alternates' to 'show alternates' in deck editor for clarity
+the 'show alternates' deck editor toggle state is now saved in config


### PR DESCRIPTION
o8build will give a more useful error if you use richtext symbols in a set but don't have a symbols element in the game XML.

richtext symbol sizes will properly scale with the font size they are placed in

changed 'hide alternates' to 'show alternates' in deck editor for clarity

the 'show alternates' deck editor toggle state is now saved in config