### PR TITLE
Szefo patches

### DIFF
--- a/octgnFX/Octgn.DataNew/CardPropertyComparer.cs
+++ b/octgnFX/Octgn.DataNew/CardPropertyComparer.cs
@@ -10,6 +10,8 @@
     {
         private readonly PropertyDef _property;
 
+        public PropertyDef Property { get { return _property; } }
+
         public CardPropertyComparer(PropertyDef property)
         {
             _property = property;
@@ -35,9 +37,35 @@
             x.PropertySets[x.Alternate].Properties.TryGetValue(_property, out object px);
             y.PropertySets[y.Alternate].Properties.TryGetValue(_property, out object py);
             if (px == null) return py == null ? 0 : -1;
+            if (int.TryParse(px.ToString(), out int px2) && int.TryParse(py.ToString(), out int py2))
+            {
+                return px2.CompareTo(py2);
+            }
             return px.ToString().CompareTo(py.ToString());
         }
 
         #endregion
     }
+    public class CompoundComparer : IComparer
+    {
+        private readonly IComparer first;
+        private readonly IComparer second;
+
+        public CompoundComparer(IComparer first, IComparer second)
+        {
+            this.first = first;
+            this.second = second;
+        }
+
+        public int Compare(object x, object y)
+        {
+            int result = this.first.Compare(x, y);
+            if (result != 0)
+            {
+                return result;
+            }
+            return second.Compare(x, y);
+        }
+    }
+
 }

--- a/octgnFX/Octgn.JodsEngine/Play/Dialogs/LimitedDialog.xaml
+++ b/octgnFX/Octgn.JodsEngine/Play/Dialogs/LimitedDialog.xaml
@@ -1,7 +1,15 @@
-﻿<Window x:Class="Octgn.Play.Dialogs.LimitedDialog" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" x:Name="This" Title="Start a limited game" Width="541"
+<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:Controls="clr-namespace:Octgn.Controls" x:Class="Octgn.Play.Dialogs.LimitedDialog" x:Name="This" Title="Start a limited game" Width="541"
         Style="{StaticResource Window}" ShowInTaskbar="False" WindowStartupLocation="CenterOwner" SizeToContent="Height">
-  <Border Style="{StaticResource Panel}" Margin="4">
+    <Border Style="{StaticResource Panel}" Margin="4" RenderTransformOrigin="0.5,0.5">
+        <Border.RenderTransform>
+            <TransformGroup>
+                <ScaleTransform ScaleY="1"/>
+                <SkewTransform/>
+                <RotateTransform/>
+                <TranslateTransform/>
+            </TransformGroup>
+        </Border.RenderTransform>
         <Grid Margin="8">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" MinWidth="100" />
@@ -14,12 +22,7 @@
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <TextBlock Text="Kind of game:" Margin="2" />
-            <TextBlock Grid.Column="1" Margin="2">
-              <Bold>Sealed</Bold>
-              <Italic>
-                (sorry, no other option in this release)
-              </Italic>
-            </TextBlock>
+            <TextBlock Grid.Column="1" Margin="2"><Bold><Run Text="Sealed"/></Bold><Run Text=" "/><Italic><Run Text="(sorry, no other option in this release)"/></Italic></TextBlock>
             <TextBlock Text="Packs:" Grid.Row="1" Margin="2" />
             <StackPanel Grid.Row="1" Grid.Column="1" Margin="2">
                 <Grid>

--- a/octgnFX/Octgn.JodsEngine/Play/Dialogs/LimitedDialog.xaml
+++ b/octgnFX/Octgn.JodsEngine/Play/Dialogs/LimitedDialog.xaml
@@ -2,66 +2,86 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" x:Name="This" Title="Start a limited game" Width="541"
         Style="{StaticResource Window}" ShowInTaskbar="False" WindowStartupLocation="CenterOwner" SizeToContent="Height">
   <Border Style="{StaticResource Panel}" Margin="4">
