### PR TITLE
Card focus feature and updates to in-game dialog windows

### DIFF
--- a/octgnFX/Octgn.JodsEngine/Play/Card.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/Card.cs
@@ -244,6 +244,7 @@ namespace Octgn.Play
                 Size = Program.GameEngine.Definition.CardSizes[cardsize];
             else
                 Size = Program.GameEngine.Definition.DefaultSize();
+            Program.GameEngine.CardFocusEvent += new EventHandler(CheckCardFocus);
         }
 
         internal override int Id
@@ -500,6 +501,7 @@ namespace Octgn.Play
                 Program.Client.Rpc.Filter(this, value);
             }
         }
+
         public string FilterColorString
         {
             get
@@ -516,6 +518,20 @@ namespace Octgn.Play
             get { return _filter != null; }
         }
 
+        private void CheckCardFocus(object sender, EventArgs e)
+        {
+            OnPropertyChanged("HasFocus");
+        }
+
+        public bool HasFocus
+        {
+            get
+            {
+                if (Program.GameEngine.FocusedCards.Count() == 0)
+                    return true;
+                return Program.GameEngine.FocusedCards.Contains(this);
+            }
+        }
         public Dictionary<PropertyDef, object> CurrentCardProperties
         {
             get

--- a/octgnFX/Octgn.JodsEngine/Play/Gui/CardControl.xaml
+++ b/octgnFX/Octgn.JodsEngine/Play/Gui/CardControl.xaml
@@ -109,6 +109,13 @@
                         </MultiBinding>
                     </Rectangle.Fill>
                 </Rectangle>
+                
+                <Rectangle Visibility="{Binding HasFocus, Converter={StaticResource InvertedBooleanToVisibilityConverter}}" 
+                           Fill="{StaticResource TransControlBackgroundBrush}" MouseLeftButtonDown="LeftButtonDownOverImage">
+                    <Rectangle.OpacityMask>
+                        <VisualBrush Visual="{Binding ElementName=img}" Stretch="None" />
+                    </Rectangle.OpacityMask>
+                </Rectangle>
 
                 <StackPanel Margin="0,8,1,0" HorizontalAlignment="Right" VerticalAlignment="Top">
                     <Border x:Name="peekEye" Background="#80000000" CornerRadius="5,0,0,5" Visibility="{Binding PeekingPlayers.Count, Converter={StaticResource CountConverter}}">

--- a/octgnFX/Octgn.JodsEngine/Play/State/GameEngine.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/State/GameEngine.cs
@@ -791,6 +791,22 @@ namespace Octgn
         }
 
 
+        public event EventHandler CardFocusEvent;
+
+        public IEnumerable<Card> FocusedCards = Enumerable.Empty<Card>();
+        public void EnableCardFocus(IEnumerable<Card> cards)
+        {
+            if (FocusedCards.SequenceEqual(cards)) return;
+            FocusedCards = cards;
+            CardFocusEvent?.Invoke(this, null);
+        }
+
+        public void ClearCardFocus()
+        {
+            if (FocusedCards.Count() == 0) return;
+            FocusedCards = Enumerable.Empty<Card>();
+            CardFocusEvent?.Invoke(this, null);
+        }
 
         //Temporarily store group visibility information for LoadDeck. //bug (google) #20
 

--- a/octgnFX/Octgn.JodsEngine/Scripting/Controls/ChoiceDlg.xaml
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Controls/ChoiceDlg.xaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:Octgn.Controls"
         Style="{StaticResource Window}" MinWidth="330" CanResize="False"
-        SizeToContent="WidthAndHeight"  ResizeMode="NoResize" ShowInTaskbar="False" WindowStartupLocation="CenterOwner">
+        SizeToContent="WidthAndHeight"  ResizeMode="NoResize" ShowInTaskbar="False">
 
     <StackPanel Orientation="Vertical" x:Name="choiceWindow">
         <Border Style="{StaticResource DarkPanel}" Margin="8">