-    <Grid Margin="8">
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="Auto" MinWidth="100" />
-        <ColumnDefinition Width="*" />
-      </Grid.ColumnDefinitions>
-      <Grid.RowDefinitions>
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="*" />
-      </Grid.RowDefinitions>
-      <TextBlock Text="Kind of game:" Margin="2" />
-      <TextBlock Grid.Column="1" Margin="2">
-        <Bold>Sealed</Bold>
-        <Italic>
-          (sorry, no other option in this release)
-        </Italic>
-      </TextBlock>
-      <TextBlock Text="Packs:" Grid.Row="1" Margin="2" />
-      <StackPanel Grid.Row="1" Grid.Column="1" Margin="2">
-        <Grid>
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-          </Grid.ColumnDefinitions>
-          <ComboBox x:Name="setsCombo" ItemsSource="{Binding Sets, ElementName=This, Mode=OneTime}"
+        <Grid Margin="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" MinWidth="100" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <TextBlock Text="Kind of game:" Margin="2" />
+            <TextBlock Grid.Column="1" Margin="2">
+              <Bold>Sealed</Bold>
+              <Italic>
+                (sorry, no other option in this release)
+              </Italic>
+            </TextBlock>
+            <TextBlock Text="Packs:" Grid.Row="1" Margin="2" />
+            <StackPanel Grid.Row="1" Grid.Column="1" Margin="2">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ComboBox x:Name="setsCombo" ItemsSource="{Binding Sets, ElementName=This, Mode=OneTime}"
                     DisplayMemberPath="Name" VerticalContentAlignment="Center" />
-          <ComboBox x:Name="packsCombo" Grid.Column="1" Margin="2,0"
-                    ItemsSource="{Binding ElementName=setsCombo, Path=SelectedItem.Packs}"  DisplayMemberPath="Name" VerticalContentAlignment="Center" />
-          <Button Content="Add" FontSize="14" Grid.Column="2" Width="80" Padding="2" Click="AddSetClicked" Style="{StaticResource FlatDarkButtonStyle}"/>
-        </Grid>
-        <ListBox ItemsSource="{Binding Packs, ElementName=This, Mode=OneTime}" Margin="0,4,0,0" MinHeight="100" ScrollViewer.VerticalScrollBarVisibility="Auto" MaxHeight="300">
-          <ListBox.ItemTemplate>
-            <DataTemplate>
-              <StackPanel Orientation="Horizontal" Background="Transparent">
-                <Button VerticalAlignment="Center" Margin="2,0,5,0" Cursor="Hand" Click="RemoveClicked">
-                  <Button.Template>
-                    <ControlTemplate>
-                      <Border Background="Transparent">
-                        <Path Data="M 0,0 L 12,12 M 12,0 L 0,12" Stroke="#e84000" StrokeThickness="3" />
-                      </Border>
-                    </ControlTemplate>
-                  </Button.Template>
-                </Button>
-                <TextBlock Text="{Binding FullName, Mode=OneTime}" />
-              </StackPanel>
-            </DataTemplate>
-          </ListBox.ItemTemplate>
-        </ListBox>
-      </StackPanel>
-      <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.ColumnSpan="2" HorizontalAlignment="Right"
+                    <ComboBox x:Name="packsCombo" Grid.Column="1" Margin="2,0"
+                    ItemsSource="{Binding SelectedItem.Packs, ElementName=setsCombo}"  DisplayMemberPath="Name" VerticalContentAlignment="Center" />
+                    <Button Content="Add" FontSize="14" Grid.Column="2" Width="80" Padding="2" Click="AddSetClicked" Style="{StaticResource FlatDarkButtonStyle}"/>
+                    <Controls:NumericUpDown x:Name="packsAmount"  FontSize="14" Grid.Column="3" Minimum="1" Margin="4,3,0,3" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto" Maximum="120" RenderTransformOrigin="0.5,0.5" >
+                        <Controls:NumericUpDown.LayoutTransform>
+                            <TransformGroup>
+                                <ScaleTransform ScaleX="1" ScaleY="1"/>
+                                <SkewTransform/>
+                                <RotateTransform/>
+                                <TranslateTransform/>
+                            </TransformGroup>
+                        </Controls:NumericUpDown.LayoutTransform>
+                        <Controls:NumericUpDown.RenderTransform>
+                            <TransformGroup>
+                                <ScaleTransform ScaleX="1.1" ScaleY="1.3"/>
+                                <SkewTransform/>
+                                <RotateTransform/>
+                                <TranslateTransform X="0" Y="0"/>
+                            </TransformGroup>
+                        </Controls:NumericUpDown.RenderTransform>
+                    </Controls:NumericUpDown>
+
+                </Grid>
+                <ListBox ItemsSource="{Binding Packs, ElementName=This, Mode=OneTime}" Margin="0,4,0,0" MinHeight="100" ScrollViewer.VerticalScrollBarVisibility="Auto" MaxHeight="300">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal" Background="Transparent">
+                                <Button VerticalAlignment="Center" Margin="2,0,5,0" Cursor="Hand" Click="RemoveClicked">
+                                    <Button.Template>
+                                        <ControlTemplate>
+                                            <Border Background="Transparent">
+                                                <Path Data="M 0,0 L 12,12 M 12,0 L 0,12" Stroke="#e84000" StrokeThickness="3" />
+                                            </Border>
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                                <TextBlock Text="{Binding FullName, Mode=OneTime}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.ColumnSpan="2" HorizontalAlignment="Right"
                   VerticalAlignment="Top" Margin="0,16,0,4">