--- a/octgnFX/Octgn.JodsEngine/Scripting/Controls/ChoiceDlg.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Controls/ChoiceDlg.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Collections.Generic;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace Octgn.Scripting.Controls
 {
@@ -17,6 +18,9 @@ namespace Octgn.Scripting.Controls
             InitializeComponent();
             //fix MAINWINDOW bug
             Owner = WindowManager.PlayWindow;
+            Left = Owner.PointToScreen(Mouse.GetPosition(Owner)).X;
+            Top = Owner.PointToScreen(Mouse.GetPosition(Owner)).Y;
+
             Title = title;
             promptLbl.Text = prompt;
             int count = 0;

--- a/octgnFX/Octgn.JodsEngine/Scripting/Controls/InputDlg.xaml
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Controls/InputDlg.xaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:Octgn.Controls"
         Style="{StaticResource Window}" Width="330"
-        SizeToContent="Height" ResizeMode="NoResize" ShowInTaskbar="False" WindowStartupLocation="CenterOwner" CanResize="False">
+        SizeToContent="Height" ResizeMode="NoResize" ShowInTaskbar="False" CanResize="False">
   <StackPanel Orientation="Vertical">
 
         <Border Style="{StaticResource DarkPanel}" Margin="8">

--- a/octgnFX/Octgn.JodsEngine/Scripting/Controls/InputDlg.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Controls/InputDlg.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Windows;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 
@@ -16,6 +17,8 @@ namespace Octgn.Scripting.Controls
             InitializeComponent();
             //fix MAINWINDOW bug
             Owner = WindowManager.PlayWindow;
+            Left = Owner.PointToScreen(Mouse.GetPosition(Owner)).X;
+            Top = Owner.PointToScreen(Mouse.GetPosition(Owner)).Y;
             Title = title;
             promptLbl.Text = prompt;
             inputBox.Text = defaultValue;

--- a/octgnFX/Octgn.JodsEngine/Scripting/Controls/SelectCardsDlg.xaml
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Controls/SelectCardsDlg.xaml
@@ -5,7 +5,7 @@
 
   <Window.Resources>
     <DataTemplate x:Key="CardTemplate">
-      <Image HorizontalAlignment="Center" Loaded="SetPicture" />
+      <Image HorizontalAlignment="Center" Loaded="SetPicture" MouseEnter="ItemMouseEnter" MouseLeave="ItemMouseLeave" />
     </DataTemplate>
 
     <Style x:Key="WrapListBox" TargetType="{x:Type ListBox}" BasedOn="{StaticResource PanelListBox}">
@@ -49,7 +49,7 @@
                  TextChanged="FilterChanged" Keyboard.PreviewKeyDown="PreviewFilterKeyDown" />
         <ListBox x:Name="allList" Margin="0,5,0,0" VerticalAlignment="Stretch" Grid.Row="1" Grid.ColumnSpan="3"
                  Style="{StaticResource WrapListBox}" ItemTemplate="{StaticResource CardTemplate}" SelectionChanged="CardSelected"
-                 MouseDoubleClick="SelectClicked">
+                 MouseDoubleClick="SelectClicked" >
           <ListBox.ItemsPanel>
             <ItemsPanelTemplate>
               <ctrl:VirtualizingWrapPanel ChildHeight="250" Loaded="ComputeChildWidth" />

--- a/octgnFX/Octgn.JodsEngine/Scripting/Controls/SelectCardsDlg.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Controls/SelectCardsDlg.xaml.cs
@@ -135,5 +135,29 @@ namespace Octgn.Scripting.Controls
             var panel = sender as VirtualizingWrapPanel;
             if (panel != null) panel.ChildWidth = panel.ChildHeight * Program.GameEngine.Definition.DefaultSize().Width / Program.GameEngine.Definition.DefaultSize().Height;
         }
+
+        private object hoveredCard;
+        private void ItemMouseEnter(object sender, MouseEventArgs e)
+        {
+            var img = sender as Image;
+            if (img == null) return;
+            var card = (img.DataContext as Card);
+            if (hoveredCard == null)
+            {
+                hoveredCard = card;
+                Program.GameEngine.EnableCardFocus(new Card[] { card });
+            }
+
+        }
+
+        private void ItemMouseLeave(object sender, MouseEventArgs e)
+        {
+
+            if (hoveredCard != null)
+            {
+                hoveredCard = null;
+                Program.GameEngine.ClearCardFocus();
+            }
+        }
     }
 }

--- a/octgnFX/Octgn.JodsEngine/Scripting/Controls/SelectMultiCardsDlg.xaml
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Controls/SelectMultiCardsDlg.xaml
@@ -5,7 +5,7 @@
 
     <Window.Resources>
         <DataTemplate x:Key="CardTemplate">
-            <Image HorizontalAlignment="Center" Loaded="SetPicture" />
+            <Image HorizontalAlignment="Center" Loaded="SetPicture" MouseEnter="ItemMouseEnter" MouseLeave="ItemMouseLeave" />
         </DataTemplate>
 
         <Style x:Key="CardListBox" TargetType="ListBoxItem">