-        <ComboBox x:Name="addCards" VerticalContentAlignment="Center" Margin="0,0,8,0" Width="Auto" SelectedIndex="0" Visibility="Hidden">
-                    <ComboBoxItem>Add packs to my Limited Pool</ComboBoxItem>
-                    <ComboBoxItem>Add packs to everyone's Limited Pool</ComboBoxItem>
+                <ComboBox x:Name="addCards" VerticalContentAlignment="Center" Margin="0,0,8,0" Width="Auto" SelectedIndex="0" Visibility="Hidden">
+                    <ComboBoxItem Content="Add packs to my Limited Pool"/>
+                    <ComboBoxItem Content="Add packs to everyone's Limited Pool"/>
                 </ComboBox>
-        <Button Content="OK" FontSize="14" Click="StartClicked" Margin="0,0,8,0" Width="100" Style="{StaticResource FlatDarkGreenButtonStyle}" />
-        <Button Content="Cancel" FontSize="14" Click="CancelClicked" Width="100" Style="{StaticResource FlatDarkButtonStyle}"/>
-      </StackPanel>
-    </Grid>
-  </Border>
+                <Button Content="OK" FontSize="14" Click="StartClicked" Margin="0,0,8,0" Width="100" Style="{StaticResource FlatDarkGreenButtonStyle}" />
+                <Button Content="Cancel" FontSize="14" Click="CancelClicked" Width="100" Style="{StaticResource FlatDarkButtonStyle}"/>
+            </StackPanel>
+        </Grid>
+    </Border>
 </Window>

--- a/octgnFX/Octgn.JodsEngine/Play/Dialogs/LimitedDialog.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/Dialogs/LimitedDialog.xaml.cs
@@ -41,7 +41,10 @@ namespace Octgn.Play.Dialogs
             // WPF ListBox doesn't like having multiple copies of the same 
             // instance and messes up selection
             var pack = (DataNew.Entities.Pack) packsCombo.SelectedItem;
-            Packs.Add(new SelectedPack {Id = pack.Id, FullName = pack.GetFullName()});
+            for (int i = 0; i < packsAmount.Value; i++)
+            {
+                Packs.Add(new SelectedPack {Id = pack.Id, FullName = pack.GetFullName()});
+            }
         }
 
         private void StartClicked(object sender, RoutedEventArgs e)

--- a/octgnFX/Octgn.JodsEngine/Play/Dialogs/PickCardsDialog.xaml
+++ b/octgnFX/Octgn.JodsEngine/Play/Dialogs/PickCardsDialog.xaml
@@ -148,11 +148,11 @@ Template="{StaticResource ExpanderButton}" />
 
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="3*" />
-            <ColumnDefinition Width="2*" />
+            <ColumnDefinition Width="59*" />
+            <ColumnDefinition Width="30*" />
         </Grid.ColumnDefinitions>
 
-        <TabControl x:Name="TabControlMain" Margin="4">
+        <TabControl x:Name="TabControlMain" Margin="4,4,4,4">
             <TabItem HeaderStringFormat="Card pool ({0})"
                Header="{Binding CardPool.Count, ElementName=This, FallbackValue=0}">
                 <Grid>
@@ -177,6 +177,7 @@ Template="{StaticResource ExpanderButton}" />
                                   DisplayMemberPath="Key" MinWidth="100"/>
                         <Grid Margin="0,0,5,0"/>
                         <Button Content="Move" Width="50" Click="ButtonMoveClick" Style="{StaticResource FlatDarkButtonStyle}"/>
+                        <Button Content="Return" Width="50" Click="ButtonReturnClick" Style="{StaticResource FlatDarkButtonStyle}"/>
                     </StackPanel>
                     <ProgressBar x:Name="ProgressBarLoading" Visibility="Visible" Height="20" Grid.Row="1" Grid.ColumnSpan="2"/>
                     <Border x:Name="FilterListBox" Style="{StaticResource ControlBorder}" Padding="0" Margin="0,2,0,0" Width="200" Grid.Row="2" Grid.Column="0">
@@ -195,7 +196,7 @@ Template="{StaticResource ExpanderButton}" />
             </TabItem>
         </TabControl>
 
-        <GridSplitter HorizontalAlignment="Right" Width="4" Background="Transparent" />
+        <GridSplitter HorizontalAlignment="Left" Width="4" Background="Transparent" Margin="487,0,0,0" />
 
         <TabControl x:Name="deckTabs" Grid.Column="1" Margin="0,4,4,4"
                 ItemsSource="{Binding Path=LimitedDeck.Sections, ElementName=This, Mode=OneTime}">
@@ -219,8 +220,8 @@ Template="{StaticResource ExpanderButton}" />
             </TabControl.ContentTemplate>
         </TabControl>
 
-        <Popup x:Name="quantityPopup" Placement="Mouse" StaysOpen="False" AllowsTransparency="True" Width="170"
-           PopupAnimation="Fade">
+        <Popup x:Name="quantityPopup" Placement="Mouse" StaysOpen="False" AllowsTransparency="True"
+           PopupAnimation="Fade" Margin="160,0,161,0">
             <Border CornerRadius="5" BorderThickness="1" BorderBrush="#E0888888" Background="#E0FFFFFF" Margin="8">
                 <Border.Effect>
                     <DropShadowEffect Opacity="0.4" />

--- a/octgnFX/Octgn.JodsEngine/Play/Gui/CardControl.xaml
+++ b/octgnFX/Octgn.JodsEngine/Play/Gui/CardControl.xaml
@@ -109,9 +109,36 @@
                         </MultiBinding>
                     </Rectangle.Fill>
                 </Rectangle>
-                
-                <Rectangle Visibility="{Binding HasFocus, Converter={StaticResource InvertedBooleanToVisibilityConverter}}" 
-                           Fill="{StaticResource TransControlBackgroundBrush}" MouseLeftButtonDown="LeftButtonDownOverImage">
+
+                <Rectangle Fill="{StaticResource TransControlBackgroundBrush}" MouseLeftButtonDown="LeftButtonDownOverImage">
+                    <Rectangle.Style>
+                        <Style TargetType="Rectangle">
+                            <Style.Resources>
+                                <Storyboard x:Key="FadeOut">
+                                    <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity">
+                                        <LinearDoubleKeyFrame KeyTime="0:0:0.35" Value="0"/>
+                                    </DoubleAnimationUsingKeyFrames>
+                                </Storyboard>
+                                <Storyboard x:Key="FadeIn">
+                                    <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity">
+                                        <LinearDoubleKeyFrame KeyTime="0:0:0.35" Value="1"/>
+                                    </DoubleAnimationUsingKeyFrames>
+                                </Storyboard>
+                            </Style.Resources>
+
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasFocus}" Value="True">
+                                    <DataTrigger.EnterActions>
+                                        <BeginStoryboard Storyboard="{StaticResource FadeOut}"/>
+                                    </DataTrigger.EnterActions>
+                                    <DataTrigger.ExitActions>
+                                        <BeginStoryboard Storyboard="{StaticResource FadeIn}"/>
+                                    </DataTrigger.ExitActions>
+                                </DataTrigger>
+                            </Style.Triggers>
+                            <Setter Property="Opacity" Value="{Binding HasFocus, Converter={StaticResource InvertedBooleanToOpacityConverter}}"/>
+                        </Style>
+                    </Rectangle.Style>
                     <Rectangle.OpacityMask>
                         <VisualBrush Visual="{Binding ElementName=img}" Stretch="None" />
                     </Rectangle.OpacityMask>