--- a/octgnFX/Octgn.JodsEngine/Scripting/Controls/SelectMultiCardsDlg.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Controls/SelectMultiCardsDlg.xaml.cs
@@ -242,6 +242,29 @@ namespace Octgn.Scripting.Controls
             SliderHeight = slider.Value;
             SliderWidth = slider.Value * Program.GameEngine.Definition.DefaultSize().Width / Program.GameEngine.Definition.DefaultSize().Height;
         }
+        
+        private object hoveredCard;
+        private void ItemMouseEnter(object sender, MouseEventArgs e)
+        {
+            var img = sender as Image;
+            if (img == null) return;
+            var card = Card.Find((int)img.DataContext);
+            if (hoveredCard == null)
+            {
+                hoveredCard = card;
+                Program.GameEngine.EnableCardFocus(new Card[] { card });
+            }
+
+        }
+        private void ItemMouseLeave(object sender, MouseEventArgs e)
+        {
+
+            if (hoveredCard != null)
+            {
+                hoveredCard = null;
+                Program.GameEngine.ClearCardFocus();
+            }
+        }
 
         #region dragDrop Stuff
 

--- a/octgnFX/Octgn.JodsEngine/Scripting/Versions/3.1.0.2.py
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Versions/3.1.0.2.py
@@ -66,7 +66,7 @@ def getActivePlayer():
 
 def setActivePlayer(player = None):
 	if player == None:
-		 _api.SetActivePlayer()
+		_api.SetActivePlayer()
 	else:
 		_api.SetActivePlayer(player._id)
 
@@ -176,6 +176,20 @@ def queryCard(properties = {}, exact = False):
 	apiResult = _api.QueryCard(realDict,exact)
 	if apiResult == None: return []
 	return [x for x in apiResult]
+
+def focus(cards = None):
+	if (cards == None):
+		_api.ClearFocus()
+	else:
+		_api.Focus(List[int](c._id for c in cards))
+
+def clearFocus():
+	_api.ClearFocus()
+
+def getFocus():
+	ret = _api.GetFocusedCards()
+	if ret == None: return None
+	return [Card(x) for x in _api.GetFocusedCards()]
 
 def getGlobalVariable(gname):
 	return _api.GetGlobalVariable(gname)

--- a/octgnFX/Octgn.JodsEngine/Scripting/Versions/Script_3_1_0_2.cs
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Versions/Script_3_1_0_2.cs
@@ -672,6 +672,25 @@ namespace Octgn.Scripting.Versions
             QueueAction(() => card.HighlightColor = value);
         }
 
+        public void Focus(List<int> idList)
+        {
+            var cards = idList.Select(x => Card.Find(x));
+
+            QueueAction(() => Program.GameEngine.EnableCardFocus(cards));
+        }
+
+        public void ClearFocus()
+        {
+            QueueAction(() => Program.GameEngine.ClearCardFocus());
+        }
+
+        public List<int> GetFocusedCards()
+        {
+            var list = Program.GameEngine.FocusedCards.Select(x => x.Id).ToList();
+
+            return list;
+        }
+
         public string CardGetFilter(int id)
         {
             Color? colorOrNull = Card.Find(id).FilterColor;

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,1 @@
-
+choiceDlg and inputDlg API now pop up next to the mouse cursor (instead of in the middle of the screen)

--- a/recentchanges.txt
+++ b/recentchanges.txt
@@ -1,1 +1,6 @@
 choiceDlg and inputDlg API now pop up next to the mouse cursor (instead of in the middle of the screen)
+Card Focus feature added, which darkens all cards on the table except for a specified list of cards
+Hovering over a card in the python API SelectCards or SelectMultiCards dialogs will Focus that card in play
+New Python API - focus([list of cards]) will Focus those cards
+New Python API - clearFocus() will clear the Focus state
+New Python API - getFocus() will return a list of Focused cards


### PR DESCRIPTION
Adds a card focus feature which darkens all cards in play (table, hand or piles) which aren't in the focus list.  NOTE that this does NOT network  to other players -- it stays local.
Added python controls to focus cards.
Hovering over cards in the SelectCards or SelectMultiCards python API dialogs will focus that card in play.

Also updates the inputDlg and choiceDlg API dialog boxes to pop open underneath the mouse cursor position, instead of in the middle of the play window.