@@ -184,3 +211,4 @@
         </ContentControl>
     </Border>
 </UserControl>
+    

--- a/octgnFX/Octgn.JodsEngine/Play/Gui/TableCanvas.cs
+++ b/octgnFX/Octgn.JodsEngine/Play/Gui/TableCanvas.cs
@@ -146,16 +146,20 @@ namespace Octgn.Play.Gui
             CardControl card = (from ContentPresenter child in Children
                                 where child.DataContext == targetAction.FromCard
                                 select VisualTreeHelper.GetChild(child, 0) as CardControl).FirstOrDefault();
-            if (card == null) return; // Opponent moved the card out of the table concurently
-
-            AdornerLayer layer = AdornerLayer.GetAdornerLayer(card);
-            Adorner[] adorners = layer.GetAdorners(card);
-            if (adorners == null) return; // Opponent removed the target card out of the table concurently
-            foreach (ArrowAdorner arrow in adorners.OfType<ArrowAdorner>())
+            if (card != null)
             {
-                layer.Remove(arrow);
-            }
+                AdornerLayer layer = AdornerLayer.GetAdornerLayer(card);
+                Adorner[] adorners = layer.GetAdorners(card);
+                // Opponent removed the target card out of the table concurently
+                if (adorners != null)
+                {
+                    foreach (ArrowAdorner arrow in adorners.OfType<ArrowAdorner>())
+                    {
+                        layer.Remove(arrow);
+                    }
+                }
 
+            }
             targetAction.FromCard.TargetsOtherCards = false;
         }
     }

--- a/octgnFX/Octgn.JodsEngine/Resources/PlayResources.xaml
+++ b/octgnFX/Octgn.JodsEngine/Resources/PlayResources.xaml
@@ -10,6 +10,7 @@
     <gui:FilterColorConverter x:Key="FilterConverter" />
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <converters:BooleanToVisibileHiddenConverter x:Key="BooleanToVisibilityHiddenConverter"/>
+    <converters:InvertedBooleanToOpacityConverter x:Key="InvertedBooleanToOpacityConverter"/>
     <converters:UriToSafeImageConverter x:Key="UriToSafeImageConverter"/>
     <converters:BooleanToFontBoldConverter x:Key="BooleanToFontBoldConverter"></converters:BooleanToFontBoldConverter>
     <converters:InvertedBooleanToVisibilityConverter x:Key="InvertedBooleanToVisibilityConverter"/>

--- a/octgnFX/Octgn.JodsEngine/Scripting/Controls/ChoiceDlg.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Controls/ChoiceDlg.xaml.cs
@@ -17,9 +17,8 @@ namespace Octgn.Scripting.Controls
         {
             InitializeComponent();
             //fix MAINWINDOW bug
-            Owner = WindowManager.PlayWindow;
-            Left = Owner.Left + Mouse.GetPosition(Owner).X;
-            Top = Owner.Top + Mouse.GetPosition(Owner).Y;
+            this.Owner = WindowManager.PlayWindow;
+            this.SizeChanged += (sender, args) => CenterWindowInsideOwner();
 
             Title = title;
             promptLbl.Text = prompt;
@@ -62,6 +61,34 @@ namespace Octgn.Scripting.Controls
                 button.Uid = buttonName;
                 button.Click += Button_Click;
                 buttonField.Children.Add(button);
+            }
+        }
+
+        private void CenterWindowInsideOwner()
+        {
+            if (Owner != null)
+            {
+                double windowWidth = this.ActualWidth;
+                double windowHeight = this.ActualHeight;
+                var ownerPosition = new System.Drawing.Point((int)Owner.Left, (int)Owner.Top);
+                var ownerScreen = System.Windows.Forms.Screen.FromPoint(ownerPosition);
+                var screenBounds = ownerScreen.Bounds;
+
+                if (Owner.WindowState == WindowState.Maximized)
+                {
+                    this.Left = screenBounds.X + (screenBounds.Width - windowWidth) / 2;
+                    this.Top = screenBounds.Y + (screenBounds.Height - windowHeight) / 2;
+                }
+                else
+                {
+                    double ownerLeft = Owner.Left;
+                    double ownerTop = Owner.Top;
+                    double ownerWidth = Owner.ActualWidth;
+                    double ownerHeight = Owner.ActualHeight;
+
+                    this.Left = ownerLeft + (ownerWidth - windowWidth) / 2;
+                    this.Top = ownerTop + (ownerHeight - windowHeight) / 2;
+                }
             }
         }
 

--- a/octgnFX/Octgn.JodsEngine/Scripting/Controls/InputDlg.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Controls/InputDlg.xaml.cs
@@ -16,9 +16,8 @@ namespace Octgn.Scripting.Controls
         {
             InitializeComponent();
             //fix MAINWINDOW bug
-            Owner = WindowManager.PlayWindow;
-            Left = Owner.Left + Mouse.GetPosition(Owner).X;
-            Top = Owner.Top + Mouse.GetPosition(Owner).Y;
+            this.Owner = WindowManager.PlayWindow;
+            this.SizeChanged += (sender, args) => CenterWindowInsideOwner();
             Title = title;
             promptLbl.Text = prompt;
             inputBox.Text = defaultValue;
@@ -28,6 +27,34 @@ namespace Octgn.Scripting.Controls
                               inputBox.Focus();
                               inputBox.SelectAll();
                           };
+        }
+
+        private void CenterWindowInsideOwner()
+        {
+            if (Owner != null)
+            {
+                double windowWidth = this.ActualWidth;
+                double windowHeight = this.ActualHeight;
+                var ownerPosition = new System.Drawing.Point((int)Owner.Left, (int)Owner.Top);
+                var ownerScreen = System.Windows.Forms.Screen.FromPoint(ownerPosition);
+                var screenBounds = ownerScreen.Bounds;
+
+                if (Owner.WindowState == WindowState.Maximized)
+                {
+                    this.Left = screenBounds.X + (screenBounds.Width - windowWidth) / 2;
+                    this.Top = screenBounds.Y + (screenBounds.Height - windowHeight) / 2;
+                }
+                else
+                {
+                    double ownerLeft = Owner.Left;
+                    double ownerTop = Owner.Top;
+                    double ownerWidth = Owner.ActualWidth;
+                    double ownerHeight = Owner.ActualHeight;
+
+                    this.Left = ownerLeft + (ownerWidth - windowWidth) / 2;
+                    this.Top = ownerTop + (ownerHeight - windowHeight) / 2;
+                }
+            }
         }
 
         public int GetInteger()

--- a/octgnFX/Octgn.JodsEngine/Scripting/Engine.cs
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Engine.cs
@@ -460,7 +460,7 @@ namespace Octgn.Scripting
 
         private void ProcessExecutionQueue()
         {
-            do
+            while (_executionQueue.Count > 0)
             {
                 ScriptJobBase job = _executionQueue.Peek();
                 var scriptjob = job as ScriptJob;
@@ -495,14 +495,14 @@ namespace Octgn.Scripting
                 {
                     Program.GameMess.Warning("{0}", job.Result.Error.Trim());
                 }
-                if (job.Suspended) return;
+                if (job.Suspended) continue;
                 job.DispatcherSignal.Dispose();
                 job.WorkerSignal.Dispose();
                 _executionQueue.Dequeue();
 
                 if (job.Continuation != null)
                     job.Continuation(job.Result);
-            } while (_executionQueue.Count > 0);
+            };
         }
 
         private void Execute(Object state)

--- a/octgnFX/Octgn.JodsEngine/Scripting/Engine.cs
+++ b/octgnFX/Octgn.JodsEngine/Scripting/Engine.cs
@@ -460,7 +460,7 @@ namespace Octgn.Scripting
 
         private void ProcessExecutionQueue()
         {
-            while (_executionQueue.Count > 0)
+            do
             {
                 ScriptJobBase job = _executionQueue.Peek();
                 var scriptjob = job as ScriptJob;
@@ -495,14 +495,14 @@ namespace Octgn.Scripting
                 {
                     Program.GameMess.Warning("{0}", job.Result.Error.Trim());
                 }
-                if (job.Suspended) continue;
+                if (job.Suspended) return;
                 job.DispatcherSignal.Dispose();
                 job.WorkerSignal.Dispose();
                 _executionQueue.Dequeue();
 
                 if (job.Continuation != null)
                     job.Continuation(job.Result);
-            };
+            } while (_executionQueue.Count > 0);
         }
 
         private void Execute(Object state)

--- a/octgnFX/Octgn.JodsEngine/Utils/Converters/BooleanToVisibleHiddenConverter.cs
+++ b/octgnFX/Octgn.JodsEngine/Utils/Converters/BooleanToVisibleHiddenConverter.cs
@@ -33,7 +33,6 @@
             return value is FontWeight && (FontWeight)value == FontWeights.Bold;
         }
     }
-
     public class InvertedBooleanToVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
@@ -46,6 +45,24 @@
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             return value is Visibility && (Visibility)value == Visibility.Collapsed;
+        }
+    }
+    public class InvertedBooleanToOpacityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var boolean = false;
+            if (value is bool) boolean = (bool)value;
+            return boolean ? 0 : 1;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null){
+                return true;
+            }
+            
+            return value is double && (double)value == 0.0;
         }
     }
 }

--- a/octgnFX/Octgn/Resources/PlayResources.xaml
+++ b/octgnFX/Octgn/Resources/PlayResources.xaml
@@ -6,5 +6,6 @@
     <converters:BooleanToVisibileHiddenConverter x:Key="BooleanToVisibilityHiddenConverter"/>
     <converters:BooleanToFontBoldConverter x:Key="BooleanToFontBoldConverter"></converters:BooleanToFontBoldConverter>
     <converters:InvertedBooleanToVisibilityConverter x:Key="InvertedBooleanToVisibilityConverter"/>
+    <converters:InvertedBooleanToOpacityConverter x:Key="InvertedBooleanToOpacityConverter"/>
     <converters:BooleanInverterConverter x:Key="BooleanInverterConverter"/>
 </ResourceDictionary>

--- a/octgnFX/Octgn/Utils/Converters/BooleanToVisibleHiddenConverter.cs
+++ b/octgnFX/Octgn/Utils/Converters/BooleanToVisibleHiddenConverter.cs
@@ -33,7 +33,6 @@
             return value is FontWeight && (FontWeight)value == FontWeights.Bold;
         }
     }
-
     public class InvertedBooleanToVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
@@ -46,6 +45,24 @@
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             return value is Visibility && (Visibility)value == Visibility.Collapsed;
+        }
+    }
+    public class InvertedBooleanToOpacityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var boolean = false;
+            if (value is bool) boolean = (bool)value;
+            return boolean ? 0 : 1;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null){
+                return true;
+            }
+            
+            return value is double && (double)value == 0.0;
         }
     }
 }


### PR DESCRIPTION
Fixes/Changes included:
- Add a Fade-In/Fade-Out for Focused cards.
- Fix issue caused by null reference exception when trying to join password protected rooms, and center every input and choice dialog window
- Fix issue caused by skipping `targetAction.FromCard.TargetsOtherCards = false;`.
- Add a more accurate sorting to Limited Game Window (sorting by two last choices).
- Add a Return button to quickly return all cards in Deck to Limited Card Pool.
![{75E67532-6793-48DA-9DF7-B676AC9176ED}](https://github.com/user-attachments/assets/8746d5e6-994b-4b31-b46e-b85c66b80ff6)

- Attempt to sort the filters in Limited Game more naturally (instead of sorting 1->10->2, we try to sort 1->2->10 if possible):
![{E3B817CC-740A-4B0B-BE3E-8B1D3FD84389}](https://github.com/user-attachments/assets/74f9b761-2224-4a11-be8e-4eb68c74f7ba)
![{EA622410-058A-456A-9BF7-F7FCF4B7945C}](https://github.com/user-attachments/assets/a404d3c9-5c57-48b2-8329-992a6e92378d)

- Allow adding more than one Pack at a time in the Start Limited Game window:
![{B4F5E8C8-6F4D-48EF-B177-E94ABB3980F1}](https://github.com/user-attachments/assets/4e269d97-5052-465e-9f4f-5ae6dae0dca6)

