### PR TITLE
Add Heat file list generator with GUID preservation

### DIFF
--- a/deploy/Heat-FileList-README.md
+++ b/deploy/Heat-FileList-README.md
@@ -1,0 +1,38 @@
+# Heat File List Generator
+
+Scripts to update the WiX installer file list while preserving component GUIDs.
+
+## Quick Start
+
+```cmd
+# Build your app first
+msbuild octgnFX\Octgn\Octgn.csproj /p:Configuration=Debug
+
+# Update heat file list
+deploy\update-heat-filelist.bat
+
+# Build installer
+msbuild octgnFX\Octgn.Installer\Octgn.Installer.wixproj
+```
+
+## Scripts
+
+- **`update-heat-filelist.bat`** - Simple wrapper (use this)
+- **`Update-HeatFileList.ps1`** - PowerShell script that does the work
+
+## Why Use This?
+
+- ✅ Preserves existing component GUIDs (upgrade compatibility)
+- ✅ Only regenerates when files actually change
+- ✅ Shows exactly what's new/removed/modified
+- ✅ Filters out .pdb/.xml files like the installer does
+
+## Options
+
+```cmd
+update-heat-filelist.bat Debug    # Debug config
+update-heat-filelist.bat Release  # Release config  
+update-heat-filelist.bat -Force   # Force regeneration
+```
+
+Run this whenever you add/remove files from your application.

--- a/deploy/Update-HeatFileList.ps1
+++ b/deploy/Update-HeatFileList.ps1
@@ -1,0 +1,402 @@
+param(
+    [string]$Configuration = "Debug",
+    [string]$WixToolPath = "",
+    [switch]$Force
+)
+
+<#
+.SYNOPSIS
+    Updates the Heat-generated file list while preserving existing GUIDs.
+
+.DESCRIPTION
+    This script uses WiX Heat.exe to generate a new file list from the built application,
+    but preserves existing component GUIDs to maintain upgrade compatibility.
+
+.PARAMETER Configuration
+    The build configuration (Debug or Release). Default is Debug.
+
+.PARAMETER WixToolPath
+    Path to WiX tools directory. If not specified, will attempt to find automatically.
+
+.PARAMETER Force
+    Force regeneration even if target files are newer than source files.
+
+.EXAMPLE
+    .\Update-HeatFileList.ps1 -Configuration Release
+    .\Update-HeatFileList.ps1 -Configuration Debug -Force
+#>
+
+# Set error handling
+$ErrorActionPreference = "Stop"
+
+# Get script directory and set paths
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootPath = Split-Path -Parent $ScriptDir
+$InstallerLibPath = Join-Path $RootPath "octgnFX\Octgn.InstallerLib"
+$OctgnBinPath = Join-Path $RootPath "octgnFX\Octgn\bin\$Configuration"
+$HeatOutputFile = Join-Path $InstallerLibPath "HeatGeneratedFileList.wxs"
+$XsltTransformFile = Join-Path $InstallerLibPath "HeatGeneratedFileList.xslt"
+$TempHeatFile = Join-Path $InstallerLibPath "HeatGeneratedFileList.temp.wxs"
+
+Write-Host "OCTGN Heat File List Generator" -ForegroundColor Green
+Write-Host "===============================" -ForegroundColor Green
+Write-Host "Configuration: $Configuration"
+Write-Host "Root Path: $RootPath"
+Write-Host "Octgn Bin Path: $OctgnBinPath"
+Write-Host "Heat Output: $HeatOutputFile"
+Write-Host ""
+
+# Check if source directory exists
+if (-not (Test-Path $OctgnBinPath)) {
+    Write-Error "Source directory not found: $OctgnBinPath`nPlease build the Octgn project first in $Configuration configuration."
+}
+
+# Check if we need to update (unless Force is specified)
+if (-not $Force -and (Test-Path $HeatOutputFile)) {
+    Write-Host "Analyzing if regeneration is needed..." -ForegroundColor Yellow    # Get current file list from bin directory (filtered like XSLT does)
+    $CurrentFiles = @{}
+    $FilteredFiles = @{}
+    Get-ChildItem $OctgnBinPath -Recurse -File | ForEach-Object {
+        $RelativePath = $_.FullName.Substring($OctgnBinPath.Length + 1)
+        
+        # Apply same filters as XSLT transform
+        $shouldInclude = $true
+        $filterReason = ""
+        
+        # Filter out .pdb files
+        if ($_.Extension -eq ".pdb") {
+            $shouldInclude = $false
+            $filterReason = "PDB file"
+        }
+        
+        # Filter out .xml files  
+        if ($_.Extension -eq ".xml") {
+            $shouldInclude = $false
+            $filterReason = "XML file"
+        }
+        
+        # Filter out data.path files
+        if ($_.Name -eq "data.path") {
+            $shouldInclude = $false
+            $filterReason = "data.path file"
+        }
+        
+        # Filter out files in Logs directories
+        if ($RelativePath -match "\\Logs\\|^Logs\\") {
+            $shouldInclude = $false
+            $filterReason = "Logs directory"
+        }
+        
+        if ($shouldInclude) {
+            $CurrentFiles[$RelativePath] = @{
+                Size = $_.Length
+                LastWrite = $_.LastWriteTime
+                Hash = (Get-FileHash $_.FullName -Algorithm MD5).Hash
+            }
+        } else {
+            $FilteredFiles[$RelativePath] = $filterReason
+        }
+    }
+    
+    # Show filtering summary
+    if ($FilteredFiles.Count -gt 0) {
+        Write-Host "Filtered out $($FilteredFiles.Count) files (same as XSLT transform):" -ForegroundColor Gray
+        $FilteredFiles.GetEnumerator() | Group-Object Value | ForEach-Object {
+            Write-Host "  $($_.Name): $($_.Count) files" -ForegroundColor Gray
+        }
+        Write-Host ""
+    }
+    
+    # Parse existing Heat file to get tracked files
+    $ExistingFiles = @{}
+    $NeedsUpdate = $false
+    $Reasons = @()
+      try {
+        [xml]$ExistingXml = Get-Content $HeatOutputFile -Encoding UTF8
+        
+        # Create namespace manager for XPath queries
+        $nsManager = New-Object System.Xml.XmlNamespaceManager($ExistingXml.NameTable)
+        $nsManager.AddNamespace("wix", "http://schemas.microsoft.com/wix/2006/wi")
+        
+        $FileElements = $ExistingXml.SelectNodes("//wix:File[@Source]", $nsManager)
+        
+        foreach ($FileElement in $FileElements) {
+            $SourcePath = $FileElement.GetAttribute("Source")
+            if ($SourcePath -match '\$\(var\.HarvestPath\)\\(.+)$') {
+                $RelativePath = $Matches[1]
+                $ExistingFiles[$RelativePath] = $true
+            }
+        }
+        
+        # Check for new files
+        $NewFiles = @()
+        foreach ($FilePath in $CurrentFiles.Keys) {
+            if (-not $ExistingFiles.ContainsKey($FilePath)) {
+                $NewFiles += $FilePath
+            }
+        }
+        
+        # Check for removed files
+        $RemovedFiles = @()
+        foreach ($FilePath in $ExistingFiles.Keys) {
+            if (-not $CurrentFiles.ContainsKey($FilePath)) {
+                $RemovedFiles += $FilePath
+            }
+        }
+          # Check for modified files (size or timestamp changes)
+        $ModifiedFiles = @()
+        foreach ($FilePath in $CurrentFiles.Keys) {
+            if ($ExistingFiles.ContainsKey($FilePath)) {
+                $CurrentFile = $CurrentFiles[$FilePath]
+                
+                # Check if file is significantly newer (more than 10 seconds difference)
+                $ExistingFileTime = (Get-Item $HeatOutputFile).LastWriteTime
+                if ($CurrentFile.LastWrite -gt $ExistingFileTime.AddSeconds(10)) {
+                    $ModifiedFiles += $FilePath
+                }
+            }
+        }
+        
+        # Determine if update is needed
+        if ($NewFiles.Count -gt 0) {
+            $NeedsUpdate = $true
+            $Reasons += "New files detected: $($NewFiles.Count) files"
+        }
+        
+        if ($RemovedFiles.Count -gt 0) {
+            $NeedsUpdate = $true
+            $Reasons += "Removed files detected: $($RemovedFiles.Count) files"
+        }
+        
+        if ($ModifiedFiles.Count -gt 0) {
+            $NeedsUpdate = $true
+            $Reasons += "Modified files detected: $($ModifiedFiles.Count) files"
+        }
+        
+        # Show detailed analysis
+        Write-Host "Analysis Results:" -ForegroundColor Cyan
+        Write-Host "  Current files in bin: $($CurrentFiles.Count)" -ForegroundColor White
+        Write-Host "  Files in Heat list: $($ExistingFiles.Count)" -ForegroundColor White
+        Write-Host "  New files: $($NewFiles.Count)" -ForegroundColor $(if ($NewFiles.Count -gt 0) { "Green" } else { "Gray" })
+        Write-Host "  Removed files: $($RemovedFiles.Count)" -ForegroundColor $(if ($RemovedFiles.Count -gt 0) { "Yellow" } else { "Gray" })
+        Write-Host "  Modified files: $($ModifiedFiles.Count)" -ForegroundColor $(if ($ModifiedFiles.Count -gt 0) { "Yellow" } else { "Gray" })
+        
+        if ($NewFiles.Count -gt 0) {
+            Write-Host "  New files:" -ForegroundColor Green
+            $NewFiles | ForEach-Object { Write-Host "    + $_" -ForegroundColor Green }
+        }
+        
+        if ($RemovedFiles.Count -gt 0) {
+            Write-Host "  Removed files:" -ForegroundColor Yellow
+            $RemovedFiles | ForEach-Object { Write-Host "    - $_" -ForegroundColor Yellow }
+        }
+        
+        if ($ModifiedFiles.Count -gt 0 -and $ModifiedFiles.Count -le 10) {
+            Write-Host "  Modified files:" -ForegroundColor Yellow
+            $ModifiedFiles | ForEach-Object { Write-Host "    * $_" -ForegroundColor Yellow }
+        } elseif ($ModifiedFiles.Count -gt 10) {
+            Write-Host "  Modified files: (showing first 10 of $($ModifiedFiles.Count))" -ForegroundColor Yellow
+            $ModifiedFiles[0..9] | ForEach-Object { Write-Host "    * $_" -ForegroundColor Yellow }
+            Write-Host "    ... and $($ModifiedFiles.Count - 10) more" -ForegroundColor Yellow
+        }
+        
+    } catch {
+        Write-Host "Could not parse existing Heat file: $($_.Exception.Message)" -ForegroundColor Yellow
+        $NeedsUpdate = $true
+        $Reasons += "Cannot parse existing Heat file"
+    }
+    
+    if (-not $NeedsUpdate) {
+        Write-Host ""
+        Write-Host "Heat file list is up to date - no changes detected." -ForegroundColor Green
+        Write-Host "Use -Force to regenerate anyway." -ForegroundColor Gray
+        exit 0
+    } else {
+        Write-Host ""
+        Write-Host "Update needed because:" -ForegroundColor Yellow
+        $Reasons | ForEach-Object { Write-Host "  - $_" -ForegroundColor Yellow }
+        Write-Host ""
+    }
+}
+
+# Find WiX tools
+if ([string]::IsNullOrEmpty($WixToolPath)) {
+    Write-Host "Searching for WiX tools..." -ForegroundColor Yellow
+    
+    $PossiblePaths = @(
+        "${env:ProgramFiles(x86)}\WiX Toolset v3.11\bin",
+        "${env:ProgramFiles}\WiX Toolset v3.11\bin",
+        "${env:ProgramFiles(x86)}\WiX Toolset v3.10\bin",
+        "${env:ProgramFiles}\WiX Toolset v3.10\bin",
+        "${env:ProgramFiles(x86)}\WiX Toolset v3.14\bin",
+        "${env:ProgramFiles}\WiX Toolset v3.14\bin",
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\WiX\v3.x",
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Professional\MSBuild\Microsoft\WiX\v3.x",
+        "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\WiX\v3.x",
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\WiX\v3.x",
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Professional\MSBuild\Microsoft\WiX\v3.x",
+        "${env:ProgramFiles}\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\WiX\v3.x"
+    )
+    
+    # Also check PATH environment variable
+    $PathDirs = $env:PATH -split ';'
+    foreach ($PathDir in $PathDirs) {
+        if ($PathDir -and (Test-Path (Join-Path $PathDir "heat.exe") -ErrorAction SilentlyContinue)) {
+            $WixToolPath = $PathDir
+            break
+        }
+    }
+    
+    # Check predefined paths if not found in PATH
+    if ([string]::IsNullOrEmpty($WixToolPath)) {
+        foreach ($Path in $PossiblePaths) {
+            Write-Host "  Checking: $Path" -ForegroundColor Gray
+            if (Test-Path $Path -ErrorAction SilentlyContinue) {
+                if (Test-Path (Join-Path $Path "heat.exe") -ErrorAction SilentlyContinue) {
+                    $WixToolPath = $Path
+                    Write-Host "  Found WiX tools at: $Path" -ForegroundColor Green
+                    break
+                }
+            }
+        }
+    }
+}
+
+if ([string]::IsNullOrEmpty($WixToolPath)) {
+    Write-Error @"
+Cannot find WiX tools (heat.exe). Please either:
+1. Install WiX Toolset v3.11 or later from https://wixtoolset.org/
+2. Add WiX tools to your PATH environment variable
+3. Use the -WixToolPath parameter to specify the location
+
+Example: .\Update-HeatFileList.ps1 -WixToolPath "C:\Program Files (x86)\WiX Toolset v3.11\bin"
+"@
+}
+
+$HeatExe = Join-Path $WixToolPath "heat.exe"
+if (-not (Test-Path $HeatExe)) {
+    Write-Error "heat.exe not found at: $HeatExe"
+}
+
+Write-Host "Using WiX tools from: $WixToolPath"
+
+# Extract existing GUIDs from current file
+$ExistingGuids = @{}
+if (Test-Path $HeatOutputFile) {
+    Write-Host "Extracting existing GUIDs..." -ForegroundColor Yellow
+    
+    try {
+        [xml]$ExistingXml = Get-Content $HeatOutputFile -Encoding UTF8
+        
+        # Create namespace manager for XPath queries
+        $nsManager = New-Object System.Xml.XmlNamespaceManager($ExistingXml.NameTable)
+        $nsManager.AddNamespace("wix", "http://schemas.microsoft.com/wix/2006/wi")
+        
+        $ExistingComponents = $ExistingXml.SelectNodes("//wix:Component[@Id and @Guid and @Guid != '*']", $nsManager)
+        
+        foreach ($Component in $ExistingComponents) {
+            $ComponentId = $Component.GetAttribute("Id")
+            $Guid = $Component.GetAttribute("Guid")
+            if ($Guid -and $Guid -ne "*" -and $Guid -ne "") {
+                $ExistingGuids[$ComponentId] = $Guid
+            }
+        }
+        
+        Write-Host "Found $($ExistingGuids.Count) existing GUIDs to preserve"
+    } catch {
+        Write-Host "Warning: Could not extract existing GUIDs: $($_.Exception.Message)" -ForegroundColor Yellow
+        Write-Host "Proceeding with new GUID generation..." -ForegroundColor Yellow
+    }
+}
+
+# Generate new heat file
+Write-Host "Running Heat.exe..." -ForegroundColor Yellow
+
+$HeatArgs = @(
+    "dir", $OctgnBinPath,
+    "-var", "var.HarvestPath",
+    "-out", $TempHeatFile,
+    "-cg", "O__HeatGenerated",
+    "-dr", "INSTALLDIR",
+    "-ag",
+    "-sfrag",
+    "-sreg",
+    "-srd",
+    "-gg"
+)
+
+if (Test-Path $XsltTransformFile) {
+    $HeatArgs += @("-t", $XsltTransformFile)
+}
+
+$Process = Start-Process -FilePath $HeatExe -ArgumentList $HeatArgs -Wait -PassThru -NoNewWindow
+if ($Process.ExitCode -ne 0) {
+    Write-Error "Heat.exe failed with exit code $($Process.ExitCode)"
+}
+
+# Read the generated file and restore GUIDs
+Write-Host "Restoring existing GUIDs..." -ForegroundColor Yellow
+
+[xml]$NewXml = Get-Content $TempHeatFile -Encoding UTF8
+
+# Create namespace manager for the new XML
+$nsManager = New-Object System.Xml.XmlNamespaceManager($NewXml.NameTable)
+$nsManager.AddNamespace("wix", "http://schemas.microsoft.com/wix/2006/wi")
+
+$NewComponents = $NewXml.SelectNodes("//wix:Component[@Id]", $nsManager)
+
+$RestoredCount = 0
+$NewCount = 0
+
+foreach ($Component in $NewComponents) {
+    $ComponentId = $Component.GetAttribute("Id")
+    
+    if ($ExistingGuids.ContainsKey($ComponentId)) {
+        # Restore existing GUID
+        $Component.SetAttribute("Guid", $ExistingGuids[$ComponentId])
+        $RestoredCount++
+    } else {
+        # Generate new GUID for new components
+        $NewGuid = [System.Guid]::NewGuid().ToString("B").ToUpper()
+        $Component.SetAttribute("Guid", $NewGuid)
+        $NewCount++
+    }
+}
+
+# Save the final file
+$NewXml.Save($HeatOutputFile)
+
+# Clean up temp file
+Remove-Item $TempHeatFile -Force -ErrorAction SilentlyContinue
+
+Write-Host ""
+Write-Host "Heat file list updated successfully!" -ForegroundColor Green
+Write-Host "- Restored GUIDs: $RestoredCount" -ForegroundColor Green
+Write-Host "- New GUIDs: $NewCount" -ForegroundColor Green
+Write-Host "- Output file: $HeatOutputFile" -ForegroundColor Green
+
+# Show summary of changes
+if ($NewCount -gt 0) {
+    Write-Host ""
+    Write-Host "New components detected:" -ForegroundColor Cyan
+    
+    # Create namespace manager for final summary
+    $nsManager = New-Object System.Xml.XmlNamespaceManager($NewXml.NameTable)
+    $nsManager.AddNamespace("wix", "http://schemas.microsoft.com/wix/2006/wi")
+    
+    $NewComponents = $NewXml.SelectNodes("//wix:Component[@Id]", $nsManager)
+    foreach ($Component in $NewComponents) {
+        $ComponentId = $Component.GetAttribute("Id")
+        if (-not $ExistingGuids.ContainsKey($ComponentId)) {
+            $FileElement = $Component.SelectSingleNode("wix:File", $nsManager)
+            if ($FileElement) {
+                $SourcePath = $FileElement.GetAttribute("Source")
+                $FileName = Split-Path $SourcePath -Leaf
+                Write-Host "  - $FileName" -ForegroundColor Cyan
+            }
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Remember to commit the updated HeatGeneratedFileList.wxs file to source control." -ForegroundColor Yellow

--- a/deploy/update-heat-filelist.bat
+++ b/deploy/update-heat-filelist.bat
@@ -1,0 +1,47 @@
+@echo off
+REM Update Heat File List - OCTGN Installer
+REM This script updates the WiX Heat-generated file list while preserving GUIDs
+
+setlocal
+
+REM Get the directory where this batch file is located
+set "SCRIPT_DIR=%~dp0"
+
+REM Default to Debug configuration
+set "CONFIG=Debug"
+set "FORCE_PARAM="
+
+REM Parse parameters
+:parse_args
+if "%1"=="" goto :done_parsing
+if /i "%1"=="Debug" set "CONFIG=Debug" & shift & goto :parse_args
+if /i "%1"=="Release" set "CONFIG=Release" & shift & goto :parse_args
+if /i "%1"=="-Force" set "FORCE_PARAM=-Force" & shift & goto :parse_args
+if /i "%1"=="Force" set "FORCE_PARAM=-Force" & shift & goto :parse_args
+REM If not recognized, assume it's configuration
+set "CONFIG=%1" & shift & goto :parse_args
+
+:done_parsing
+
+echo.
+echo OCTGN Heat File List Updater
+echo ============================
+echo Configuration: %CONFIG%
+if not "%FORCE_PARAM%"=="" echo Force mode: ON
+echo.
+
+REM Run the PowerShell script
+powershell.exe -ExecutionPolicy Bypass -File "%SCRIPT_DIR%Update-HeatFileList.ps1" -Configuration "%CONFIG%" %FORCE_PARAM%
+
+if %ERRORLEVEL% neq 0 (
+    echo.
+    echo ERROR: Failed to update heat file list
+    pause
+    exit /b 1
+)
+
+echo.
+echo SUCCESS: Heat file list updated
+echo You can now build the installer projects.
+echo.
+pause

--- a/octgnFX/Octgn.InstallerLib/HeatGeneratedFileList.wxs
+++ b/octgnFX/Octgn.InstallerLib/HeatGeneratedFileList.wxs
@@ -1,1425 +1,1428 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-    <Fragment>
-        <DirectoryRef Id="INSTALLDIR">
-            <Component Id="RemoveInstalledDirectories" Guid="" Location="local">
-                <RemoveFolder Id="dir82972532CA27BEF6B972C3A142E19BC1" Directory="dir82972532CA27BEF6B972C3A142E19BC1" On="uninstall" />
-                <RemoveFolder Id="dirAF6DD7A53CA77B3027ADFBAEC049BD01" Directory="dirAF6DD7A53CA77B3027ADFBAEC049BD01" On="uninstall" />
-                <RemoveFolder Id="dir811F417A61360E81212787DAAAEA6D18" Directory="dir811F417A61360E81212787DAAAEA6D18" On="uninstall" />
-                <RemoveFolder Id="dir236726D31B8846E56F94A60B4BDA0D5D" Directory="dir236726D31B8846E56F94A60B4BDA0D5D" On="uninstall" />
-                <RemoveFolder Id="dirBC02319722C77D63C381B32042A43610" Directory="dirBC02319722C77D63C381B32042A43610" On="uninstall" />
-                <RemoveFolder Id="dirF5C503B5843C4B671B9659DAD472C99B" Directory="dirF5C503B5843C4B671B9659DAD472C99B" On="uninstall" />
-                <RemoveFolder Id="dir61B122782F2749F187324C134F6498C1" Directory="dir61B122782F2749F187324C134F6498C1" On="uninstall" />
-                <RemoveFolder Id="dir239481E6A388B3487D44CE1316E7F18D" Directory="dir239481E6A388B3487D44CE1316E7F18D" On="uninstall" />
-                <RemoveFolder Id="dirC9449A876BE1D543C4BEF0F2A70550D0" Directory="dirC9449A876BE1D543C4BEF0F2A70550D0" On="uninstall" />
-                <RemoveFolder Id="dir54B0732D1EC7055747BB11A9069B5872" Directory="dir54B0732D1EC7055747BB11A9069B5872" On="uninstall" />
-                <RemoveFolder Id="dirEE481B3D48A90B5CC7FF22BC03F5F006" Directory="dirEE481B3D48A90B5CC7FF22BC03F5F006" On="uninstall" />
-                <RemoveFolder Id="dir9A922803B4F75A03E6F353457F8EA5A3" Directory="dir9A922803B4F75A03E6F353457F8EA5A3" On="uninstall" />
-                <RemoveFolder Id="dirA1E22504AD8FC7CFED287202DA6698C6" Directory="dirA1E22504AD8FC7CFED287202DA6698C6" On="uninstall" />
-                <RemoveFolder Id="dir71F51BB8FFD7417900F6A6C18D636546" Directory="dir71F51BB8FFD7417900F6A6C18D636546" On="uninstall" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE5004356FE7CC543DB30277EBA335A30" Guid="{83E01714-D132-4FF7-8CEF-9EF12D2F6613}">
-                <File Id="fil5159DCE9D857F88BB103745E425061C9" Source="$(var.HarvestPath)\CommonServiceLocator.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp669D7BFE3F77F8D3E757F78FE36D1217" Guid="{50C6B440-1B68-45A8-91D1-311B7D690DEC}">
-                <File Id="fil01FD9A438453A336BFC7E1C098C52A86" Source="$(var.HarvestPath)\ControlzEx.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpAA976D0FC5F51A5E72C45F0626C92246" Guid="{E48EE0C4-DC73-4D0B-8BED-78DE0574CD69}">
-                <File Id="filA0EA556533910ED0C8B57AF781D4344D" Source="$(var.HarvestPath)\DotNetZip.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp488D27FD7F12CC5B0CA2DA2EA3B41D0D" Guid="{B094F1BB-C7F8-4CA1-BB4E-47DA8FA55B9C}">
-                <File Id="fil185ABF006E89BA8A4D51B571C8563487" Source="$(var.HarvestPath)\GalaSoft.MvvmLight.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7DB90804D3EED1D9CFD3C64FFB5E4115" Guid="{DAA3B81C-DBF6-42F9-A7F1-10CAD718D96D}">
-                <File Id="fil767D16365A57A31EFB10B16A311C4A96" Source="$(var.HarvestPath)\GalaSoft.MvvmLight.Extras.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp5B1CB9670A427F5E3F2553830607FC0D" Guid="{34C78223-5D1D-4877-8DB3-581B9C3173B9}">
-                <File Id="fil3D52221AD70477F85AC254E167A7BD0B" Source="$(var.HarvestPath)\GalaSoft.MvvmLight.Platform.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp3E2C89676240A14A7164CA0B257A401F" Guid="{E8A8B752-90FE-4717-8F2A-27C71DC0B7B4}">
-                <File Id="fil3DE3BA5197F12E35F960885AF9394DB6" Source="$(var.HarvestPath)\GongSolutions.WPF.DragDrop.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp0E16CB47C3F6B22E2FFDD2CC515AD1C8" Guid="{95BD7D1A-D316-48CE-B12C-7C42BBD9F309}">
-                <File Id="fil6D3D5546417727749907FC9E19D97FF8" Source="$(var.HarvestPath)\ICSharpCode.AvalonEdit.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpD6D0ACC34D73AA09627602A91169D2DB" Guid="{A3E80A48-5A6A-4AF2-95EB-588663B1444D}">
-                <File Id="fil2806E2EABDDD9EB65DA3C51FFB074B1D" Source="$(var.HarvestPath)\IronPython.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp39527D5EC1B0688C7C9D63712D499341" Guid="{28A132DA-3E57-42EE-8FB3-F52C3F1DF286}">
-                <File Id="filF01A5A4471C5C531E7F4BDEC9D26323B" Source="$(var.HarvestPath)\IronPython.Modules.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp78D15F6F5231CF1E19D525ABEE99FCA6" Guid="{5C7FD485-176F-4060-B0F7-065080395A9E}">
-                <File Id="fil83AC47640800262DC0ACAB230E1CC60B" Source="$(var.HarvestPath)\IronPython.SQLite.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp253E049275FEE4BD1697BDA6EA4C9417" Guid="{43C89E4D-5741-47D2-AF98-C1508D75502D}">
-                <File Id="filB29DAEF7CB7926EF25FF78193684E66C" Source="$(var.HarvestPath)\IronPython.Wpf.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp13D6573EA8CF3F99F44BAE837E2771F0" Guid="{C39E1435-5802-4F53-BC86-8F1EAE8B5317}">
-                <File Id="fil2991F53D601CDF7142D0A9E1B42E116E" Source="$(var.HarvestPath)\log4net.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE395334EA0B9B925C1A69130E5678AF0" Guid="{994E3A12-FC6E-438A-9355-54DA5C679C92}">
-                <File Id="filA3AA19892B63F96ED05F28829FC89F94" Source="$(var.HarvestPath)\logging.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp2AC41B9A3E9E58C9FAC717C515DD6534" Guid="{0423E0F6-0386-4C54-BE54-AE6B5108D0F9}">
-                <File Id="filC48A97D03FAF26C6CB0B00A73EBC747A" Source="$(var.HarvestPath)\MahApps.Metro.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp6ECE5161C032390B6D41F4669C9B2FBA" Guid="{BA204D11-6864-4EC2-A785-EC18123A117D}">
-                <File Id="fil12A79ACDDBCCB205B2316C211EFDB9C5" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.BootstrapIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpB828F2E0E3908AEB84554538E14583D2" Guid="{BAD743B3-FE4E-451E-B607-204417992BAB}">
-                <File Id="fil4A85852AFF564A727068558456B40A96" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.BoxIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp0B410F6F5DE5B5ECFF29B60BFB274F0F" Guid="{CFC18000-2933-4D16-9C51-5AEF0DA61D8B}">
-                <File Id="filDA9835F7AF9DFA7028A598514D8FD4E8" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Codicons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpAA3D78E9B3AE6821E2C081A41FD040FD" Guid="{740FE4B8-95CB-4F55-BDBC-C1A50FE86E7F}">
-                <File Id="fil41A7C42F7C04E764DDE088620AF23D8E" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Core.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp286A3BDB1EC430B908FD322B1322D746" Guid="{59FD3996-10DD-42DA-A2D1-24406C777086}">
-                <File Id="fil3D712A15730F07F094E6844258950361" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp219E02EF943746676A4668B48FBE1820" Guid="{7B266787-5BA5-4188-B9FF-F44834B9C15C}">
-                <File Id="filD24A8005F1224750204A4571D045A568" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Entypo.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7F9ECE136F3D1474CBD79D0EDC835364" Guid="{CC4E67A5-BBE4-4BAB-B8F2-F3762DF35785}">
-                <File Id="fil36943521145537089B063D681E2FE2EB" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.EvaIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp48E1E5C93860F49EF00841C60B81D2E9" Guid="{6A4732B0-5ECF-453F-9268-BFF3E4510097}">
-                <File Id="filDECE322D4CF04F3C3CE84BD2C78CFE73" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.FeatherIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp5A3B0FEEF305F52451B314C57A61717B" Guid="{5F7D2114-ACDB-44B0-BD75-840CACF0273F}">
-                <File Id="filC0E8B93A1F48A011740009B168DB698B" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.FileIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp04FD776539E2628403B1D84D7E4D2BF3" Guid="{04F7DD54-C628-4303-B411-E56F295143F4}">
-                <File Id="filD75DE729566832C3DDAE2FB2BCBDF9E6" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Fontaudio.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp558FC5B3CC2B23E0A8DE37F92B4255E0" Guid="{D08EAE05-CF0F-42FC-94A0-0F5E695E3121}">
-                <File Id="filB47F5825E05B63D1F79D61A45D9978E5" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.FontAwesome.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpEE5095AF5D6CA4E21BB31324DCA12A9D" Guid="{B5D495B1-BA87-42AB-9A52-D48358B627D7}">
-                <File Id="fil8E692CA1019718C99A7B2DF09D2682DC" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.ForkAwesome.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp90BBBFEF1982BB90418B4644CF2F7828" Guid="{5E73A6B6-4142-4669-B4F1-03412CC61F06}">
-                <File Id="fil6BAC0A24DAC7F39A1620E95997185B5F" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Ionicons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpFEB20DDD1566488925514934FC1DD9D5" Guid="{6A1455F2-BA8E-47BA-B95B-8C7FC7604309}">
-                <File Id="fil96729ABD08F7D5011F4AD8C30E7FCBB0" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.JamIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp93AF99501BD43251496EBFA1881A64EF" Guid="{1195F1E9-083F-4A5B-9BCC-99E393615AAA}">
-                <File Id="filAFBAE20130F99F271F54C2951B2BAD34" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Material.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp6E690104F2F1BB697CC4758AD1E26E58" Guid="{1B5F85B3-CE8C-43DB-ADA7-E794D3C3BEE8}">
-                <File Id="filCC531ED0434ABA77DD529A9B508AE0F0" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.MaterialDesign.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp1B3BA240BD1C077BF83416736D48186D" Guid="{3F196920-29DF-49D4-AB4F-96BAF0B6C695}">
-                <File Id="fil6BE9ACE2E766B800E6FF54F4E697D460" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.MaterialLight.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4305F7BD8AC4EC7C4D0AA718D88266C2" Guid="{BAD90132-451E-4E93-9AEC-3A709F6FC768}">
-                <File Id="fil1353F3D65C99A57CE7FEE3E813A915C5" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Microns.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp351597C63B1AC6EEBF7FC5A22A89959E" Guid="{09330475-0055-47D3-ADEF-7BE45F91E941}">
-                <File Id="fil370BD642BFD820178252FA7494C0652F" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Modern.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp90A934A8431ACC8512A4EA7F53BC937E" Guid="{C1F70FBF-D5F8-4DB8-9B2B-F738515CF9E2}">
-                <File Id="filDAECF68FD05D1A7565D1F23F70456832" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Octicons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp9799763CBFF3E472309F980CF7998B39" Guid="{B0139F0B-C89A-46B9-A8A7-2ABB2B8276C5}">
-                <File Id="fil1C9F04DF88B43F1AD9753E1160ACC824" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.PicolIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpF3639C930704BB7395EC1FA447E3381B" Guid="{581F4293-9752-4B7C-9BE9-BC3794BDD1DD}">
-                <File Id="filF0152A8A540DAC9CB21C2DFC3C6CF225" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.PixelartIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpCB2E6D7505E8F9992D331D3A906C43F4" Guid="{D6F7B466-9C68-4FF5-A489-0ED6037E08DE}">
-                <File Id="fil089D5E6B326A0FF9C2DA536B5A0F00B1" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.RadixIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpA06D8E3E1D88DC98CDABEDC2E5C06BB4" Guid="{A4A723DF-5C19-4273-ADA7-6FB8E2E26213}">
-                <File Id="fil84795354B6D4F23CC639F91FBA101F9C" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.RemixIcon.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE3CF238EBFAA39F9B8A792C87C154D23" Guid="{CB42D9A8-2DDD-4022-9EA2-64FCEBA09B07}">
-                <File Id="fil73FB4D9BCCE8C4486C1322A5C9783B52" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.RPGAwesome.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp1D298ECB70462F6B6B9C736D46C3703A" Guid="{A23D12F8-06B7-498B-8228-F519F9F56D65}">
-                <File Id="fil7536289E16969FC23A4B8C686710CC3E" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.SimpleIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp1343B58142FF8A721A61A226461A348A" Guid="{48F46113-EEC1-4245-8202-A609CB703AC8}">
-                <File Id="filF966C280AC0005F57F91968D0EE1B645" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Typicons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpA2394AB6E80CFE6873404D7E45067744" Guid="{D9F40138-7C75-4D87-B59F-628ED9562572}">
-                <File Id="fil723C34647F418233D488A22D0103A8F1" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Unicons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpC7DD7DCD8E4083B4375CEC2B790F42C4" Guid="{649B8C83-0E2D-446C-8920-B699FE93CB21}">
-                <File Id="fil25607EF9627D38D21F76141459FAF6BF" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.VaadinIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE45996FE404705547B851665885248CF" Guid="{2BC8980D-DD23-4227-B17F-0308FD4D20D5}">
-                <File Id="fil48F04595EE37A65779B1C74F49CCDEE2" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.WeatherIcons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp06B5FF1D134B60C8550290639423F91D" Guid="{FB46FD9F-9C4F-4C19-941C-E6EEAE3D1DA3}">
-                <File Id="fil206A0BAC6AC49BDE329150BF3348CDBC" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Zondicons.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7254E72FE73F320AEB41601E41FB205C" Guid="{EA402757-32A6-4B3D-9CC3-C8BFDED92605}">
-                <File Id="fil13415A8D8C4BF2A65643689519A0020A" Source="$(var.HarvestPath)\Microsoft.Dynamic.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp3BEA937DC04A8694133FFFE7D2D9DD04" Guid="{01D04ACE-187A-47B2-906B-C717310BB624}">
-                <File Id="filFBE32D4AF66E9BC3F6EF09887D4DC489" Source="$(var.HarvestPath)\Microsoft.Scripting.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7DC125062D4B14D8FC6C510683E68764" Guid="{C50B591C-6B87-43E3-8BD8-A16DB01EAA79}">
-                <File Id="fil69C17A90B7EBC90FF29B44ABCB1E8B50" Source="$(var.HarvestPath)\Microsoft.Scripting.Metadata.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4370A5F473BC7C578FA8C4A674514135" Guid="{2721EACB-1371-47A3-869A-7FCB25A13BEC}">
-                <File Id="fil44FD26BE5AA3BE512E4A18D3072087AE" Source="$(var.HarvestPath)\Microsoft.Threading.Tasks.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpBF316BAA97EE8CE76D0E2E7D86CB70F5" Guid="{C188975D-8EE9-4FE5-9382-AC510AFAC32B}">
-                <File Id="fil3F3FAF9A5D44A074B2AB8FC3101C1A92" Source="$(var.HarvestPath)\Microsoft.Threading.Tasks.Extensions.Desktop.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp82951EB65984B52CAC92DE74F90EEE71" Guid="{6C4FC451-4D29-4256-8183-348188964D86}">
-                <File Id="fil4A3914E8BA2E4BD8BB82F62B0967AAFB" Source="$(var.HarvestPath)\Microsoft.Threading.Tasks.Extensions.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpD6E0355A434255FE85D95233B0AEB24C" Guid="{AEA6879A-C7AD-4899-90EA-4E84A6719ADD}">
-                <File Id="fil68B8557306E79D976A11D85295D37CCB" Source="$(var.HarvestPath)\Microsoft.Web.XmlTransform.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpFC2072AC6AB749CFD7255D8127B1D945" Guid="{05DFA1A4-BCE8-466E-ABB1-F4ECE8742900}">
-                <File Id="fil9394A47DDAD5C82DE43D4227296DDBFB" Source="$(var.HarvestPath)\Microsoft.Win32.Primitives.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp0CF5B14E86747BCFC1DDFCDF28AE4A82" Guid="{56421E0D-120E-4B9D-ADDB-8EE5DDF9225C}">
-                <File Id="fil20B8F60F955E06C42916655EC36B7FF6" Source="$(var.HarvestPath)\Microsoft.Win32.Registry.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp9ECFE97C3E16F0F19742C25CE41E91CC" Guid="{407029F4-62C6-4725-B732-B7EEC4269121}">
-                <File Id="fil6FBF3F6F8C26D2CD1CD858B08DE0A938" Source="$(var.HarvestPath)\Microsoft.WindowsAzure.Configuration.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp6107C12C2A55CB8E7E97FF2C9A33F385" Guid="{CEF9790C-53F4-4A50-9A65-7D2CADA9BC1A}">
-                <File Id="fil135F9AEEB4A74E1EE438100986E97C41" Source="$(var.HarvestPath)\Microsoft.Xaml.Behaviors.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE5B545219A4761BDD755E5F33A229024" Guid="{0A932FA4-BD93-41AF-9C20-492270418718}">
-                <File Id="filF85B362BB09126F71319D8C4C09F7A00" Source="$(var.HarvestPath)\Mono.Options.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7762CAE69A07BF558B2EDF1798F02FA8" Guid="{3344BF4A-BA94-4B97-AE66-492F109D066A}">
-                <File Id="fil422AD37AD210EABF4A29945700C514C9" Source="$(var.HarvestPath)\NAudio.Asio.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp07814B6C8393BF87D48FD742866B4421" Guid="{9EE27989-4B4C-4DC1-932D-F18741B0FFAD}">
-                <File Id="fil2DFD8B340CAF47C2A37E6FB0AEF11FDD" Source="$(var.HarvestPath)\NAudio.Core.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpCBAD1189E4A95476F45730EA6D8A3E03" Guid="{A92C03CA-C2C7-4E3A-8781-D239DDA3E1BB}">
-                <File Id="filB5CE7890FC801E39F6B9B8C9FF5E4D0D" Source="$(var.HarvestPath)\NAudio.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpAE19781133491B2193381E0614D1D3D9" Guid="{582E748F-6F1F-46C4-B93D-CE17015EBAD7}">
-                <File Id="fil6ECEDDF70D62C4F861EEFDD84439EED5" Source="$(var.HarvestPath)\NAudio.Midi.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp76294603D17E356B01EC46623A3970CE" Guid="{D48ABE47-46F7-425F-8CD9-3A109B68E3CD}">
-                <File Id="filB67CC63B9C4671EA549F17299B5F53C0" Source="$(var.HarvestPath)\NAudio.Wasapi.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpB84206E7872F2865ED1F54C864FA6F34" Guid="{DE029EF5-4D2C-48F1-BD24-D394E24D6D82}">
-                <File Id="fil875692AF07DA73A676DC839BE3843D28" Source="$(var.HarvestPath)\NAudio.WinForms.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpA29803D2B7B90F564254224D67C6AFD4" Guid="{7527BD5E-FD5E-4C52-9138-37F3DA39CA6A}">
-                <File Id="fil39F2D5E0248524222CADBE8693A5AA54" Source="$(var.HarvestPath)\NAudio.WinMM.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpACFF2DEC99E6BC166A0253634ED41A4F" Guid="{95EA59E0-BF04-4CBC-8DA4-65CF3E501B9D}">
-                <File Id="fil21E384679BF7C5ECBD525841F6692B51" Source="$(var.HarvestPath)\netstandard.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp1874AB219070404EED322213C6A1A49E" Guid="{7DFFE2B0-5F55-47C9-B2DE-F453C060BF87}">
-                <File Id="fil05FF769999D602AD4FA6A489C44ED290" Source="$(var.HarvestPath)\Newtonsoft.Json.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp6C6E3A4782B29A777EAFACCECDE25A75" Guid="{378E77A4-87B4-434C-9D42-C032A34FAEAC}">
-                <File Id="fil61E2178807DDF4CB67E717F57A0B45E1" Source="$(var.HarvestPath)\Ninject.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpB66FADA902303B620146AF05EF8B205C" Guid="{D9BC8B91-EF02-4996-B90A-6842560F07CA}">
-                <File Id="fil9C4309AE2C59075802B06539F1944B44" Source="$(var.HarvestPath)\Nito.AsyncEx.Context.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp8DFFC5DEB197ECE614FFE3F5C7E04DE4" Guid="{C46CA214-FDB5-411E-B191-BAA4E0F13B96}">
-                <File Id="filF20CF67215C2139C8693496EC24E5D08" Source="$(var.HarvestPath)\Nito.AsyncEx.Coordination.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpAEDF2B3BA3696FBDD725B364F3E86ECE" Guid="{F62A51A0-B74B-4DE5-82DA-7342A63715FF}">
-                <File Id="fil7C1F3919999C7AD7A00A53673BBF482F" Source="$(var.HarvestPath)\Nito.AsyncEx.Interop.WaitHandles.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp72CF3E6159C32478210203D321CFE41F" Guid="{1BB5C801-F37D-465B-A5FC-895FDDC776A2}">
-                <File Id="fil13B8DC0EDCDD02F838AC62535FFD0417" Source="$(var.HarvestPath)\Nito.AsyncEx.Oop.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpF44C29B10AEFDB62AD0AF98A017AA917" Guid="{CDA86211-AB13-4A49-904F-4DEBE947E158}">
-                <File Id="filB1FCE5EF20B18AB8634E9D0BFFE17CC1" Source="$(var.HarvestPath)\Nito.AsyncEx.Tasks.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp260D7C50CBDB73562628EC85FC92D384" Guid="{DF9C49F4-9BB7-457E-8C77-6090FA13713B}">
-                <File Id="fil737FB645C88EF94C8F7DFEC3AC1C3E2A" Source="$(var.HarvestPath)\Nito.Cancellation.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp66F3E11ECD62C2F3F07FE833435629AE" Guid="{4BA578BB-7D40-4562-A60D-F0B8164951CB}">
-                <File Id="fil46B56D09508058011C2F519DF3616F4F" Source="$(var.HarvestPath)\Nito.Collections.Deque.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp2C5E7C277E5AA44B5685A4B212F12806" Guid="{EC888274-52B7-402C-84B7-6D6F82C8F5E5}">
-                <File Id="fil16DB30711CC35B87FEACE31771C83B32" Source="$(var.HarvestPath)\Nito.Disposables.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7573EC2390E2B47667BC392F0AB1294C" Guid="{86DA1DE7-D280-4F8E-8567-60BEDD477E90}">
-                <File Id="fil793549DAC9BBACE3FE0A2C6207439558" Source="$(var.HarvestPath)\NuGet.Common.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp5D12C26270BD09CA3D45919FA8719AE2" Guid="{AB9AD29D-982F-40AE-A0F6-1DCC007FAA64}">
-                <File Id="fil1914470A96C406BB700EBFE4DFAB0CEF" Source="$(var.HarvestPath)\NuGet.Configuration.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp5B6706A46F3A714C8F8DBBC8D99570F8" Guid="{D4A35679-D85F-453B-A461-7943A41B6144}">
-                <File Id="filA10C8BC6EBB3877E81710607DA5F8E3A" Source="$(var.HarvestPath)\NuGet.Core.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp5B4B4955C58608067B41D6BE02863260" Guid="{FD9985FD-ED2A-4B0F-A42E-0ABA3CC174D2}">
-                <File Id="filC77BFD5C891086AC3DFE76BB004671EB" Source="$(var.HarvestPath)\NuGet.Frameworks.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4D072D5842DFB1E9399C435C746D295F" Guid="{D9C64107-2E12-4C98-9527-70BD3BE8DDA8}">
-                <File Id="filA46D093A333210FF3DF479B37CE2796C" Source="$(var.HarvestPath)\NuGet.Packaging.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpEEB4733FD782D8FCC77902F908470D17" Guid="{D54C9BF9-31DD-4330-A032-E338D1D551C1}">
-                <File Id="filFAE94905D72D8368BA8CE7A78C6DEA45" Source="$(var.HarvestPath)\NuGet.Versioning.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp14EC87DA50B81B5E6A67429F9F656722" Guid="{1171D6C7-008B-45CE-80D2-71109599DE63}">
-                <File Id="fil115F8AF38B90879DB02D672AAD89C8F2" Source="$(var.HarvestPath)\o8build.exe" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpECB62EFCC36DED701B049645322D5EA4" Guid="{2ABFC508-DA9F-4B3C-B6A7-3A7802D7F1E4}">
-                <File Id="filD6E3595BC3A12F1178BADDB8B0C651DB" Source="$(var.HarvestPath)\o8build.exe.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpDB3F27CA75DD8B428D656610D824F43E" Guid="{94157147-5620-4645-B6DE-A4E628E374EE}">
-                <File Id="fil1867AEB40FE12C433049BEB9C91F1DB5" Source="$(var.HarvestPath)\O8buildgui.exe" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp8F4B94EF0828B6BB61CFB54CF020D91D" Guid="{7F1079E1-C807-44B3-8CE6-C731A4283C93}">
-                <File Id="fil12556778E1378D4E227933C7673EDE13" Source="$(var.HarvestPath)\O8buildgui.exe.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp78D420543530ED3C4E9AF59E5E43A46A" Guid="{B8B11EE8-09DF-44EC-92C3-D3DF2C74CF54}">
-                <File Id="fil5DD75D83A77AB95ED421DEEF0BF2B01A" Source="$(var.HarvestPath)\Octgn.Communication.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp13DB3273CD8E9EFBC311065EC87BC2ED" Guid="{2A99E44F-8390-48E7-889B-43A6A5EF40C6}">
-                <File Id="fil77B8C56BFD301B24319AB3307D9BA392" Source="$(var.HarvestPath)\Octgn.Core.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp01B928B4ECBFCD61A6907C15B51FD576" Guid="{5A41CD71-E761-4565-B64C-88028CE5BADF}">
-                <File Id="filA077434039560EE768241001F37074B3" Source="$(var.HarvestPath)\Octgn.Core.dll.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4AC56D024FE3EBC0C5D484FD32C6AD39" Guid="{4BD12BE0-AC37-4D50-BB98-617C91131140}">
-                <File Id="fil778540729DB4A65ADFBE96E16513FDDD" Source="$(var.HarvestPath)\Octgn.DataNew.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE198BBD5DE02A49C4928C1C0050A8D2C" Guid="{A8CC6659-2508-4B6D-B98A-D0412BA01833}">
-                <File Id="fil1BF4E8D8B821B657E6BD6C4D5D17E01F" Source="$(var.HarvestPath)\Octgn.DataNew.dll.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp816741CB75C2802164361F1A72B563A8" Guid="{A719F839-B2A5-43CF-9D11-20CF517946E5}">
-                <File Id="filDD92BED66D8CCAE233C37576A2AB17A7" Source="$(var.HarvestPath)\OCTGN.exe" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpC5DE7EC60F5EA8A9A5B95B7D4B9C5BC5" Guid="{6233F947-FC19-4191-A1A0-CB01770FB116}">
-                <File Id="fil69ABE435B2D8C724C37AFE643B9377A4" Source="$(var.HarvestPath)\OCTGN.exe.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4A176DBA1ADB8645F1FA42676F3A6B86" Guid="{98D627D3-EE73-4E7D-B81A-62CE99F242E0}">
-                <File Id="fil5DDB7773FA15E3A2816CA9EFEB1C60C9" Source="$(var.HarvestPath)\Octgn.GameWizard.exe" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4625614E297B1252FE7F922014CC80F1" Guid="{6B2147C5-57C2-4120-AA05-ED7000BCC4BD}">
-                <File Id="fil847FADADF6B5C12004BF4BD633CAC112" Source="$(var.HarvestPath)\Octgn.GameWizard.exe.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4DB7CFE68CF05E3AD59E02028E042BB9" Guid="{9F355E39-2AEC-4285-BDA9-760D039AF927}">
-                <File Id="fil8674A56D73676920122A40678BF74ABE" Source="$(var.HarvestPath)\Octgn.JodsEngine.exe" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp63DE213263DED6C2550F304BEE2CFE7A" Guid="{306B1902-B23E-4A2A-A0BB-DF6FDF4592A8}">
-                <File Id="fil1EB4834F0D954D20AB8C86314FC306E6" Source="$(var.HarvestPath)\Octgn.JodsEngine.exe.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7F4884BAFC25CC83145B44C41BD9E715" Guid="{5CAC4E95-7CBF-4F58-9CB6-AD075C2311BA}">
-                <File Id="fil59E2C7E4B79381DF45FA80A2BB35088F" Source="$(var.HarvestPath)\Octgn.Launcher.exe" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp5F98DC92A09C93FA41A8E8735029D622" Guid="{B7BE9310-F4D4-40CA-96F2-0B09B5FB7FF8}">
-                <File Id="fil16956E54BC419F5003B36A82D564A1B5" Source="$(var.HarvestPath)\Octgn.Launcher.exe.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp94F2EBC9267AA03E64C0B4C125B6E0ED" Guid="{D92F6F88-7E87-4F71-B7BE-6332D1D563E6}">
-                <File Id="fil9B7905D43CACE41185C88AC56FE48C94" Source="$(var.HarvestPath)\Octgn.Library.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp258FD747182EA4C603508266DBC1755E" Guid="{F9E40228-64DA-4E83-996E-D3CB354B31E5}">
-                <File Id="fil8D5F737CD62562E564C183DBA36FC396" Source="$(var.HarvestPath)\Octgn.Library.dll.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp46AC8D28D9CA83259E3ED6310534D2DB" Guid="{77D02324-575A-4DCB-AA6F-48FF5AD0E51C}">
-                <File Id="filADC02EADCCD3A41A1292298778B013E3" Source="$(var.HarvestPath)\Octgn.LogExporter.exe" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp6660405BF614CDE8F11AAA818351849C" Guid="{2DC7AE6B-F7DB-44A7-BF3D-795342622CBC}">
-                <File Id="fil8156F89096B49D16DDF97A5953C85065" Source="$(var.HarvestPath)\Octgn.LogExporter.exe.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpAED5FD47C57C7237045FCBCFE4808351" Guid="{72D6DF96-616E-4E5E-8A74-2E6400672822}">
-                <File Id="filC86A2DA50F892AA8D72DE35DA43F483C" Source="$(var.HarvestPath)\Octgn.Online.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp2708F486C57CA602B063BE9697C5C4FF" Guid="{87AD4812-35E7-48A7-BCD6-53778CC669AA}">
-                <File Id="fil98B7F9E20F8EA19A2CAB20633523D7EC" Source="$(var.HarvestPath)\Octgn.Online.StandAloneServer.exe" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp52CC0A0B26C40F9923BF174EBA67CAE4" Guid="{DF39FBC2-72E7-4568-9C5B-1DE2C40426D8}">
-                <File Id="fil436F3908350FE867344545552CA452A4" Source="$(var.HarvestPath)\Octgn.Online.StandAloneServer.exe.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp9B0BCDBA40A5A291A237F6B435F5FF75" Guid="{4F1C1257-792A-464D-8EA5-F02338CF58B7}">
-                <File Id="filF5CD34D43BBDA9E63E39FF788CB30E51" Source="$(var.HarvestPath)\Octgn.ProxyGenerator.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp178679DA6076A0B4B6DF75E8E4258E14" Guid="{C4DA23FF-7E8B-45F6-8F39-357C9A9DFF31}">
-                <File Id="fil4482CF52B147A902654489F837D6D87D" Source="$(var.HarvestPath)\Octgn.ProxyGenerator.dll.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp92EE4200C4A0C8862AD9CF28B1628DF1" Guid="{18C74331-CF04-4520-976D-05B0BDDCF817}">
-                <File Id="fil17614427FBA65EB6F62FDFC105DDCB90" Source="$(var.HarvestPath)\Octgn.Server.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp85D8CC8E2390ACE57897B8F9779150CD" Guid="{4D6D042A-53B6-4F82-A69A-C5D47F37899F}">
-                <File Id="fil653B712CE97114CE7A0FB028C47C2EE4" Source="$(var.HarvestPath)\Octgn.Server.dll.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpBB3FBFA8930E710EA15D7C39668E6B92" Guid="{54006DA1-AC01-4DF4-81D6-A43D89F0C21C}">
-                <File Id="fil5974997ECA52452C12CBBAC4AA8EE638" Source="$(var.HarvestPath)\Octgn.WindowsDesktopUtilities.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp3E631296B6A9F7DE8958713A82C16A85" Guid="{AE8B1622-FE02-45D0-B4B6-D845B644B9CC}">
-                <File Id="filE085A10E86DAA2724A3EAB33BFC235AE" Source="$(var.HarvestPath)\Octide.exe" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpEC029F3A7060E84C5B2D271A9EDDB2A8" Guid="{4450B3D3-5DD0-4D48-B50A-9D1A4030D99A}">
-                <File Id="fil4FC94796D8AF5704272B67CBA4B3EEF4" Source="$(var.HarvestPath)\Octide.exe.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpAF0E057F905629B87D150B5E4CBA6ECF" Guid="{5CECD031-4604-4E93-9138-61CC6AD0A505}">
-                <File Id="filCC840F8C439A6275BFDCC523E5E0EB75" Source="$(var.HarvestPath)\Polenter.SharpSerializer.PCL.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp5482D5772865980D333DA18D1F255E64" Guid="{DB4C0951-3188-4C73-8075-20035BF62872}">
-                <File Id="fil8B16167CC7454A1CA2703D872FD59E90" Source="$(var.HarvestPath)\ProxygenTest.exe" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp1C38F2C71379D97BF0854CDDD948F94D" Guid="{FD029054-7AB7-4012-B2CA-AE637A0823B3}">
-                <File Id="filDA0AAE19DBC236E0F91C98D399C0CC2E" Source="$(var.HarvestPath)\ProxygenTest.exe.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp2DF0B2895DFC3CB720B48A6D9BFD37EF" Guid="{9AE4B157-EB2A-4C8C-86C2-960F35B5445D}">
-                <File Id="fil759547BBD39D067958C66E9281A84E0E" Source="$(var.HarvestPath)\System.AppContext.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp73085246C202ABD1D96D2E5DEFB2A801" Guid="{CA32B1BC-6C46-4727-8B00-89F4EEF9F64E}">
-                <File Id="filEDD81E77BF6933BF90C42AE0EFAA681B" Source="$(var.HarvestPath)\System.Buffers.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpFCAB0086ACF92637C85CEFB939B694E1" Guid="{1FB987C6-7561-46BF-92BE-F36CAA91F8AD}">
-                <File Id="filAD99C15B3296CE6AABBE5BB40D132051" Source="$(var.HarvestPath)\System.Collections.Concurrent.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE4B4F7691D3ACD4A72AE99FFE470CE17" Guid="{997891D5-EA75-4CBA-AD54-231619711A29}">
-                <File Id="filF5B5D111739157EBBB5E22D86DF5780A" Source="$(var.HarvestPath)\System.Collections.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp33FDA478CB86F083519801379B2D2D8B" Guid="{36D7D220-83F9-4378-AE86-0A147F789AF3}">
-                <File Id="fil5D4575804C3CE3ACC76FF53290806177" Source="$(var.HarvestPath)\System.Collections.Immutable.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp75515765AA531707944115B02998F998" Guid="{45DBD801-1AAE-4776-AA2D-35223CA4BEB6}">
-                <File Id="fil6D02755830088A3C5A117FEE2B465D5D" Source="$(var.HarvestPath)\System.Collections.NonGeneric.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp22D219EF6A7035FFC0254F6BE572FF77" Guid="{1FD30790-289F-4EB2-86C3-A69A8E10335C}">
-                <File Id="filCD75540AD97745722ED0A7EAABF287E1" Source="$(var.HarvestPath)\System.Collections.Specialized.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp22AEF5790256905123AF78698CD859DD" Guid="{3347A2DF-8DF7-48A7-BBBF-EE5123F05E9F}">
-                <File Id="fil09C18C7CA467795F6FA97EEB9E2387EB" Source="$(var.HarvestPath)\System.ComponentModel.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp5349EC5703EBCAA1E6C7DA272802BE58" Guid="{EC98AF41-E268-4E2D-9E7F-5C368A259E23}">
-                <File Id="fil399C00E90F93D6D53C7EB4198B8E6425" Source="$(var.HarvestPath)\System.ComponentModel.EventBasedAsync.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7B3236183FA982DA508702B357E3D75E" Guid="{93E9F3C3-4AD8-4AAA-98A2-FD37055545AC}">
-                <File Id="fil832F201A04CF05CFC4CF092D70DAB4D9" Source="$(var.HarvestPath)\System.ComponentModel.Primitives.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp58C198180EDB7D42EDD28920E1B2E513" Guid="{77662EA5-14BE-4561-BDF5-8D296BB089EB}">
-                <File Id="filF9ABD40F11D5C42FF00EF312FB605BA8" Source="$(var.HarvestPath)\System.ComponentModel.TypeConverter.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp03737AA3B5F539D51D9418A6ED0E4F6C" Guid="{A754B558-3E42-486E-9BAC-002360BA90DC}">
-                <File Id="fil5272CFE8A4472345C08FD356C568CCDB" Source="$(var.HarvestPath)\System.Console.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpB25E057E8242CD01A509E8CBCAB104DA" Guid="{A7BE0DF6-180C-40AA-B7A9-AF54152C9468}">
-                <File Id="filEE34C54941CD776131B74466DF35363A" Source="$(var.HarvestPath)\System.Data.Common.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp44C51162C2752731AF9E2E31BB09713C" Guid="{A5FDD183-F6D7-46EE-BEFD-28DC3BC4EA1F}">
-                <File Id="filB040E785B28D49D2AB7820EA35D4E70F" Source="$(var.HarvestPath)\System.Diagnostics.Contracts.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpB0C2F11F7CA680BF7E48B8A4268E9C98" Guid="{D5B5CF06-641A-470A-8AF3-04D2286BB463}">
-                <File Id="fil3C470A1D30CD627DFFBF6DD8881B668D" Source="$(var.HarvestPath)\System.Diagnostics.Debug.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpA59732DC764B94E5F1FB4BDE22083814" Guid="{1A3C1F4E-5D9F-49EA-B699-2771AAEEFA60}">
-                <File Id="fil2F1CF172154C6293C5A6ACB1E151C0A9" Source="$(var.HarvestPath)\System.Diagnostics.FileVersionInfo.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpF6FEF9FF36C695681C6A77FAD09A51DA" Guid="{BD8234C5-6C22-487B-9612-8D5109DDA19D}">
-                <File Id="fil51269EFEE8943C4F9AB6A03955BB33AD" Source="$(var.HarvestPath)\System.Diagnostics.Process.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpFE82493E4455C953D8F01BA5365F9C1A" Guid="{45E0DDB3-947D-47EA-BB6A-2ED0CE076490}">
-                <File Id="fil0F5FC5A056E90A15787004331E6B2B8F" Source="$(var.HarvestPath)\System.Diagnostics.StackTrace.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp0E83A6F1E468052C63DFCFE168BE9F86" Guid="{B6FCEBB8-46AD-46A2-9255-2D3574ADCFBE}">
-                <File Id="filF010877744275880482B24613609AB8D" Source="$(var.HarvestPath)\System.Diagnostics.TextWriterTraceListener.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp50A76DD8AF0E25149A565F185A1F29A3" Guid="{4C0F83BD-493D-41B0-B514-FD9A5D20A49F}">
-                <File Id="fil89402E5A5EF55D5D1DC9EB807D0163CD" Source="$(var.HarvestPath)\System.Diagnostics.Tools.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpDBAE7236105C33C9758DD48E8B6DCCB2" Guid="{1C61ACF1-2B8B-4626-B45C-CD8F11E5BF37}">
-                <File Id="fil57119B89E434A6BBC42AE8C1D26609BF" Source="$(var.HarvestPath)\System.Diagnostics.TraceSource.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp5686A5DCF2A08C618B3500928277C12C" Guid="{3A9E6D35-71B1-4F4D-AC73-7ED1DEEDE407}">
-                <File Id="fil70BB899DCE8D657F32B0FAC4DFF6638E" Source="$(var.HarvestPath)\System.Diagnostics.Tracing.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp8D6B0D0D5B997AF1B9BB2F2784692E03" Guid="{9AA15ACD-382C-4049-9ECD-469513EAEF5F}">
-                <File Id="filB19BBDDEF37FA03C3CE38BCFF05583EC" Source="$(var.HarvestPath)\System.Drawing.Primitives.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp15CD896C1257803F1EAAF21F13643142" Guid="{ABD667F5-04F1-491A-8147-D1134064F8C5}">
-                <File Id="filC982A846E7172EA04317E0E51B86A4E6" Source="$(var.HarvestPath)\System.Dynamic.Runtime.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp29422AE271D6B2356E2AF332D256B1DE" Guid="{AE8862F6-4D91-4ACA-A51A-466500A58847}">
-                <File Id="filB54F98D44891971453C10FBE1B05B1AB" Source="$(var.HarvestPath)\System.Globalization.Calendars.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpAA087E95574A085C5201D270F443E62E" Guid="{68D940CB-5A8D-48C7-852B-B54652AA01BC}">
-                <File Id="filAE617BAD3153A0952E9F3AC5EEF74A91" Source="$(var.HarvestPath)\System.Globalization.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp2AE6AC0EBDF241F5A2F3268BA1ACA754" Guid="{9DC69118-2295-48A1-A7A4-2F57F68EA2FD}">
-                <File Id="filE95A7394964F5DE38E1D4BF952444394" Source="$(var.HarvestPath)\System.Globalization.Extensions.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp129F5F5267671C7AB542077C2BDD8D72" Guid="{8974EA8D-C30B-455D-A086-3F7C1D317456}">
-                <File Id="fil9EAB17C18CD3A8D30FCF1017E3F9B1E6" Source="$(var.HarvestPath)\System.IO.Compression.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp23F7C2354109EC7F3034457C47235AA0" Guid="{A547F79B-0124-472C-A337-AF991CC8EA0A}">
-                <File Id="filA88EB5E9549A3F482ECCF70642AE8E9F" Source="$(var.HarvestPath)\System.IO.Compression.ZipFile.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp1AB2F694FBE065FEC98E27EC233540D7" Guid="{BE7E6EFB-960C-4C99-950F-B6A8B8CDF87F}">
-                <File Id="filF97298386D9CA5BBFEF3BA1266204948" Source="$(var.HarvestPath)\System.IO.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4F71FF3179249F40AA83CC5D26424EFE" Guid="{C8616FA7-00A1-4797-9729-4DA5BBD648B9}">
-                <File Id="filC6DDCD354E20866B99A7A52238AAF325" Source="$(var.HarvestPath)\System.IO.FileSystem.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpCE934969B52A8BF6C3B94FA9636916F6" Guid="{EEDDCC38-9551-4711-AEF6-7C2C6251A6FF}">
-                <File Id="fil0E00B68474AC0129918FF360842A9CBF" Source="$(var.HarvestPath)\System.IO.FileSystem.DriveInfo.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpC99C1FCF2F2B5727FFA9240232755632" Guid="{C8C173A6-FA1A-4AB0-A4F3-7C7A0C19DB4A}">
-                <File Id="filC3D4C9C1D8A5E81CA2C9F12AA05C8E2F" Source="$(var.HarvestPath)\System.IO.FileSystem.Primitives.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp39DE53A6E602C76462F0260E369F2792" Guid="{3745A51F-666F-45D1-8BAD-D4ED49E335E6}">
-                <File Id="fil576190832420D0AA668E4332EFFB4CBF" Source="$(var.HarvestPath)\System.IO.FileSystem.Watcher.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4A7BCFB5DA46BC95D2E49236FC59D8A5" Guid="{3AB5E8F2-1762-4F16-B892-7FF5CEC48964}">
-                <File Id="filC8B845031D596C89E35A64614B930E36" Source="$(var.HarvestPath)\System.IO.IsolatedStorage.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp3C994A927E01FC3CC7E0AE001AF0CD4C" Guid="{D1BF7152-3293-4C95-8997-59EE159FCE9C}">
-                <File Id="filA22B487AC8691FA22B43B5D947EB4791" Source="$(var.HarvestPath)\System.IO.MemoryMappedFiles.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp461F4A455CD0EB1AD2E4E35B51C09850" Guid="{13AEF4EC-8434-4DCC-9D7F-A00AF600F8D0}">
-                <File Id="fil0B2EFCDE9779CC5CD0E6EB630A00C291" Source="$(var.HarvestPath)\System.IO.Pipes.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp6042D98678A0BF1EE1EB0EC4AF5E5C52" Guid="{5632BB95-22B4-4C68-A80A-A68BA4BD2E41}">
-                <File Id="fil770B68ECB2EAAA73F75AE90EC59CDF4E" Source="$(var.HarvestPath)\System.IO.UnmanagedMemoryStream.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpEE5BBE99E2C22FC8023A8976953D2181" Guid="{CDEC4CC0-ACBE-42B6-BD7A-4C6CACD31B3D}">
-                <File Id="fil9624BD0666E81BA5E2C9A90C8EE12DF1" Source="$(var.HarvestPath)\System.Linq.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp3B693E836B896CF886DF7174A12D37F7" Guid="{E971D830-737B-4ED2-8DDE-A12DAA074A3D}">
-                <File Id="filC4914ECA26BAF54E9A2DD6F052DA9C90" Source="$(var.HarvestPath)\System.Linq.Expressions.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp8EB6B1FB2B50FFBB0CA48841D0C7E01B" Guid="{AD821D24-D7F9-4253-95A5-2C524877A1D8}">
-                <File Id="filE34040F3256391C32697BF02C1A69D6C" Source="$(var.HarvestPath)\System.Linq.Parallel.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpDB259A99945F85FEC221D6F75ACCB8EF" Guid="{9848B1FE-521F-48DE-8841-FD8501A838D6}">
-                <File Id="fil3B519832BFCC96F2B9F9A9E556AD7266" Source="$(var.HarvestPath)\System.Linq.Queryable.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4CFC7C3721FFD91FA4E9798A516D5E97" Guid="{D5B3EFC5-EDCA-4E7D-A4AA-B6F9B746FFEC}">
-                <File Id="fil1E24D2F3B531B1D76E1631314436BD58" Source="$(var.HarvestPath)\System.Memory.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7C8ACFEA497AD75401FFD01A9AEB31D4" Guid="{AC79619F-0002-435F-B513-1AFA9E3C599D}">
-                <File Id="filE0C3E4A153D639D49A90C05560AF1912" Source="$(var.HarvestPath)\System.Net.Http.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpD577135453C63C124E24214ACA6ED9B4" Guid="{D16189F6-446A-42E6-B7F1-C1133971A9B6}">
-                <File Id="filE386BE0BA9453CEB70C0D0A4F87AFE13" Source="$(var.HarvestPath)\System.Net.NameResolution.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp5CF9D73D8F28A4EF0D37B0136ED71006" Guid="{73148841-EE5C-4D9A-84E6-57A2464FC0E9}">
-                <File Id="filBE42196B38AEB33D0CDF75251FE2D7B1" Source="$(var.HarvestPath)\System.Net.NetworkInformation.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE95A3A7DB0E5B6B057A2BEF1A9ACCBA6" Guid="{0873A9AB-1AA7-4901-A848-81F523C4C592}">
-                <File Id="filE8CE2C8F8D88989206070BB80BED53C7" Source="$(var.HarvestPath)\System.Net.Ping.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp57ED19A38749352B4A6312602AF32EEA" Guid="{28DC0795-B482-4DBC-900F-14899BB54EE3}">
-                <File Id="fil73A9A1A5553BBD979A6AE05955A0BFC3" Source="$(var.HarvestPath)\System.Net.Primitives.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp3BED5AB46AF442FB282395C20F099F24" Guid="{089D3360-C91C-48E6-8B79-27D97F56A3B6}">
-                <File Id="filBF1F0395A4430CE4FD07957B53031C4A" Source="$(var.HarvestPath)\System.Net.Requests.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4629EBAC56A143487ECF260AF98BF78D" Guid="{623C9057-6193-41B1-8033-F00D8986A4A7}">
-                <File Id="fil591D46E363F8E823067D9B8BEF2F7B81" Source="$(var.HarvestPath)\System.Net.Security.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp6A4CEF696231A141C3BD0E963AF7FC9A" Guid="{02C58340-7BEF-48F2-903C-2B17782253D4}">
-                <File Id="filDEE378E4FB4D3F4448BC26AA15C9E83D" Source="$(var.HarvestPath)\System.Net.Sockets.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpC11D8B4CADC383AE71657D4082C7C44C" Guid="{60F7B7A8-AAE3-40EF-A2F1-B857ECD1876C}">
-                <File Id="filC9BBDB35B270BFF7BFB6C819013763B8" Source="$(var.HarvestPath)\System.Net.WebHeaderCollection.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7CDF555F26EC27374503C4D251C0ADD7" Guid="{74F89CB6-CA25-451D-91FF-124A1011E519}">
-                <File Id="fil7E89DC70B56E449D3B0FBFB3811872C9" Source="$(var.HarvestPath)\System.Net.WebSockets.Client.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7FDA86390D774733F2019204F3EF9348" Guid="{EAAFC104-26AC-4BE8-ACA3-438D4E7DDE4E}">
-                <File Id="filFF4A0F663A05BAEEDC1EF2CA53FB8D4F" Source="$(var.HarvestPath)\System.Net.WebSockets.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpA780BD9CC7EF10DE58A9E17B691B0205" Guid="{1EEC271F-A505-41A1-A9A0-40528285FF98}">
-                <File Id="fil41D7AC86F0924A477EE48B3AF9E39249" Source="$(var.HarvestPath)\System.Numerics.Vectors.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp0ECCBE7E7A91EA3F9AC4E08C42060A74" Guid="{B16FD2CA-B56A-4C11-9BB4-138B28F49857}">
-                <File Id="filCD330848999366093EF4945E95052719" Source="$(var.HarvestPath)\System.ObjectModel.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7320660D409A823430EC1ADFF0D83564" Guid="{EE146B61-D9B8-4CB3-BB7A-625989D92253}">
-                <File Id="fil0F1435C9F703FD077AC5E77B34B69CC8" Source="$(var.HarvestPath)\System.Reflection.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp68097EB457BBDE8DE960E7CC72000139" Guid="{E56A7E68-CE60-49D6-B7A1-6ECAB8A32BE3}">
-                <File Id="filFFC887013D8E0165D1A96DFCECBB62D6" Source="$(var.HarvestPath)\System.Reflection.Extensions.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpC2109B9173A8B91CBDD411618A20588C" Guid="{3151EF4D-086D-410E-AA7E-EF903F0D3D63}">
-                <File Id="fil2A581D7BEB9E3BA198BA51891387E525" Source="$(var.HarvestPath)\System.Reflection.Primitives.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp48A7934AD38EE63A44A9478E1C31E3BB" Guid="{F502B4E2-F726-4DF0-B1AA-76EB287371C5}">
-                <File Id="fil3BB10164D9FC561AC346D63A8AB66A9E" Source="$(var.HarvestPath)\System.Resources.Reader.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp92E77A73B8159FC7BF51704F06BB1689" Guid="{0CBDC236-6829-4FEF-B339-9CA2D6BC6577}">
-                <File Id="fil7656E2B5556FCB519B0B66F7B480FE7B" Source="$(var.HarvestPath)\System.Resources.ResourceManager.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp82CD5F539E128C7A8CC025CBA927B9F3" Guid="{6D0F86D2-A35F-4988-9FFE-D40CD132C3E3}">
-                <File Id="fil3BCC5DD79CA7001CCCDB0DE845D707D3" Source="$(var.HarvestPath)\System.Resources.Writer.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp04E7760BC247B05C847A4A6D5D8C7091" Guid="{F65429FB-D22D-4A1A-8BF6-4C6EE5A6DF5C}">
-                <File Id="fil8974B12282083EB6B4CB7BAC26546374" Source="$(var.HarvestPath)\System.Runtime.CompilerServices.Unsafe.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp336F82620F5FFCA06611B8FD22F7066F" Guid="{F8FBE5B7-753D-4721-9655-761320B08557}">
-                <File Id="fil3B157F8B05D7C8C49D0B2E4879F2135C" Source="$(var.HarvestPath)\System.Runtime.CompilerServices.VisualC.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpF68CE304EDD0D14A7BFF18236F51BC48" Guid="{457D6A4F-F2B1-43A9-9961-D0CCDDF26950}">
-                <File Id="fil1DF46A3A328CA5A1B3C9E619D2E6B80A" Source="$(var.HarvestPath)\System.Runtime.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp975FB1B5D4A3126E0525915FB4C90ECF" Guid="{89F7BB3A-6767-479E-80C6-398D585BCB35}">
-                <File Id="filA4A42760CA9FD5DD6B18B4E51A05E900" Source="$(var.HarvestPath)\System.Runtime.Extensions.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE55D5ABD5E06B7AC82A1A464F710DC2E" Guid="{925D1B8C-1A5D-4ED7-8B77-E0DE322FDC33}">
-                <File Id="fil1B530BA53CDCE15C6F6170DBC8B8D72B" Source="$(var.HarvestPath)\System.Runtime.Handles.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpF8D128DB049817F164973BCC38DE4935" Guid="{7F6F9733-8461-49D6-8D9D-5B458C38ED71}">
-                <File Id="filFD0221B77EC7449E1F90EA01B453DEC9" Source="$(var.HarvestPath)\System.Runtime.InteropServices.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpEF0EA4DA72195CE89ADEBCDFBBB1A537" Guid="{00DCC2D6-D341-49C1-BF20-D5AD80493489}">
-                <File Id="fil3469E12317CB8788F95F8E393705340B" Source="$(var.HarvestPath)\System.Runtime.InteropServices.RuntimeInformation.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp058B1E2892E76D2F98E9569E383E5B83" Guid="{52923318-ABC0-4112-BB6B-625FE15063E5}">
-                <File Id="fil57772530FF83DF69270D8AA86333BE83" Source="$(var.HarvestPath)\System.Runtime.Numerics.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp8383C67527BDAFE41A3001900C896480" Guid="{897509BE-F50B-42AA-9CA9-245AD8EE9A57}">
-                <File Id="fil508F4D8A219CB235A6A05A06440BAD9A" Source="$(var.HarvestPath)\System.Runtime.Serialization.Formatters.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp1D49D64F849E58598D108BA2293DAD87" Guid="{EDA66BFB-DBF0-498C-A332-2B5E4C4858A8}">
-                <File Id="fil996377CBD20957AB61D1F7794647229A" Source="$(var.HarvestPath)\System.Runtime.Serialization.Json.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpFFD9C90842D9C8A5251533EE3764882E" Guid="{674DC373-21BD-4090-97BB-1F5D6C4BD081}">
-                <File Id="fil78BB41794127DCA0098197C99B85DEC0" Source="$(var.HarvestPath)\System.Runtime.Serialization.Primitives.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp852AADF38F8E567003DDA62F8B2655B6" Guid="{E4865509-28CB-4EDC-91FF-E84C300BEBB2}">
-                <File Id="filFBE1D5D50943EABD41BF7FBDDE38558D" Source="$(var.HarvestPath)\System.Runtime.Serialization.Xml.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp43A33CE3413979CC718E796B1C1E3E5B" Guid="{E802E4F8-563A-4267-81A7-D02525BFCE78}">
-                <File Id="fil6E218B321475AAF07492F4993D21A018" Source="$(var.HarvestPath)\System.Security.AccessControl.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp74104254FD237403FE1336A0257C4330" Guid="{074C5637-A46F-4F72-8DAA-290AF03260B5}">
-                <File Id="fil4B059CBA3EE02B33F172310663FA47A2" Source="$(var.HarvestPath)\System.Security.Claims.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp92D5F6B984CFD9B211394CCCEE1F04A5" Guid="{FB7C5DCC-CCD8-4A0B-B155-15C1DA59364E}">
-                <File Id="filEBF3D292F27598D7663F2D486D689D1E" Source="$(var.HarvestPath)\System.Security.Cryptography.Algorithms.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7B9CC5FD009F8DDFD5BF9EA0D105C4CA" Guid="{7D8706C4-A8A6-4996-827E-975104623301}">
-                <File Id="fil50D322D8544CA61F46C2ADE1B6D20EAB" Source="$(var.HarvestPath)\System.Security.Cryptography.Cng.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpDFB191D893C4B975B51D3352B7B82109" Guid="{074BDA5B-4110-4F24-B8DA-B751A52772CE}">
-                <File Id="fil5903FB61F7250A24E1C6485BA5781F06" Source="$(var.HarvestPath)\System.Security.Cryptography.Csp.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp626E0E80197224B4DF0D25BD513CFE42" Guid="{769C853B-1F4B-4FC3-AB10-CDBB59FE9F64}">
-                <File Id="fil1992BB2EBFE606350BB0C0A3EB90AE08" Source="$(var.HarvestPath)\System.Security.Cryptography.Encoding.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp11C8DA598E403582C9E9F65C927CA880" Guid="{22C6D0F4-4C54-4E3A-B0BE-CB4A9677225F}">
-                <File Id="filFDF5ED320EBDD3488A9A83071319B9FD" Source="$(var.HarvestPath)\System.Security.Cryptography.Pkcs.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp9AFF12285630BC013517118B5EEA5D3C" Guid="{6407C3C2-59EE-456A-9275-210E1D673196}">
-                <File Id="fil5CF1A17519FD312AFF94811EE6B36214" Source="$(var.HarvestPath)\System.Security.Cryptography.Primitives.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpF504650A7859834E56B465827ADA1936" Guid="{6735B4A7-C2CF-411F-AB7D-D6361F952B6F}">
-                <File Id="filF3505C51B6D770D84F54BDDB6F4AE5C2" Source="$(var.HarvestPath)\System.Security.Cryptography.ProtectedData.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp6951ADE3434FC5DEA7A943576EAFC9C9" Guid="{5E5AECB5-1E10-45C6-8F49-5C624DD6BE5A}">
-                <File Id="fil19629832AA6A1448CA14FB1052541870" Source="$(var.HarvestPath)\System.Security.Cryptography.X509Certificates.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpA0BE31D5F64E6C8E4232B1246C6E6EBA" Guid="{5E324E42-5445-4FDF-99FE-D2F686434362}">
-                <File Id="filB839AACE9B1FA27047CB38A105A51A43" Source="$(var.HarvestPath)\System.Security.Principal.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp6AEFC17E20EAA1A80B51320D84CB4117" Guid="{CEA74AA7-E6D2-4557-893E-E6EED9F9A425}">
-                <File Id="fil79E5070652584CDC0B95879F06EF0079" Source="$(var.HarvestPath)\System.Security.Principal.Windows.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE7D2AE44E717D315763AA4408AAB16FB" Guid="{FC6FFF3F-5DD7-4951-BFC7-3CECBB511D5C}">
-                <File Id="fil2DEEED95EC66E42E5135E15E0D4BDEAC" Source="$(var.HarvestPath)\System.Security.SecureString.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp75DAC5FDC2337ECAD4CD4B6633997292" Guid="{AF5302DC-81D0-464F-A916-125D79044AAB}">
-                <File Id="fil882D2FAAA08CD42BDE8C89122E0451FC" Source="$(var.HarvestPath)\System.Text.Encoding.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp69B094884B9A8B61C779794ADEBBC1A9" Guid="{E7E2271A-8418-4929-A4CE-15A0C75F9749}">
-                <File Id="filF2A6B49561E51548D949049A3979C98E" Source="$(var.HarvestPath)\System.Text.Encoding.Extensions.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpC5D9D0B15AFBC0CF5AFAE1D408F93B74" Guid="{02C7A035-48E0-450B-9EC4-0661D0BE8FE8}">
-                <File Id="filFE0C8F47D86E044043A5140C2900BC86" Source="$(var.HarvestPath)\System.Text.RegularExpressions.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpF574B7D15C8F67E99CE93D4A59FC6585" Guid="{56C97A61-1741-4352-9D8B-F61F08348593}">
-                <File Id="fil6382A5666A4DE7DD4AB95697F7D2C79F" Source="$(var.HarvestPath)\System.Threading.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpEA99956125140C149444D0EA2A2FBD11" Guid="{888C8D7B-0523-4BEE-AFDB-8A4E64A451A5}">
-                <File Id="filFAEBEC1A0D6D5ECFF6E97BBAE0CA0AE3" Source="$(var.HarvestPath)\System.Threading.Overlapped.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp3B63C4A8BD59792FD308ADD749073AE3" Guid="{A0323136-12C6-4CA0-8B19-5872DD184AD2}">
-                <File Id="filAFB2C8AB9328AAA60E4F1F016E024155" Source="$(var.HarvestPath)\System.Threading.Tasks.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp632B6E4876B3D900A85D26C65E49B166" Guid="{2F8B12D0-BF0D-479D-A8C1-EF5FE00E0FF2}">
-                <File Id="filDD4E8354C14401F7691CA8D69B4AB49D" Source="$(var.HarvestPath)\System.Threading.Tasks.Parallel.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp6B712402D454F08D96D36C530166919B" Guid="{712D0088-7576-42CA-A93C-356B93B26018}">
-                <File Id="filFF87888E479CA922120322C6DD2CA43C" Source="$(var.HarvestPath)\System.Threading.Thread.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp8AEEDC24B08C41AED47ACF763BF574A1" Guid="{789A38BB-82A4-46D9-9D5E-DB5EF2873F53}">
-                <File Id="filAA0C516BEAE2F97B5992ADB07A7F7275" Source="$(var.HarvestPath)\System.Threading.ThreadPool.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpBAD65A0DD84D5EC853BB247DBE86F887" Guid="{BF23A0F0-92C4-47B4-B1E1-18931C0981C4}">
-                <File Id="filC3DA66B6AA09D95F39F5A2E562CCEA8B" Source="$(var.HarvestPath)\System.Threading.Timer.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpCB5E5E4C7D798FA2732BABDEB0BE886D" Guid="{8482BD14-7A43-4B95-BD60-9FC6E8DDB04C}">
-                <File Id="fil2D8127F560A04E97657BE7D1D9CB7525" Source="$(var.HarvestPath)\System.ValueTuple.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp4FE4E61EC9791201921745B40643CBB8" Guid="{19A73B39-7058-4619-B793-61D37CEF0A79}">
-                <File Id="fil6F11DE09547B0AE8405683CDB88F7FC4" Source="$(var.HarvestPath)\System.Windows.Interactivity.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpB29480D26980660C0E9ADE25F14B43AD" Guid="{EC622B3D-BB2F-4649-BDE3-537373EEEB66}">
-                <File Id="filA4CB8C3F6118005605F8F71AB7E4A572" Source="$(var.HarvestPath)\System.Xml.ReaderWriter.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE59C0BD28DF5A4DF51B1078ACE43A415" Guid="{762ABE47-40C8-41EF-9726-65BDC28B98E2}">
-                <File Id="fil6CC059A8F8B87D96BDD3CBBDDC6744CC" Source="$(var.HarvestPath)\System.Xml.XDocument.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp3123E1EB1C5D225391FC1D6617D55C3F" Guid="{6F2A4195-32F7-4E41-BE7A-3E2F488256E3}">
-                <File Id="filAF8592E2C3BEA2ADA7883648F5BD3E2B" Source="$(var.HarvestPath)\System.Xml.XmlDocument.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp31F020064DD03E3B81CC5C22BABF3806" Guid="{F44DCB21-1854-4532-9E9E-5DBB6D5704FA}">
-                <File Id="fil6551700C172C6669B5CFDCBAC0B650DD" Source="$(var.HarvestPath)\System.Xml.XmlSerializer.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7F8869CF8631075DAAB292885B3366B9" Guid="{5352FBD9-EF07-4F56-A7E5-D2325F73B7F2}">
-                <File Id="filBA372692826B579213FAF4D36C948A0B" Source="$(var.HarvestPath)\System.Xml.XPath.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp808A78AA924556012D14BE1271FD1203" Guid="{0F719ECF-DED9-4DA2-96DC-C44F5C59F0D3}">
-                <File Id="filD68A3D67F917418E29DB132D939A3029" Source="$(var.HarvestPath)\System.Xml.XPath.XDocument.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpF8D234C94A74E417EF588934DCFF97BD" Guid="{A29EE95B-F0B8-4BF0-9619-197C03E32472}">
-                <File Id="fil07765C69E2C4D71D1FC1CD8CA672FEA2" Source="$(var.HarvestPath)\TestableIO.System.IO.Abstractions.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpD00056C26CE3E92AF69A9586119ED38D" Guid="{3709FFAE-82B3-486F-8A9C-F6528B3D0199}">
-                <File Id="fil692327FD8941FA6A0FE25A6511E5C400" Source="$(var.HarvestPath)\TestableIO.System.IO.Abstractions.Wrappers.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp5DEA586D2ED0D6139C9215BE23D7EF3E" Guid="{7305C4B9-0BCE-4175-99E8-90EAA9001FA2}">
-                <File Id="fil492F2C28F3962CA93730F18422E5479B" Source="$(var.HarvestPath)\ToggleSwitch.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpD3FCA1DCFD6F1C58BCEAF979F86ABDE5" Guid="{1425CE82-09E1-4B79-8699-31F4347A0D6F}">
-                <File Id="fil89D560951B37A5D6C19ADE0A5C1AF890" Source="$(var.HarvestPath)\WpfCircularProgressBar.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp331A8D1EB324EFA20DDAC123A3CCBC20" Guid="{065C342A-C644-413E-B5C1-36BAD98018FA}">
-                <File Id="fil7877B30D7CCBC9A1D241D01A032E7702" Source="$(var.HarvestPath)\WpfCircularProgressBar.dll.config" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp7165B8BA93A80A0EA1B7728AD04D6E72" Guid="{6130F867-AA10-4D34-B47B-F9895036AFB3}">
-                <File Id="fil0F135695E925EFFCE422A78CD28F4C92" Source="$(var.HarvestPath)\Xceed.Wpf.AvalonDock.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmpE2468C9865F90573476173F547848D40" Guid="{6BE880F7-0A49-4346-8EAB-6583856B680D}">
-                <File Id="fil283C54AA0CCA5A82032AD6F88F3D5D84" Source="$(var.HarvestPath)\Xceed.Wpf.AvalonDock.Themes.Aero.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp25B7CDE65FC6F7EDFBADDCA69300789E" Guid="{7BEC34C4-3394-41AD-A1C1-24F75E9F641C}">
-                <File Id="filB6214F7016ABD85F0A90650A1F105B9C" Source="$(var.HarvestPath)\Xceed.Wpf.AvalonDock.Themes.Metro.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp9A0FBE0E3FB55EEBB37903AC9A080A23" Guid="{48581701-1778-44BA-9AB7-E0EB16A63BA8}">
-                <File Id="filBB96100CC38385FF7DB0DBFE799C5F23" Source="$(var.HarvestPath)\Xceed.Wpf.AvalonDock.Themes.VS2010.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Component Id="cmp6DF273F8C8C1322EE403E364E1D04A16" Guid="{87A3836B-6BBC-40E9-B742-150047C66EB4}">
-                <File Id="fil4F8E845B9B0CB9B26B9D7BA0D7737124" Source="$(var.HarvestPath)\Xceed.Wpf.Toolkit.dll" KeyPath="no" />
-                <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-            </Component>
-            <Directory Id="dir82972532CA27BEF6B972C3A142E19BC1" Name="cs-CZ">
-                <Component Id="cmpCAB95CA222FD066C2C7497309ED3B42D" Guid="{6E4D0FED-F993-4121-975B-EE12DA6FFF34}">
-                    <File Id="filCA42D07B4FBD03D93F55D109D4CAC8DD" Source="$(var.HarvestPath)\cs-CZ\Xceed.Wpf.AvalonDock.resources.dll" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-            </Directory>
-            <Directory Id="dirAF6DD7A53CA77B3027ADFBAEC049BD01" Name="DiscordIntegration">
-                <Directory Id="dir811F417A61360E81212787DAAAEA6D18" Name="DiscordGameSdk">
-                    <Component Id="cmpC0276994A573A078D26013C7FDACBC9F" Guid="{E5E7CD95-6E15-417A-AC7B-A0CE1EAC2C73}">
-                        <File Id="fil60282A969E4ADB939D147700568C1FA4" Source="$(var.HarvestPath)\DiscordIntegration\DiscordGameSdk\discord_game_sdk.bundle" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                    <Component Id="cmpE52BB7FC3DC29679069503B4DF297C59" Guid="{93AF5E00-F43F-403F-AC38-E1AA1FC9CD73}">
-                        <File Id="fil4FE9C5992E55E086DEB5F14F17040536" Source="$(var.HarvestPath)\DiscordIntegration\DiscordGameSdk\discord_game_sdk.dll" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                    <Component Id="cmpAD718F30AB48C261D251811A652C1A94" Guid="{4B959758-1B46-4C20-82B9-5C874EAEEB86}">
-                        <File Id="filB561F9823DCBCAFE44A9058BFB1907CC" Source="$(var.HarvestPath)\DiscordIntegration\DiscordGameSdk\discord_game_sdk.dylib" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                    <Component Id="cmp25256AE2947632219BC83B85B9C41CC9" Guid="{5BDCD566-F5C0-4D12-B61A-41F0C72B1C1C}">
-                        <File Id="fil15A92A4DBB5617EB41BF5F1589376F7D" Source="$(var.HarvestPath)\DiscordIntegration\DiscordGameSdk\discord_game_sdk.so" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                </Directory>
-            </Directory>
-            <Directory Id="dir236726D31B8846E56F94A60B4BDA0D5D" Name="ja-JP">
-                <Component Id="cmp3D9D9347147FF3133AFC17C7F9A998A4" Guid="{60F4AAC4-6D5B-47DE-B1E1-E4F6753C599A}">
-                    <File Id="fil760D80DF8AD4E443D2C0E378EAF5D02B" Source="$(var.HarvestPath)\ja-JP\Xceed.Wpf.AvalonDock.resources.dll" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-            </Directory>
-            <Directory Id="dirBC02319722C77D63C381B32042A43610" Name="Logs" />
-            <Directory Id="dirF5C503B5843C4B671B9659DAD472C99B" Name="nl-BE">
-                <Component Id="cmp7DADD6ADD2F165DAFF4A877D9CE92226" Guid="{FBCF5BA4-3CF0-4194-8EAD-7110880DB8F4}">
-                    <File Id="fil3AC2CD3D341C21CA07A55027F15A368F" Source="$(var.HarvestPath)\nl-BE\Xceed.Wpf.AvalonDock.resources.dll" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-            </Directory>
-            <Directory Id="dir61B122782F2749F187324C134F6498C1" Name="Resources">
-                <Component Id="cmp2FC36AEE2CF320C880B44E1AA37C3621" Guid="{83B249B0-A5B4-4683-A339-03DD8FD6734D}">
-                    <File Id="fil12236043116FD118BA8377F978BFCF29" Source="$(var.HarvestPath)\Resources\Icon.ico" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Directory Id="dir239481E6A388B3487D44CE1316E7F18D" Name="FileIcons">
-                    <Component Id="cmp5309461917AF261F7AA012868E31B24D" Guid="{D3219A79-B955-4C39-A50E-5DE010ACDD91}">
-                        <File Id="filCFF5B796DD323F2CD1F94F9BB1D19852" Source="$(var.HarvestPath)\Resources\FileIcons\Deck.ico" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                    <Component Id="cmp15CBF72A1B5100D015A36ED54D768755" Guid="{703541B4-69A9-43A5-A4A8-86497BC2902D}">
-                        <File Id="filEC9744E3D94AA0DF3F4D57C841ABA097" Source="$(var.HarvestPath)\Resources\FileIcons\Game.ico" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                    <Component Id="cmp66EA0083CE16F42885E9A45C8423F861" Guid="{E1AEABA2-81B2-4944-94CC-5400F3B141E9}">
-                        <File Id="fil6D03A9A21CDF9D68DE2C9BD237901984" Source="$(var.HarvestPath)\Resources\FileIcons\Patch.ico" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                    <Component Id="cmp7C5531A9CFC5BBD59347B4FE096D00AA" Guid="{7E1EA7D3-A6B8-4FC2-875F-EC8FE7947C4F}">
-                        <File Id="fil856A84B94078810C5F3E2627A9083523" Source="$(var.HarvestPath)\Resources\FileIcons\Set.ico" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                </Directory>
-                <Directory Id="dirC9449A876BE1D543C4BEF0F2A70550D0" Name="LoadingWindowAds">
-                    <Component Id="cmp365D3C9E067374AF45EF43A234B8A344" Guid="{4FC026B4-3B92-4FCE-95E0-155A8A6A1B4C}">
-                        <File Id="fil7D8171D3B9A84D453F45F1F4BEAD1C40" Source="$(var.HarvestPath)\Resources\LoadingWindowAds\0.jpg" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                </Directory>
-            </Directory>
-            <Directory Id="dir54B0732D1EC7055747BB11A9069B5872" Name="Schemas">
-                <Component Id="cmpF0C980121A5E61260C111F3B30F232B7" Guid="{E0265E59-4F6D-4278-A2B5-FCE19DE25DF3}">
-                    <File Id="fil06729F2D22F76C1C14C4E5CCFECD7113" Source="$(var.HarvestPath)\Schemas\CardGenerator.cs" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp0A14E0A89CCA0C7068384033422CD7AB" Guid="{760395F7-8D8F-47EC-B672-4693F2865DFF}">
-                    <File Id="fil1F00E8F3533087C519DA9886F47F4BA3" Source="$(var.HarvestPath)\Schemas\CardGenerator.xsd" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp99F64E4ABB9D6E632DDB60A9C9B7966D" Guid="{E3315A42-9307-495D-9D38-932932865B0E}">
-                    <File Id="fil292F5D9F5EB7C3E21016F041725CC72B" Source="$(var.HarvestPath)\Schemas\CardSet.cs" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp6CFF27CB489486958633E8131F5E4D96" Guid="{8D948D47-A76E-4189-AC93-0E4B101DCA59}">
-                    <File Id="fil887442C9CD7F584C63B462A90CCA26A8" Source="$(var.HarvestPath)\Schemas\CardSet.xsd" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp72BBB1DEFF5AA8D14FFE7F59F6DF3CD4" Guid="{28709386-E0C1-49DC-B923-A45F2423F082}">
-                    <File Id="fil50E5CC3FA9E1647BD267C83949B4CFC2" Source="$(var.HarvestPath)\Schemas\CardSet.xsx" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp50DEB045C2F6D94CF8F4EE13A02F2E29" Guid="{6D48957D-7F95-4D69-8376-04470450AB1A}">
-                    <File Id="fil6F6409B748DE1C1F03D9A4D261A0CC34" Source="$(var.HarvestPath)\Schemas\Game.cs" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp2BD3867353E7AAE34423CE42D2161179" Guid="{754482FF-31FE-41C8-9D15-B3B2E9FAC957}">
-                    <File Id="fil877781121FC71C521AB357B0EA510EB8" Source="$(var.HarvestPath)\Schemas\Game.xsd" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-            </Directory>
-            <Directory Id="dirEE481B3D48A90B5CC7FF22BC03F5F006" Name="Scripting">
-                <Directory Id="dir9A922803B4F75A03E6F353457F8EA5A3" Name="Lib">
-                    <Component Id="cmp5891E87842F703FAAD0E25A183FCAFB4" Guid="{59D01964-048B-4ECD-B7B1-5E5E4E4A10DC}">
-                        <File Id="filF74F3F46C3FAF66790BE2A322E6C041E" Source="$(var.HarvestPath)\Scripting\Lib\abc.py" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                    <Component Id="cmpA1F9E1D023828076838FEAF99357F1C8" Guid="{5769C0D7-2130-4F15-8513-262929BBF1C9}">
-                        <File Id="filA944E6A3C541E96E07B20E67F9238C39" Source="$(var.HarvestPath)\Scripting\Lib\bisect.py" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                    <Component Id="cmp82ABC1C65A89C8B85616CDB19B418F0A" Guid="{C619A228-08E8-46F2-BDF5-C607C58AB91E}">
-                        <File Id="filE566A2EF10CB0BBC2FEACEF2E8C7D619" Source="$(var.HarvestPath)\Scripting\Lib\collections.py" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                    <Component Id="cmp4224008DC8B545EE045E5C1D4F07B8A4" Guid="{868A5E45-2D93-49EF-9AE9-CFE17FAE9FA8}">
-                        <File Id="fil81BFE11B785618DA3DB5A17566D83C68" Source="$(var.HarvestPath)\Scripting\Lib\heapq.py" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                    <Component Id="cmpF7B23DD6C32500246DFE17B18912EEA7" Guid="{58656FD3-1DC3-4585-8B2B-7660473D087C}">
-                        <File Id="filE90141BD7A0FA78089564C66FD2EECBE" Source="$(var.HarvestPath)\Scripting\Lib\keyword.py" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                    <Component Id="cmp224C9CBD6D60697EF584DDD66966547B" Guid="{0054687E-AAFC-4C70-BEA2-AAC3E9550873}">
-                        <File Id="filF114FBC343C5F1E1638FCBE963F0B047" Source="$(var.HarvestPath)\Scripting\Lib\_abcoll.py" KeyPath="no" />
-                        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                    </Component>
-                </Directory>
-            </Directory>
-            <Directory Id="dirA1E22504AD8FC7CFED287202DA6698C6" Name="Sleeves">
-                <Component Id="cmp250FF729C8BD9E2DCC0A29FF3A42538B" Guid="{B87B441B-C68A-471E-B20A-B7BBC58275A2}">
-                    <File Id="fil0C4964D6D7A9F476E33F19B23A08B05D" Source="$(var.HarvestPath)\Sleeves\Air-Travel.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp851CF2A12D28A04576ED178EBC3EC14D" Guid="{CB1CE20B-4A27-4E10-83B9-B43B1DFBD779}">
-                    <File Id="filD7620265864475FB3EEC08D09DFFF8DB" Source="$(var.HarvestPath)\Sleeves\Canival.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmpBD11FE282EF2D6805D8CAF0C92545FC6" Guid="{2B2834A4-C3C3-474F-A858-FF206FF6D6FD}">
-                    <File Id="fil581B5B6F35B918A5DA83D8FBE0792CFD" Source="$(var.HarvestPath)\Sleeves\cb1.png" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp79D5CC1F35DDD4676DDE2FF3572F57A6" Guid="{DB42DE5B-AC7A-4B10-B291-201BBB25B3B3}">
-                    <File Id="filC391F0296D6AC22C661C6042EE0783F5" Source="$(var.HarvestPath)\Sleeves\cb2.png" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp192CC8EA92A74866C878D594EA47AB46" Guid="{934AE7B5-83FA-4758-9998-9BC2A1976A4A}">
-                    <File Id="fil212585BA14DB604B7B6C8EC2435209B6" Source="$(var.HarvestPath)\Sleeves\Dragon-Strategy.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp5E0622C834B75698A044409D256FADC6" Guid="{F05A2E12-53F5-4B7F-84A9-A8FCC56C7C11}">
-                    <File Id="filB3F095641B257D2EC37F995DEFB6D783" Source="$(var.HarvestPath)\Sleeves\Face-In-The-Crowd.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp94D11D053AB4429B17BB1608BBF07CC6" Guid="{041496A7-E766-4260-AD10-C2DE1763961E}">
-                    <File Id="fil82E6E391CC2B8CBCE76ACE3457ED581B" Source="$(var.HarvestPath)\Sleeves\GGG.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp560C08D6E294663FC928D9126A053846" Guid="{99E57949-6B99-4975-816B-FC988D617C27}">
-                    <File Id="fil320A638E2A30AAA5A92264B3EEE11129" Source="$(var.HarvestPath)\Sleeves\Homewrecker.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp9033A5A91CE68C70E9E5ADAC500381C9" Guid="{B256759C-6AE9-40B0-8C6D-C0496B6EED3F}">
-                    <File Id="fil0D758772E4249CAC52B1C872AFB55487" Source="$(var.HarvestPath)\Sleeves\Invent.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp9A12F2C14A49C01E49B1D3F62169973E" Guid="{7C8EB136-3ACF-4567-9323-6F536A75911B}">
-                    <File Id="fil912EE67B44627F17F582BDE8CEAEB4D7" Source="$(var.HarvestPath)\Sleeves\Master-Ritualist.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp2E2A69436DE79A0A6BA0F2F81AE392F5" Guid="{27026BAC-DF30-482E-BCD8-1AA3E7E38030}">
-                    <File Id="filBADC6F7D71DFF3BB30C3CACA7A14F4F8" Source="$(var.HarvestPath)\Sleeves\Monstrous-Lassitude.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp6AD9909523DFE5DF92AF0684CBEB1DA3" Guid="{3EC32BA4-5F5E-41C0-9E7E-A9A8E33C1ACF}">
-                    <File Id="fil39391AC12009D64F70040623FEB908CD" Source="$(var.HarvestPath)\Sleeves\P-Warrior.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp223CC4B60E550995D6D9E5C8339B3CC5" Guid="{064FA73F-0782-4DB2-BD95-DCD028F1795A}">
-                    <File Id="filEB3F10289D9191546E78C466597F36D7" Source="$(var.HarvestPath)\Sleeves\Rudo-Shade.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmpCE90934757713436DECA2402F52E8757" Guid="{A200A652-F90B-4C58-A55C-311E38F0E5ED}">
-                    <File Id="fil668672504F49F717118693173798DC91" Source="$(var.HarvestPath)\Sleeves\Straw-Man.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmpEB3AFAB0420906A35F7DC855CC84A3AC" Guid="{8BD442EE-DC16-40E7-93C3-8B0DD6D570A9}">
-                    <File Id="fil257C2F949BEC9DC7609B8527C19C4E09" Source="$(var.HarvestPath)\Sleeves\Thabbashite-Assailant.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-                <Component Id="cmp83A66EE5FA3672E5E11057D6309018B7" Guid="{D18AC9E6-BF97-4D07-856B-F5B55DE951C3}">
-                    <File Id="filB6A49476269249BC9B2FC4BB75F6C7D6" Source="$(var.HarvestPath)\Sleeves\The-Spoils.jpg" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-            </Directory>
-            <Directory Id="dir71F51BB8FFD7417900F6A6C18D636546" Name="SyntaxHighlighting">
-                <Component Id="cmp78FEACFB17F978B10A3C8CAE9BD4C26E" Guid="{8EAE20CF-C905-4551-8467-99EB054E8DE4}">
-                    <File Id="fil001E169FAF5F2F06989BD552A8EACD3C" Source="$(var.HarvestPath)\SyntaxHighlighting\Python.xshd" KeyPath="no" />
-                    <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
-                </Component>
-            </Directory>
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <ComponentGroup Id="O__HeatGenerated">
-            <ComponentRef Id="cmpE5004356FE7CC543DB30277EBA335A30" />
-            <ComponentRef Id="cmp669D7BFE3F77F8D3E757F78FE36D1217" />
-            <ComponentRef Id="cmpAA976D0FC5F51A5E72C45F0626C92246" />
-            <ComponentRef Id="cmp488D27FD7F12CC5B0CA2DA2EA3B41D0D" />
-            <ComponentRef Id="cmp7DB90804D3EED1D9CFD3C64FFB5E4115" />
-            <ComponentRef Id="cmp5B1CB9670A427F5E3F2553830607FC0D" />
-            <ComponentRef Id="cmp3E2C89676240A14A7164CA0B257A401F" />
-            <ComponentRef Id="cmp0E16CB47C3F6B22E2FFDD2CC515AD1C8" />
-            <ComponentRef Id="cmpD6D0ACC34D73AA09627602A91169D2DB" />
-            <ComponentRef Id="cmp39527D5EC1B0688C7C9D63712D499341" />
-            <ComponentRef Id="cmp78D15F6F5231CF1E19D525ABEE99FCA6" />
-            <ComponentRef Id="cmp253E049275FEE4BD1697BDA6EA4C9417" />
-            <ComponentRef Id="cmp13D6573EA8CF3F99F44BAE837E2771F0" />
-            <ComponentRef Id="cmpE395334EA0B9B925C1A69130E5678AF0" />
-            <ComponentRef Id="cmp2AC41B9A3E9E58C9FAC717C515DD6534" />
-            <ComponentRef Id="cmp6ECE5161C032390B6D41F4669C9B2FBA" />
-            <ComponentRef Id="cmpB828F2E0E3908AEB84554538E14583D2" />
-            <ComponentRef Id="cmp0B410F6F5DE5B5ECFF29B60BFB274F0F" />
-            <ComponentRef Id="cmpAA3D78E9B3AE6821E2C081A41FD040FD" />
-            <ComponentRef Id="cmp286A3BDB1EC430B908FD322B1322D746" />
-            <ComponentRef Id="cmp219E02EF943746676A4668B48FBE1820" />
-            <ComponentRef Id="cmp7F9ECE136F3D1474CBD79D0EDC835364" />
-            <ComponentRef Id="cmp48E1E5C93860F49EF00841C60B81D2E9" />
-            <ComponentRef Id="cmp5A3B0FEEF305F52451B314C57A61717B" />
-            <ComponentRef Id="cmp04FD776539E2628403B1D84D7E4D2BF3" />
-            <ComponentRef Id="cmp558FC5B3CC2B23E0A8DE37F92B4255E0" />
-            <ComponentRef Id="cmpEE5095AF5D6CA4E21BB31324DCA12A9D" />
-            <ComponentRef Id="cmp90BBBFEF1982BB90418B4644CF2F7828" />
-            <ComponentRef Id="cmpFEB20DDD1566488925514934FC1DD9D5" />
-            <ComponentRef Id="cmp93AF99501BD43251496EBFA1881A64EF" />
-            <ComponentRef Id="cmp6E690104F2F1BB697CC4758AD1E26E58" />
-            <ComponentRef Id="cmp1B3BA240BD1C077BF83416736D48186D" />
-            <ComponentRef Id="cmp4305F7BD8AC4EC7C4D0AA718D88266C2" />
-            <ComponentRef Id="cmp351597C63B1AC6EEBF7FC5A22A89959E" />
-            <ComponentRef Id="cmp90A934A8431ACC8512A4EA7F53BC937E" />
-            <ComponentRef Id="cmp9799763CBFF3E472309F980CF7998B39" />
-            <ComponentRef Id="cmpF3639C930704BB7395EC1FA447E3381B" />
-            <ComponentRef Id="cmpCB2E6D7505E8F9992D331D3A906C43F4" />
-            <ComponentRef Id="cmpA06D8E3E1D88DC98CDABEDC2E5C06BB4" />
-            <ComponentRef Id="cmpE3CF238EBFAA39F9B8A792C87C154D23" />
-            <ComponentRef Id="cmp1D298ECB70462F6B6B9C736D46C3703A" />
-            <ComponentRef Id="cmp1343B58142FF8A721A61A226461A348A" />
-            <ComponentRef Id="cmpA2394AB6E80CFE6873404D7E45067744" />
-            <ComponentRef Id="cmpC7DD7DCD8E4083B4375CEC2B790F42C4" />
-            <ComponentRef Id="cmpE45996FE404705547B851665885248CF" />
-            <ComponentRef Id="cmp06B5FF1D134B60C8550290639423F91D" />
-            <ComponentRef Id="cmp7254E72FE73F320AEB41601E41FB205C" />
-            <ComponentRef Id="cmp3BEA937DC04A8694133FFFE7D2D9DD04" />
-            <ComponentRef Id="cmp7DC125062D4B14D8FC6C510683E68764" />
-            <ComponentRef Id="cmp4370A5F473BC7C578FA8C4A674514135" />
-            <ComponentRef Id="cmpBF316BAA97EE8CE76D0E2E7D86CB70F5" />
-            <ComponentRef Id="cmp82951EB65984B52CAC92DE74F90EEE71" />
-            <ComponentRef Id="cmpD6E0355A434255FE85D95233B0AEB24C" />
-            <ComponentRef Id="cmpFC2072AC6AB749CFD7255D8127B1D945" />
-            <ComponentRef Id="cmp0CF5B14E86747BCFC1DDFCDF28AE4A82" />
-            <ComponentRef Id="cmp9ECFE97C3E16F0F19742C25CE41E91CC" />
-            <ComponentRef Id="cmp6107C12C2A55CB8E7E97FF2C9A33F385" />
-            <ComponentRef Id="cmpE5B545219A4761BDD755E5F33A229024" />
-            <ComponentRef Id="cmp7762CAE69A07BF558B2EDF1798F02FA8" />
-            <ComponentRef Id="cmp07814B6C8393BF87D48FD742866B4421" />
-            <ComponentRef Id="cmpCBAD1189E4A95476F45730EA6D8A3E03" />
-            <ComponentRef Id="cmpAE19781133491B2193381E0614D1D3D9" />
-            <ComponentRef Id="cmp76294603D17E356B01EC46623A3970CE" />
-            <ComponentRef Id="cmpB84206E7872F2865ED1F54C864FA6F34" />
-            <ComponentRef Id="cmpA29803D2B7B90F564254224D67C6AFD4" />
-            <ComponentRef Id="cmpACFF2DEC99E6BC166A0253634ED41A4F" />
-            <ComponentRef Id="cmp1874AB219070404EED322213C6A1A49E" />
-            <ComponentRef Id="cmp6C6E3A4782B29A777EAFACCECDE25A75" />
-            <ComponentRef Id="cmpB66FADA902303B620146AF05EF8B205C" />
-            <ComponentRef Id="cmp8DFFC5DEB197ECE614FFE3F5C7E04DE4" />
-            <ComponentRef Id="cmpAEDF2B3BA3696FBDD725B364F3E86ECE" />
-            <ComponentRef Id="cmp72CF3E6159C32478210203D321CFE41F" />
-            <ComponentRef Id="cmpF44C29B10AEFDB62AD0AF98A017AA917" />
-            <ComponentRef Id="cmp260D7C50CBDB73562628EC85FC92D384" />
-            <ComponentRef Id="cmp66F3E11ECD62C2F3F07FE833435629AE" />
-            <ComponentRef Id="cmp2C5E7C277E5AA44B5685A4B212F12806" />
-            <ComponentRef Id="cmp7573EC2390E2B47667BC392F0AB1294C" />
-            <ComponentRef Id="cmp5D12C26270BD09CA3D45919FA8719AE2" />
-            <ComponentRef Id="cmp5B6706A46F3A714C8F8DBBC8D99570F8" />
-            <ComponentRef Id="cmp5B4B4955C58608067B41D6BE02863260" />
-            <ComponentRef Id="cmp4D072D5842DFB1E9399C435C746D295F" />
-            <ComponentRef Id="cmpEEB4733FD782D8FCC77902F908470D17" />
-            <ComponentRef Id="cmp14EC87DA50B81B5E6A67429F9F656722" />
-            <ComponentRef Id="cmpECB62EFCC36DED701B049645322D5EA4" />
-            <ComponentRef Id="cmpDB3F27CA75DD8B428D656610D824F43E" />
-            <ComponentRef Id="cmp8F4B94EF0828B6BB61CFB54CF020D91D" />
-            <ComponentRef Id="cmp78D420543530ED3C4E9AF59E5E43A46A" />
-            <ComponentRef Id="cmp13DB3273CD8E9EFBC311065EC87BC2ED" />
-            <ComponentRef Id="cmp01B928B4ECBFCD61A6907C15B51FD576" />
-            <ComponentRef Id="cmp4AC56D024FE3EBC0C5D484FD32C6AD39" />
-            <ComponentRef Id="cmpE198BBD5DE02A49C4928C1C0050A8D2C" />
-            <ComponentRef Id="cmp816741CB75C2802164361F1A72B563A8" />
-            <ComponentRef Id="cmpC5DE7EC60F5EA8A9A5B95B7D4B9C5BC5" />
-            <ComponentRef Id="cmp4A176DBA1ADB8645F1FA42676F3A6B86" />
-            <ComponentRef Id="cmp4625614E297B1252FE7F922014CC80F1" />
-            <ComponentRef Id="cmp4DB7CFE68CF05E3AD59E02028E042BB9" />
-            <ComponentRef Id="cmp63DE213263DED6C2550F304BEE2CFE7A" />
-            <ComponentRef Id="cmp7F4884BAFC25CC83145B44C41BD9E715" />
-            <ComponentRef Id="cmp5F98DC92A09C93FA41A8E8735029D622" />
-            <ComponentRef Id="cmp94F2EBC9267AA03E64C0B4C125B6E0ED" />
-            <ComponentRef Id="cmp258FD747182EA4C603508266DBC1755E" />
-            <ComponentRef Id="cmp46AC8D28D9CA83259E3ED6310534D2DB" />
-            <ComponentRef Id="cmp6660405BF614CDE8F11AAA818351849C" />
-            <ComponentRef Id="cmpAED5FD47C57C7237045FCBCFE4808351" />
-            <ComponentRef Id="cmp2708F486C57CA602B063BE9697C5C4FF" />
-            <ComponentRef Id="cmp52CC0A0B26C40F9923BF174EBA67CAE4" />
-            <ComponentRef Id="cmp9B0BCDBA40A5A291A237F6B435F5FF75" />
-            <ComponentRef Id="cmp178679DA6076A0B4B6DF75E8E4258E14" />
-            <ComponentRef Id="cmp92EE4200C4A0C8862AD9CF28B1628DF1" />
-            <ComponentRef Id="cmp85D8CC8E2390ACE57897B8F9779150CD" />
-            <ComponentRef Id="cmpBB3FBFA8930E710EA15D7C39668E6B92" />
-            <ComponentRef Id="cmp3E631296B6A9F7DE8958713A82C16A85" />
-            <ComponentRef Id="cmpEC029F3A7060E84C5B2D271A9EDDB2A8" />
-            <ComponentRef Id="cmpAF0E057F905629B87D150B5E4CBA6ECF" />
-            <ComponentRef Id="cmp5482D5772865980D333DA18D1F255E64" />
-            <ComponentRef Id="cmp1C38F2C71379D97BF0854CDDD948F94D" />
-            <ComponentRef Id="cmp2DF0B2895DFC3CB720B48A6D9BFD37EF" />
-            <ComponentRef Id="cmp73085246C202ABD1D96D2E5DEFB2A801" />
-            <ComponentRef Id="cmpFCAB0086ACF92637C85CEFB939B694E1" />
-            <ComponentRef Id="cmpE4B4F7691D3ACD4A72AE99FFE470CE17" />
-            <ComponentRef Id="cmp33FDA478CB86F083519801379B2D2D8B" />
-            <ComponentRef Id="cmp75515765AA531707944115B02998F998" />
-            <ComponentRef Id="cmp22D219EF6A7035FFC0254F6BE572FF77" />
-            <ComponentRef Id="cmp22AEF5790256905123AF78698CD859DD" />
-            <ComponentRef Id="cmp5349EC5703EBCAA1E6C7DA272802BE58" />
-            <ComponentRef Id="cmp7B3236183FA982DA508702B357E3D75E" />
-            <ComponentRef Id="cmp58C198180EDB7D42EDD28920E1B2E513" />
-            <ComponentRef Id="cmp03737AA3B5F539D51D9418A6ED0E4F6C" />
-            <ComponentRef Id="cmpB25E057E8242CD01A509E8CBCAB104DA" />
-            <ComponentRef Id="cmp44C51162C2752731AF9E2E31BB09713C" />
-            <ComponentRef Id="cmpB0C2F11F7CA680BF7E48B8A4268E9C98" />
-            <ComponentRef Id="cmpA59732DC764B94E5F1FB4BDE22083814" />
-            <ComponentRef Id="cmpF6FEF9FF36C695681C6A77FAD09A51DA" />
-            <ComponentRef Id="cmpFE82493E4455C953D8F01BA5365F9C1A" />
-            <ComponentRef Id="cmp0E83A6F1E468052C63DFCFE168BE9F86" />
-            <ComponentRef Id="cmp50A76DD8AF0E25149A565F185A1F29A3" />
-            <ComponentRef Id="cmpDBAE7236105C33C9758DD48E8B6DCCB2" />
-            <ComponentRef Id="cmp5686A5DCF2A08C618B3500928277C12C" />
-            <ComponentRef Id="cmp8D6B0D0D5B997AF1B9BB2F2784692E03" />
-            <ComponentRef Id="cmp15CD896C1257803F1EAAF21F13643142" />
-            <ComponentRef Id="cmp29422AE271D6B2356E2AF332D256B1DE" />
-            <ComponentRef Id="cmpAA087E95574A085C5201D270F443E62E" />
-            <ComponentRef Id="cmp2AE6AC0EBDF241F5A2F3268BA1ACA754" />
-            <ComponentRef Id="cmp129F5F5267671C7AB542077C2BDD8D72" />
-            <ComponentRef Id="cmp23F7C2354109EC7F3034457C47235AA0" />
-            <ComponentRef Id="cmp1AB2F694FBE065FEC98E27EC233540D7" />
-            <ComponentRef Id="cmp4F71FF3179249F40AA83CC5D26424EFE" />
-            <ComponentRef Id="cmpCE934969B52A8BF6C3B94FA9636916F6" />
-            <ComponentRef Id="cmpC99C1FCF2F2B5727FFA9240232755632" />
-            <ComponentRef Id="cmp39DE53A6E602C76462F0260E369F2792" />
-            <ComponentRef Id="cmp4A7BCFB5DA46BC95D2E49236FC59D8A5" />
-            <ComponentRef Id="cmp3C994A927E01FC3CC7E0AE001AF0CD4C" />
-            <ComponentRef Id="cmp461F4A455CD0EB1AD2E4E35B51C09850" />
-            <ComponentRef Id="cmp6042D98678A0BF1EE1EB0EC4AF5E5C52" />
-            <ComponentRef Id="cmpEE5BBE99E2C22FC8023A8976953D2181" />
-            <ComponentRef Id="cmp3B693E836B896CF886DF7174A12D37F7" />
-            <ComponentRef Id="cmp8EB6B1FB2B50FFBB0CA48841D0C7E01B" />
-            <ComponentRef Id="cmpDB259A99945F85FEC221D6F75ACCB8EF" />
-            <ComponentRef Id="cmp4CFC7C3721FFD91FA4E9798A516D5E97" />
-            <ComponentRef Id="cmp7C8ACFEA497AD75401FFD01A9AEB31D4" />
-            <ComponentRef Id="cmpD577135453C63C124E24214ACA6ED9B4" />
-            <ComponentRef Id="cmp5CF9D73D8F28A4EF0D37B0136ED71006" />
-            <ComponentRef Id="cmpE95A3A7DB0E5B6B057A2BEF1A9ACCBA6" />
-            <ComponentRef Id="cmp57ED19A38749352B4A6312602AF32EEA" />
-            <ComponentRef Id="cmp3BED5AB46AF442FB282395C20F099F24" />
-            <ComponentRef Id="cmp4629EBAC56A143487ECF260AF98BF78D" />
-            <ComponentRef Id="cmp6A4CEF696231A141C3BD0E963AF7FC9A" />
-            <ComponentRef Id="cmpC11D8B4CADC383AE71657D4082C7C44C" />
-            <ComponentRef Id="cmp7CDF555F26EC27374503C4D251C0ADD7" />
-            <ComponentRef Id="cmp7FDA86390D774733F2019204F3EF9348" />
-            <ComponentRef Id="cmpA780BD9CC7EF10DE58A9E17B691B0205" />
-            <ComponentRef Id="cmp0ECCBE7E7A91EA3F9AC4E08C42060A74" />
-            <ComponentRef Id="cmp7320660D409A823430EC1ADFF0D83564" />
-            <ComponentRef Id="cmp68097EB457BBDE8DE960E7CC72000139" />
-            <ComponentRef Id="cmpC2109B9173A8B91CBDD411618A20588C" />
-            <ComponentRef Id="cmp48A7934AD38EE63A44A9478E1C31E3BB" />
-            <ComponentRef Id="cmp92E77A73B8159FC7BF51704F06BB1689" />
-            <ComponentRef Id="cmp82CD5F539E128C7A8CC025CBA927B9F3" />
-            <ComponentRef Id="cmp04E7760BC247B05C847A4A6D5D8C7091" />
-            <ComponentRef Id="cmp336F82620F5FFCA06611B8FD22F7066F" />
-            <ComponentRef Id="cmpF68CE304EDD0D14A7BFF18236F51BC48" />
-            <ComponentRef Id="cmp975FB1B5D4A3126E0525915FB4C90ECF" />
-            <ComponentRef Id="cmpE55D5ABD5E06B7AC82A1A464F710DC2E" />
-            <ComponentRef Id="cmpF8D128DB049817F164973BCC38DE4935" />
-            <ComponentRef Id="cmpEF0EA4DA72195CE89ADEBCDFBBB1A537" />
-            <ComponentRef Id="cmp058B1E2892E76D2F98E9569E383E5B83" />
-            <ComponentRef Id="cmp8383C67527BDAFE41A3001900C896480" />
-            <ComponentRef Id="cmp1D49D64F849E58598D108BA2293DAD87" />
-            <ComponentRef Id="cmpFFD9C90842D9C8A5251533EE3764882E" />
-            <ComponentRef Id="cmp852AADF38F8E567003DDA62F8B2655B6" />
-            <ComponentRef Id="cmp43A33CE3413979CC718E796B1C1E3E5B" />
-            <ComponentRef Id="cmp74104254FD237403FE1336A0257C4330" />
-            <ComponentRef Id="cmp92D5F6B984CFD9B211394CCCEE1F04A5" />
-            <ComponentRef Id="cmp7B9CC5FD009F8DDFD5BF9EA0D105C4CA" />
-            <ComponentRef Id="cmpDFB191D893C4B975B51D3352B7B82109" />
-            <ComponentRef Id="cmp626E0E80197224B4DF0D25BD513CFE42" />
-            <ComponentRef Id="cmp11C8DA598E403582C9E9F65C927CA880" />
-            <ComponentRef Id="cmp9AFF12285630BC013517118B5EEA5D3C" />
-            <ComponentRef Id="cmpF504650A7859834E56B465827ADA1936" />
-            <ComponentRef Id="cmp6951ADE3434FC5DEA7A943576EAFC9C9" />
-            <ComponentRef Id="cmpA0BE31D5F64E6C8E4232B1246C6E6EBA" />
-            <ComponentRef Id="cmp6AEFC17E20EAA1A80B51320D84CB4117" />
-            <ComponentRef Id="cmpE7D2AE44E717D315763AA4408AAB16FB" />
-            <ComponentRef Id="cmp75DAC5FDC2337ECAD4CD4B6633997292" />
-            <ComponentRef Id="cmp69B094884B9A8B61C779794ADEBBC1A9" />
-            <ComponentRef Id="cmpC5D9D0B15AFBC0CF5AFAE1D408F93B74" />
-            <ComponentRef Id="cmpF574B7D15C8F67E99CE93D4A59FC6585" />
-            <ComponentRef Id="cmpEA99956125140C149444D0EA2A2FBD11" />
-            <ComponentRef Id="cmp3B63C4A8BD59792FD308ADD749073AE3" />
-            <ComponentRef Id="cmp632B6E4876B3D900A85D26C65E49B166" />
-            <ComponentRef Id="cmp6B712402D454F08D96D36C530166919B" />
-            <ComponentRef Id="cmp8AEEDC24B08C41AED47ACF763BF574A1" />
-            <ComponentRef Id="cmpBAD65A0DD84D5EC853BB247DBE86F887" />
-            <ComponentRef Id="cmpCB5E5E4C7D798FA2732BABDEB0BE886D" />
-            <ComponentRef Id="cmp4FE4E61EC9791201921745B40643CBB8" />
-            <ComponentRef Id="cmpB29480D26980660C0E9ADE25F14B43AD" />
-            <ComponentRef Id="cmpE59C0BD28DF5A4DF51B1078ACE43A415" />
-            <ComponentRef Id="cmp3123E1EB1C5D225391FC1D6617D55C3F" />
-            <ComponentRef Id="cmp31F020064DD03E3B81CC5C22BABF3806" />
-            <ComponentRef Id="cmp7F8869CF8631075DAAB292885B3366B9" />
-            <ComponentRef Id="cmp808A78AA924556012D14BE1271FD1203" />
-            <ComponentRef Id="cmpF8D234C94A74E417EF588934DCFF97BD" />
-            <ComponentRef Id="cmpD00056C26CE3E92AF69A9586119ED38D" />
-            <ComponentRef Id="cmp5DEA586D2ED0D6139C9215BE23D7EF3E" />
-            <ComponentRef Id="cmpD3FCA1DCFD6F1C58BCEAF979F86ABDE5" />
-            <ComponentRef Id="cmp331A8D1EB324EFA20DDAC123A3CCBC20" />
-            <ComponentRef Id="cmp7165B8BA93A80A0EA1B7728AD04D6E72" />
-            <ComponentRef Id="cmpE2468C9865F90573476173F547848D40" />
-            <ComponentRef Id="cmp25B7CDE65FC6F7EDFBADDCA69300789E" />
-            <ComponentRef Id="cmp9A0FBE0E3FB55EEBB37903AC9A080A23" />
-            <ComponentRef Id="cmp6DF273F8C8C1322EE403E364E1D04A16" />
-            <ComponentRef Id="cmpCAB95CA222FD066C2C7497309ED3B42D" />
-            <ComponentRef Id="cmpC0276994A573A078D26013C7FDACBC9F" />
-            <ComponentRef Id="cmpE52BB7FC3DC29679069503B4DF297C59" />
-            <ComponentRef Id="cmpAD718F30AB48C261D251811A652C1A94" />
-            <ComponentRef Id="cmp25256AE2947632219BC83B85B9C41CC9" />
-            <ComponentRef Id="cmp3D9D9347147FF3133AFC17C7F9A998A4" />
-            <ComponentRef Id="cmp7DADD6ADD2F165DAFF4A877D9CE92226" />
-            <ComponentRef Id="cmp2FC36AEE2CF320C880B44E1AA37C3621" />
-            <ComponentRef Id="cmp5309461917AF261F7AA012868E31B24D" />
-            <ComponentRef Id="cmp15CBF72A1B5100D015A36ED54D768755" />
-            <ComponentRef Id="cmp66EA0083CE16F42885E9A45C8423F861" />
-            <ComponentRef Id="cmp7C5531A9CFC5BBD59347B4FE096D00AA" />
-            <ComponentRef Id="cmp365D3C9E067374AF45EF43A234B8A344" />
-            <ComponentRef Id="cmpF0C980121A5E61260C111F3B30F232B7" />
-            <ComponentRef Id="cmp0A14E0A89CCA0C7068384033422CD7AB" />
-            <ComponentRef Id="cmp99F64E4ABB9D6E632DDB60A9C9B7966D" />
-            <ComponentRef Id="cmp6CFF27CB489486958633E8131F5E4D96" />
-            <ComponentRef Id="cmp72BBB1DEFF5AA8D14FFE7F59F6DF3CD4" />
-            <ComponentRef Id="cmp50DEB045C2F6D94CF8F4EE13A02F2E29" />
-            <ComponentRef Id="cmp2BD3867353E7AAE34423CE42D2161179" />
-            <ComponentRef Id="cmp5891E87842F703FAAD0E25A183FCAFB4" />
-            <ComponentRef Id="cmpA1F9E1D023828076838FEAF99357F1C8" />
-            <ComponentRef Id="cmp82ABC1C65A89C8B85616CDB19B418F0A" />
-            <ComponentRef Id="cmp4224008DC8B545EE045E5C1D4F07B8A4" />
-            <ComponentRef Id="cmpF7B23DD6C32500246DFE17B18912EEA7" />
-            <ComponentRef Id="cmp224C9CBD6D60697EF584DDD66966547B" />
-            <ComponentRef Id="cmp250FF729C8BD9E2DCC0A29FF3A42538B" />
-            <ComponentRef Id="cmp851CF2A12D28A04576ED178EBC3EC14D" />
-            <ComponentRef Id="cmpBD11FE282EF2D6805D8CAF0C92545FC6" />
-            <ComponentRef Id="cmp79D5CC1F35DDD4676DDE2FF3572F57A6" />
-            <ComponentRef Id="cmp192CC8EA92A74866C878D594EA47AB46" />
-            <ComponentRef Id="cmp5E0622C834B75698A044409D256FADC6" />
-            <ComponentRef Id="cmp94D11D053AB4429B17BB1608BBF07CC6" />
-            <ComponentRef Id="cmp560C08D6E294663FC928D9126A053846" />
-            <ComponentRef Id="cmp9033A5A91CE68C70E9E5ADAC500381C9" />
-            <ComponentRef Id="cmp9A12F2C14A49C01E49B1D3F62169973E" />
-            <ComponentRef Id="cmp2E2A69436DE79A0A6BA0F2F81AE392F5" />
-            <ComponentRef Id="cmp6AD9909523DFE5DF92AF0684CBEB1DA3" />
-            <ComponentRef Id="cmp223CC4B60E550995D6D9E5C8339B3CC5" />
-            <ComponentRef Id="cmpCE90934757713436DECA2402F52E8757" />
-            <ComponentRef Id="cmpEB3AFAB0420906A35F7DC855CC84A3AC" />
-            <ComponentRef Id="cmp83A66EE5FA3672E5E11057D6309018B7" />
-            <ComponentRef Id="cmp78FEACFB17F978B10A3C8CAE9BD4C26E" />
-        </ComponentGroup>
-    </Fragment>
+  <Fragment>
+    <DirectoryRef Id="INSTALLDIR">
+      <Component Id="RemoveInstalledDirectories" Guid="{34385794-6793-4ECF-AB54-775546E3B4C5}" Location="local">
+        <RemoveFolder Id="dir82972532CA27BEF6B972C3A142E19BC1" Directory="dir82972532CA27BEF6B972C3A142E19BC1" On="uninstall" />
+        <RemoveFolder Id="dirAF6DD7A53CA77B3027ADFBAEC049BD01" Directory="dirAF6DD7A53CA77B3027ADFBAEC049BD01" On="uninstall" />
+        <RemoveFolder Id="dir811F417A61360E81212787DAAAEA6D18" Directory="dir811F417A61360E81212787DAAAEA6D18" On="uninstall" />
+        <RemoveFolder Id="dir236726D31B8846E56F94A60B4BDA0D5D" Directory="dir236726D31B8846E56F94A60B4BDA0D5D" On="uninstall" />
+        <RemoveFolder Id="dirF5C503B5843C4B671B9659DAD472C99B" Directory="dirF5C503B5843C4B671B9659DAD472C99B" On="uninstall" />
+        <RemoveFolder Id="dir61B122782F2749F187324C134F6498C1" Directory="dir61B122782F2749F187324C134F6498C1" On="uninstall" />
+        <RemoveFolder Id="dir239481E6A388B3487D44CE1316E7F18D" Directory="dir239481E6A388B3487D44CE1316E7F18D" On="uninstall" />
+        <RemoveFolder Id="dirC9449A876BE1D543C4BEF0F2A70550D0" Directory="dirC9449A876BE1D543C4BEF0F2A70550D0" On="uninstall" />
+        <RemoveFolder Id="dir54B0732D1EC7055747BB11A9069B5872" Directory="dir54B0732D1EC7055747BB11A9069B5872" On="uninstall" />
+        <RemoveFolder Id="dirEE481B3D48A90B5CC7FF22BC03F5F006" Directory="dirEE481B3D48A90B5CC7FF22BC03F5F006" On="uninstall" />
+        <RemoveFolder Id="dir9A922803B4F75A03E6F353457F8EA5A3" Directory="dir9A922803B4F75A03E6F353457F8EA5A3" On="uninstall" />
+        <RemoveFolder Id="dirA1E22504AD8FC7CFED287202DA6698C6" Directory="dirA1E22504AD8FC7CFED287202DA6698C6" On="uninstall" />
+        <RemoveFolder Id="dir71F51BB8FFD7417900F6A6C18D636546" Directory="dir71F51BB8FFD7417900F6A6C18D636546" On="uninstall" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE5004356FE7CC543DB30277EBA335A30" Guid="{83E01714-D132-4FF7-8CEF-9EF12D2F6613}">
+        <File Id="fil5159DCE9D857F88BB103745E425061C9" Source="$(var.HarvestPath)\CommonServiceLocator.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp669D7BFE3F77F8D3E757F78FE36D1217" Guid="{50C6B440-1B68-45A8-91D1-311B7D690DEC}">
+        <File Id="fil01FD9A438453A336BFC7E1C098C52A86" Source="$(var.HarvestPath)\ControlzEx.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp488D27FD7F12CC5B0CA2DA2EA3B41D0D" Guid="{B094F1BB-C7F8-4CA1-BB4E-47DA8FA55B9C}">
+        <File Id="fil185ABF006E89BA8A4D51B571C8563487" Source="$(var.HarvestPath)\GalaSoft.MvvmLight.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7DB90804D3EED1D9CFD3C64FFB5E4115" Guid="{DAA3B81C-DBF6-42F9-A7F1-10CAD718D96D}">
+        <File Id="fil767D16365A57A31EFB10B16A311C4A96" Source="$(var.HarvestPath)\GalaSoft.MvvmLight.Extras.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp5B1CB9670A427F5E3F2553830607FC0D" Guid="{34C78223-5D1D-4877-8DB3-581B9C3173B9}">
+        <File Id="fil3D52221AD70477F85AC254E167A7BD0B" Source="$(var.HarvestPath)\GalaSoft.MvvmLight.Platform.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp3E2C89676240A14A7164CA0B257A401F" Guid="{E8A8B752-90FE-4717-8F2A-27C71DC0B7B4}">
+        <File Id="fil3DE3BA5197F12E35F960885AF9394DB6" Source="$(var.HarvestPath)\GongSolutions.WPF.DragDrop.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp0E16CB47C3F6B22E2FFDD2CC515AD1C8" Guid="{95BD7D1A-D316-48CE-B12C-7C42BBD9F309}">
+        <File Id="fil6D3D5546417727749907FC9E19D97FF8" Source="$(var.HarvestPath)\ICSharpCode.AvalonEdit.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpD6D0ACC34D73AA09627602A91169D2DB" Guid="{A3E80A48-5A6A-4AF2-95EB-588663B1444D}">
+        <File Id="fil2806E2EABDDD9EB65DA3C51FFB074B1D" Source="$(var.HarvestPath)\IronPython.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp39527D5EC1B0688C7C9D63712D499341" Guid="{28A132DA-3E57-42EE-8FB3-F52C3F1DF286}">
+        <File Id="filF01A5A4471C5C531E7F4BDEC9D26323B" Source="$(var.HarvestPath)\IronPython.Modules.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp78D15F6F5231CF1E19D525ABEE99FCA6" Guid="{5C7FD485-176F-4060-B0F7-065080395A9E}">
+        <File Id="fil83AC47640800262DC0ACAB230E1CC60B" Source="$(var.HarvestPath)\IronPython.SQLite.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp253E049275FEE4BD1697BDA6EA4C9417" Guid="{43C89E4D-5741-47D2-AF98-C1508D75502D}">
+        <File Id="filB29DAEF7CB7926EF25FF78193684E66C" Source="$(var.HarvestPath)\IronPython.Wpf.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp13D6573EA8CF3F99F44BAE837E2771F0" Guid="{C39E1435-5802-4F53-BC86-8F1EAE8B5317}">
+        <File Id="fil2991F53D601CDF7142D0A9E1B42E116E" Source="$(var.HarvestPath)\log4net.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE395334EA0B9B925C1A69130E5678AF0" Guid="{994E3A12-FC6E-438A-9355-54DA5C679C92}">
+        <File Id="filA3AA19892B63F96ED05F28829FC89F94" Source="$(var.HarvestPath)\logging.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp2AC41B9A3E9E58C9FAC717C515DD6534" Guid="{0423E0F6-0386-4C54-BE54-AE6B5108D0F9}">
+        <File Id="filC48A97D03FAF26C6CB0B00A73EBC747A" Source="$(var.HarvestPath)\MahApps.Metro.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp6ECE5161C032390B6D41F4669C9B2FBA" Guid="{BA204D11-6864-4EC2-A785-EC18123A117D}">
+        <File Id="fil12A79ACDDBCCB205B2316C211EFDB9C5" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.BootstrapIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpB828F2E0E3908AEB84554538E14583D2" Guid="{BAD743B3-FE4E-451E-B607-204417992BAB}">
+        <File Id="fil4A85852AFF564A727068558456B40A96" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.BoxIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp0B410F6F5DE5B5ECFF29B60BFB274F0F" Guid="{CFC18000-2933-4D16-9C51-5AEF0DA61D8B}">
+        <File Id="filDA9835F7AF9DFA7028A598514D8FD4E8" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Codicons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpC173D9C7C59B34A6E81F67962030049C" Guid="{2983518E-8E8D-40DD-A8E4-516E55DA2DAD}">
+        <File Id="fil566603B0CB013198CE5E793261212BDF" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Coolicons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpAA3D78E9B3AE6821E2C081A41FD040FD" Guid="{740FE4B8-95CB-4F55-BDBC-C1A50FE86E7F}">
+        <File Id="fil41A7C42F7C04E764DDE088620AF23D8E" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Core.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp286A3BDB1EC430B908FD322B1322D746" Guid="{59FD3996-10DD-42DA-A2D1-24406C777086}">
+        <File Id="fil3D712A15730F07F094E6844258950361" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp219E02EF943746676A4668B48FBE1820" Guid="{7B266787-5BA5-4188-B9FF-F44834B9C15C}">
+        <File Id="filD24A8005F1224750204A4571D045A568" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Entypo.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7F9ECE136F3D1474CBD79D0EDC835364" Guid="{CC4E67A5-BBE4-4BAB-B8F2-F3762DF35785}">
+        <File Id="fil36943521145537089B063D681E2FE2EB" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.EvaIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp48E1E5C93860F49EF00841C60B81D2E9" Guid="{6A4732B0-5ECF-453F-9268-BFF3E4510097}">
+        <File Id="filDECE322D4CF04F3C3CE84BD2C78CFE73" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.FeatherIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp5A3B0FEEF305F52451B314C57A61717B" Guid="{5F7D2114-ACDB-44B0-BD75-840CACF0273F}">
+        <File Id="filC0E8B93A1F48A011740009B168DB698B" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.FileIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp04FD776539E2628403B1D84D7E4D2BF3" Guid="{04F7DD54-C628-4303-B411-E56F295143F4}">
+        <File Id="filD75DE729566832C3DDAE2FB2BCBDF9E6" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Fontaudio.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp558FC5B3CC2B23E0A8DE37F92B4255E0" Guid="{D08EAE05-CF0F-42FC-94A0-0F5E695E3121}">
+        <File Id="filB47F5825E05B63D1F79D61A45D9978E5" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.FontAwesome.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp15D8C5940372B97CA9C98944AF6922A3" Guid="{03CF112E-2440-47FC-937B-46221A6513B3}">
+        <File Id="fil348CB4EA6988C282EAE3B8437FD88739" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Fontisto.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpEE5095AF5D6CA4E21BB31324DCA12A9D" Guid="{B5D495B1-BA87-42AB-9A52-D48358B627D7}">
+        <File Id="fil8E692CA1019718C99A7B2DF09D2682DC" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.ForkAwesome.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp90BBBFEF1982BB90418B4644CF2F7828" Guid="{5E73A6B6-4142-4669-B4F1-03412CC61F06}">
+        <File Id="fil6BAC0A24DAC7F39A1620E95997185B5F" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Ionicons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpFEB20DDD1566488925514934FC1DD9D5" Guid="{6A1455F2-BA8E-47BA-B95B-8C7FC7604309}">
+        <File Id="fil96729ABD08F7D5011F4AD8C30E7FCBB0" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.JamIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp93AF99501BD43251496EBFA1881A64EF" Guid="{1195F1E9-083F-4A5B-9BCC-99E393615AAA}">
+        <File Id="filAFBAE20130F99F271F54C2951B2BAD34" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Material.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp6E690104F2F1BB697CC4758AD1E26E58" Guid="{1B5F85B3-CE8C-43DB-ADA7-E794D3C3BEE8}">
+        <File Id="filCC531ED0434ABA77DD529A9B508AE0F0" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.MaterialDesign.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp1B3BA240BD1C077BF83416736D48186D" Guid="{3F196920-29DF-49D4-AB4F-96BAF0B6C695}">
+        <File Id="fil6BE9ACE2E766B800E6FF54F4E697D460" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.MaterialLight.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4305F7BD8AC4EC7C4D0AA718D88266C2" Guid="{BAD90132-451E-4E93-9AEC-3A709F6FC768}">
+        <File Id="fil1353F3D65C99A57CE7FEE3E813A915C5" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Microns.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp351597C63B1AC6EEBF7FC5A22A89959E" Guid="{09330475-0055-47D3-ADEF-7BE45F91E941}">
+        <File Id="fil370BD642BFD820178252FA7494C0652F" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Modern.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp90A934A8431ACC8512A4EA7F53BC937E" Guid="{C1F70FBF-D5F8-4DB8-9B2B-F738515CF9E2}">
+        <File Id="filDAECF68FD05D1A7565D1F23F70456832" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Octicons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp9799763CBFF3E472309F980CF7998B39" Guid="{B0139F0B-C89A-46B9-A8A7-2ABB2B8276C5}">
+        <File Id="fil1C9F04DF88B43F1AD9753E1160ACC824" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.PicolIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpF3639C930704BB7395EC1FA447E3381B" Guid="{581F4293-9752-4B7C-9BE9-BC3794BDD1DD}">
+        <File Id="filF0152A8A540DAC9CB21C2DFC3C6CF225" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.PixelartIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpCB2E6D7505E8F9992D331D3A906C43F4" Guid="{D6F7B466-9C68-4FF5-A489-0ED6037E08DE}">
+        <File Id="fil089D5E6B326A0FF9C2DA536B5A0F00B1" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.RadixIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpA06D8E3E1D88DC98CDABEDC2E5C06BB4" Guid="{A4A723DF-5C19-4273-ADA7-6FB8E2E26213}">
+        <File Id="fil84795354B6D4F23CC639F91FBA101F9C" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.RemixIcon.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE3CF238EBFAA39F9B8A792C87C154D23" Guid="{CB42D9A8-2DDD-4022-9EA2-64FCEBA09B07}">
+        <File Id="fil73FB4D9BCCE8C4486C1322A5C9783B52" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.RPGAwesome.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp1D298ECB70462F6B6B9C736D46C3703A" Guid="{A23D12F8-06B7-498B-8228-F519F9F56D65}">
+        <File Id="fil7536289E16969FC23A4B8C686710CC3E" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.SimpleIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp1343B58142FF8A721A61A226461A348A" Guid="{48F46113-EEC1-4245-8202-A609CB703AC8}">
+        <File Id="filF966C280AC0005F57F91968D0EE1B645" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Typicons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpA2394AB6E80CFE6873404D7E45067744" Guid="{D9F40138-7C75-4D87-B59F-628ED9562572}">
+        <File Id="fil723C34647F418233D488A22D0103A8F1" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Unicons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpC7DD7DCD8E4083B4375CEC2B790F42C4" Guid="{649B8C83-0E2D-446C-8920-B699FE93CB21}">
+        <File Id="fil25607EF9627D38D21F76141459FAF6BF" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.VaadinIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE45996FE404705547B851665885248CF" Guid="{2BC8980D-DD23-4227-B17F-0308FD4D20D5}">
+        <File Id="fil48F04595EE37A65779B1C74F49CCDEE2" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.WeatherIcons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp06B5FF1D134B60C8550290639423F91D" Guid="{FB46FD9F-9C4F-4C19-941C-E6EEAE3D1DA3}">
+        <File Id="fil206A0BAC6AC49BDE329150BF3348CDBC" Source="$(var.HarvestPath)\MahApps.Metro.IconPacks.Zondicons.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7254E72FE73F320AEB41601E41FB205C" Guid="{EA402757-32A6-4B3D-9CC3-C8BFDED92605}">
+        <File Id="fil13415A8D8C4BF2A65643689519A0020A" Source="$(var.HarvestPath)\Microsoft.Dynamic.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp3BEA937DC04A8694133FFFE7D2D9DD04" Guid="{01D04ACE-187A-47B2-906B-C717310BB624}">
+        <File Id="filFBE32D4AF66E9BC3F6EF09887D4DC489" Source="$(var.HarvestPath)\Microsoft.Scripting.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7DC125062D4B14D8FC6C510683E68764" Guid="{C50B591C-6B87-43E3-8BD8-A16DB01EAA79}">
+        <File Id="fil69C17A90B7EBC90FF29B44ABCB1E8B50" Source="$(var.HarvestPath)\Microsoft.Scripting.Metadata.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4370A5F473BC7C578FA8C4A674514135" Guid="{2721EACB-1371-47A3-869A-7FCB25A13BEC}">
+        <File Id="fil44FD26BE5AA3BE512E4A18D3072087AE" Source="$(var.HarvestPath)\Microsoft.Threading.Tasks.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpBF316BAA97EE8CE76D0E2E7D86CB70F5" Guid="{C188975D-8EE9-4FE5-9382-AC510AFAC32B}">
+        <File Id="fil3F3FAF9A5D44A074B2AB8FC3101C1A92" Source="$(var.HarvestPath)\Microsoft.Threading.Tasks.Extensions.Desktop.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp82951EB65984B52CAC92DE74F90EEE71" Guid="{6C4FC451-4D29-4256-8183-348188964D86}">
+        <File Id="fil4A3914E8BA2E4BD8BB82F62B0967AAFB" Source="$(var.HarvestPath)\Microsoft.Threading.Tasks.Extensions.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpD6E0355A434255FE85D95233B0AEB24C" Guid="{AEA6879A-C7AD-4899-90EA-4E84A6719ADD}">
+        <File Id="fil68B8557306E79D976A11D85295D37CCB" Source="$(var.HarvestPath)\Microsoft.Web.XmlTransform.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpFC2072AC6AB749CFD7255D8127B1D945" Guid="{05DFA1A4-BCE8-466E-ABB1-F4ECE8742900}">
+        <File Id="fil9394A47DDAD5C82DE43D4227296DDBFB" Source="$(var.HarvestPath)\Microsoft.Win32.Primitives.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp0CF5B14E86747BCFC1DDFCDF28AE4A82" Guid="{56421E0D-120E-4B9D-ADDB-8EE5DDF9225C}">
+        <File Id="fil20B8F60F955E06C42916655EC36B7FF6" Source="$(var.HarvestPath)\Microsoft.Win32.Registry.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp9ECFE97C3E16F0F19742C25CE41E91CC" Guid="{407029F4-62C6-4725-B732-B7EEC4269121}">
+        <File Id="fil6FBF3F6F8C26D2CD1CD858B08DE0A938" Source="$(var.HarvestPath)\Microsoft.WindowsAzure.Configuration.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp6107C12C2A55CB8E7E97FF2C9A33F385" Guid="{CEF9790C-53F4-4A50-9A65-7D2CADA9BC1A}">
+        <File Id="fil135F9AEEB4A74E1EE438100986E97C41" Source="$(var.HarvestPath)\Microsoft.Xaml.Behaviors.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE5B545219A4761BDD755E5F33A229024" Guid="{0A932FA4-BD93-41AF-9C20-492270418718}">
+        <File Id="filF85B362BB09126F71319D8C4C09F7A00" Source="$(var.HarvestPath)\Mono.Options.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7762CAE69A07BF558B2EDF1798F02FA8" Guid="{3344BF4A-BA94-4B97-AE66-492F109D066A}">
+        <File Id="fil422AD37AD210EABF4A29945700C514C9" Source="$(var.HarvestPath)\NAudio.Asio.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp07814B6C8393BF87D48FD742866B4421" Guid="{9EE27989-4B4C-4DC1-932D-F18741B0FFAD}">
+        <File Id="fil2DFD8B340CAF47C2A37E6FB0AEF11FDD" Source="$(var.HarvestPath)\NAudio.Core.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpCBAD1189E4A95476F45730EA6D8A3E03" Guid="{A92C03CA-C2C7-4E3A-8781-D239DDA3E1BB}">
+        <File Id="filB5CE7890FC801E39F6B9B8C9FF5E4D0D" Source="$(var.HarvestPath)\NAudio.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpAE19781133491B2193381E0614D1D3D9" Guid="{582E748F-6F1F-46C4-B93D-CE17015EBAD7}">
+        <File Id="fil6ECEDDF70D62C4F861EEFDD84439EED5" Source="$(var.HarvestPath)\NAudio.Midi.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp76294603D17E356B01EC46623A3970CE" Guid="{D48ABE47-46F7-425F-8CD9-3A109B68E3CD}">
+        <File Id="filB67CC63B9C4671EA549F17299B5F53C0" Source="$(var.HarvestPath)\NAudio.Wasapi.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpB84206E7872F2865ED1F54C864FA6F34" Guid="{DE029EF5-4D2C-48F1-BD24-D394E24D6D82}">
+        <File Id="fil875692AF07DA73A676DC839BE3843D28" Source="$(var.HarvestPath)\NAudio.WinForms.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpA29803D2B7B90F564254224D67C6AFD4" Guid="{7527BD5E-FD5E-4C52-9138-37F3DA39CA6A}">
+        <File Id="fil39F2D5E0248524222CADBE8693A5AA54" Source="$(var.HarvestPath)\NAudio.WinMM.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpACFF2DEC99E6BC166A0253634ED41A4F" Guid="{95EA59E0-BF04-4CBC-8DA4-65CF3E501B9D}">
+        <File Id="fil21E384679BF7C5ECBD525841F6692B51" Source="$(var.HarvestPath)\netstandard.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp1874AB219070404EED322213C6A1A49E" Guid="{7DFFE2B0-5F55-47C9-B2DE-F453C060BF87}">
+        <File Id="fil05FF769999D602AD4FA6A489C44ED290" Source="$(var.HarvestPath)\Newtonsoft.Json.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp6C6E3A4782B29A777EAFACCECDE25A75" Guid="{378E77A4-87B4-434C-9D42-C032A34FAEAC}">
+        <File Id="fil61E2178807DDF4CB67E717F57A0B45E1" Source="$(var.HarvestPath)\Ninject.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpB66FADA902303B620146AF05EF8B205C" Guid="{D9BC8B91-EF02-4996-B90A-6842560F07CA}">
+        <File Id="fil9C4309AE2C59075802B06539F1944B44" Source="$(var.HarvestPath)\Nito.AsyncEx.Context.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp8DFFC5DEB197ECE614FFE3F5C7E04DE4" Guid="{C46CA214-FDB5-411E-B191-BAA4E0F13B96}">
+        <File Id="filF20CF67215C2139C8693496EC24E5D08" Source="$(var.HarvestPath)\Nito.AsyncEx.Coordination.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpAEDF2B3BA3696FBDD725B364F3E86ECE" Guid="{F62A51A0-B74B-4DE5-82DA-7342A63715FF}">
+        <File Id="fil7C1F3919999C7AD7A00A53673BBF482F" Source="$(var.HarvestPath)\Nito.AsyncEx.Interop.WaitHandles.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp72CF3E6159C32478210203D321CFE41F" Guid="{1BB5C801-F37D-465B-A5FC-895FDDC776A2}">
+        <File Id="fil13B8DC0EDCDD02F838AC62535FFD0417" Source="$(var.HarvestPath)\Nito.AsyncEx.Oop.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpF44C29B10AEFDB62AD0AF98A017AA917" Guid="{CDA86211-AB13-4A49-904F-4DEBE947E158}">
+        <File Id="filB1FCE5EF20B18AB8634E9D0BFFE17CC1" Source="$(var.HarvestPath)\Nito.AsyncEx.Tasks.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp260D7C50CBDB73562628EC85FC92D384" Guid="{DF9C49F4-9BB7-457E-8C77-6090FA13713B}">
+        <File Id="fil737FB645C88EF94C8F7DFEC3AC1C3E2A" Source="$(var.HarvestPath)\Nito.Cancellation.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp66F3E11ECD62C2F3F07FE833435629AE" Guid="{4BA578BB-7D40-4562-A60D-F0B8164951CB}">
+        <File Id="fil46B56D09508058011C2F519DF3616F4F" Source="$(var.HarvestPath)\Nito.Collections.Deque.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp2C5E7C277E5AA44B5685A4B212F12806" Guid="{EC888274-52B7-402C-84B7-6D6F82C8F5E5}">
+        <File Id="fil16DB30711CC35B87FEACE31771C83B32" Source="$(var.HarvestPath)\Nito.Disposables.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7573EC2390E2B47667BC392F0AB1294C" Guid="{86DA1DE7-D280-4F8E-8567-60BEDD477E90}">
+        <File Id="fil793549DAC9BBACE3FE0A2C6207439558" Source="$(var.HarvestPath)\NuGet.Common.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp5D12C26270BD09CA3D45919FA8719AE2" Guid="{AB9AD29D-982F-40AE-A0F6-1DCC007FAA64}">
+        <File Id="fil1914470A96C406BB700EBFE4DFAB0CEF" Source="$(var.HarvestPath)\NuGet.Configuration.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp5B6706A46F3A714C8F8DBBC8D99570F8" Guid="{D4A35679-D85F-453B-A461-7943A41B6144}">
+        <File Id="filA10C8BC6EBB3877E81710607DA5F8E3A" Source="$(var.HarvestPath)\NuGet.Core.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp5B4B4955C58608067B41D6BE02863260" Guid="{FD9985FD-ED2A-4B0F-A42E-0ABA3CC174D2}">
+        <File Id="filC77BFD5C891086AC3DFE76BB004671EB" Source="$(var.HarvestPath)\NuGet.Frameworks.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4D072D5842DFB1E9399C435C746D295F" Guid="{D9C64107-2E12-4C98-9527-70BD3BE8DDA8}">
+        <File Id="filA46D093A333210FF3DF479B37CE2796C" Source="$(var.HarvestPath)\NuGet.Packaging.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpEEB4733FD782D8FCC77902F908470D17" Guid="{D54C9BF9-31DD-4330-A032-E338D1D551C1}">
+        <File Id="filFAE94905D72D8368BA8CE7A78C6DEA45" Source="$(var.HarvestPath)\NuGet.Versioning.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp14EC87DA50B81B5E6A67429F9F656722" Guid="{1171D6C7-008B-45CE-80D2-71109599DE63}">
+        <File Id="fil115F8AF38B90879DB02D672AAD89C8F2" Source="$(var.HarvestPath)\o8build.exe" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpECB62EFCC36DED701B049645322D5EA4" Guid="{2ABFC508-DA9F-4B3C-B6A7-3A7802D7F1E4}">
+        <File Id="filD6E3595BC3A12F1178BADDB8B0C651DB" Source="$(var.HarvestPath)\o8build.exe.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpDB3F27CA75DD8B428D656610D824F43E" Guid="{94157147-5620-4645-B6DE-A4E628E374EE}">
+        <File Id="fil1867AEB40FE12C433049BEB9C91F1DB5" Source="$(var.HarvestPath)\O8buildgui.exe" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp8F4B94EF0828B6BB61CFB54CF020D91D" Guid="{7F1079E1-C807-44B3-8CE6-C731A4283C93}">
+        <File Id="fil12556778E1378D4E227933C7673EDE13" Source="$(var.HarvestPath)\O8buildgui.exe.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp78D420543530ED3C4E9AF59E5E43A46A" Guid="{B8B11EE8-09DF-44EC-92C3-D3DF2C74CF54}">
+        <File Id="fil5DD75D83A77AB95ED421DEEF0BF2B01A" Source="$(var.HarvestPath)\Octgn.Communication.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp13DB3273CD8E9EFBC311065EC87BC2ED" Guid="{2A99E44F-8390-48E7-889B-43A6A5EF40C6}">
+        <File Id="fil77B8C56BFD301B24319AB3307D9BA392" Source="$(var.HarvestPath)\Octgn.Core.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp01B928B4ECBFCD61A6907C15B51FD576" Guid="{5A41CD71-E761-4565-B64C-88028CE5BADF}">
+        <File Id="filA077434039560EE768241001F37074B3" Source="$(var.HarvestPath)\Octgn.Core.dll.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4AC56D024FE3EBC0C5D484FD32C6AD39" Guid="{4BD12BE0-AC37-4D50-BB98-617C91131140}">
+        <File Id="fil778540729DB4A65ADFBE96E16513FDDD" Source="$(var.HarvestPath)\Octgn.DataNew.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE198BBD5DE02A49C4928C1C0050A8D2C" Guid="{A8CC6659-2508-4B6D-B98A-D0412BA01833}">
+        <File Id="fil1BF4E8D8B821B657E6BD6C4D5D17E01F" Source="$(var.HarvestPath)\Octgn.DataNew.dll.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp816741CB75C2802164361F1A72B563A8" Guid="{A719F839-B2A5-43CF-9D11-20CF517946E5}">
+        <File Id="filDD92BED66D8CCAE233C37576A2AB17A7" Source="$(var.HarvestPath)\OCTGN.exe" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpC5DE7EC60F5EA8A9A5B95B7D4B9C5BC5" Guid="{6233F947-FC19-4191-A1A0-CB01770FB116}">
+        <File Id="fil69ABE435B2D8C724C37AFE643B9377A4" Source="$(var.HarvestPath)\OCTGN.exe.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4A176DBA1ADB8645F1FA42676F3A6B86" Guid="{98D627D3-EE73-4E7D-B81A-62CE99F242E0}">
+        <File Id="fil5DDB7773FA15E3A2816CA9EFEB1C60C9" Source="$(var.HarvestPath)\Octgn.GameWizard.exe" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4625614E297B1252FE7F922014CC80F1" Guid="{6B2147C5-57C2-4120-AA05-ED7000BCC4BD}">
+        <File Id="fil847FADADF6B5C12004BF4BD633CAC112" Source="$(var.HarvestPath)\Octgn.GameWizard.exe.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4DB7CFE68CF05E3AD59E02028E042BB9" Guid="{9F355E39-2AEC-4285-BDA9-760D039AF927}">
+        <File Id="fil8674A56D73676920122A40678BF74ABE" Source="$(var.HarvestPath)\Octgn.JodsEngine.exe" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp63DE213263DED6C2550F304BEE2CFE7A" Guid="{306B1902-B23E-4A2A-A0BB-DF6FDF4592A8}">
+        <File Id="fil1EB4834F0D954D20AB8C86314FC306E6" Source="$(var.HarvestPath)\Octgn.JodsEngine.exe.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7F4884BAFC25CC83145B44C41BD9E715" Guid="{5CAC4E95-7CBF-4F58-9CB6-AD075C2311BA}">
+        <File Id="fil59E2C7E4B79381DF45FA80A2BB35088F" Source="$(var.HarvestPath)\Octgn.Launcher.exe" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp5F98DC92A09C93FA41A8E8735029D622" Guid="{B7BE9310-F4D4-40CA-96F2-0B09B5FB7FF8}">
+        <File Id="fil16956E54BC419F5003B36A82D564A1B5" Source="$(var.HarvestPath)\Octgn.Launcher.exe.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp94F2EBC9267AA03E64C0B4C125B6E0ED" Guid="{D92F6F88-7E87-4F71-B7BE-6332D1D563E6}">
+        <File Id="fil9B7905D43CACE41185C88AC56FE48C94" Source="$(var.HarvestPath)\Octgn.Library.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp258FD747182EA4C603508266DBC1755E" Guid="{F9E40228-64DA-4E83-996E-D3CB354B31E5}">
+        <File Id="fil8D5F737CD62562E564C183DBA36FC396" Source="$(var.HarvestPath)\Octgn.Library.dll.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp46AC8D28D9CA83259E3ED6310534D2DB" Guid="{77D02324-575A-4DCB-AA6F-48FF5AD0E51C}">
+        <File Id="filADC02EADCCD3A41A1292298778B013E3" Source="$(var.HarvestPath)\Octgn.LogExporter.exe" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp6660405BF614CDE8F11AAA818351849C" Guid="{2DC7AE6B-F7DB-44A7-BF3D-795342622CBC}">
+        <File Id="fil8156F89096B49D16DDF97A5953C85065" Source="$(var.HarvestPath)\Octgn.LogExporter.exe.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpAED5FD47C57C7237045FCBCFE4808351" Guid="{72D6DF96-616E-4E5E-8A74-2E6400672822}">
+        <File Id="filC86A2DA50F892AA8D72DE35DA43F483C" Source="$(var.HarvestPath)\Octgn.Online.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp2708F486C57CA602B063BE9697C5C4FF" Guid="{87AD4812-35E7-48A7-BCD6-53778CC669AA}">
+        <File Id="fil98B7F9E20F8EA19A2CAB20633523D7EC" Source="$(var.HarvestPath)\Octgn.Online.StandAloneServer.exe" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp52CC0A0B26C40F9923BF174EBA67CAE4" Guid="{DF39FBC2-72E7-4568-9C5B-1DE2C40426D8}">
+        <File Id="fil436F3908350FE867344545552CA452A4" Source="$(var.HarvestPath)\Octgn.Online.StandAloneServer.exe.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp9B0BCDBA40A5A291A237F6B435F5FF75" Guid="{4F1C1257-792A-464D-8EA5-F02338CF58B7}">
+        <File Id="filF5CD34D43BBDA9E63E39FF788CB30E51" Source="$(var.HarvestPath)\Octgn.ProxyGenerator.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp178679DA6076A0B4B6DF75E8E4258E14" Guid="{C4DA23FF-7E8B-45F6-8F39-357C9A9DFF31}">
+        <File Id="fil4482CF52B147A902654489F837D6D87D" Source="$(var.HarvestPath)\Octgn.ProxyGenerator.dll.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp92EE4200C4A0C8862AD9CF28B1628DF1" Guid="{18C74331-CF04-4520-976D-05B0BDDCF817}">
+        <File Id="fil17614427FBA65EB6F62FDFC105DDCB90" Source="$(var.HarvestPath)\Octgn.Server.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp85D8CC8E2390ACE57897B8F9779150CD" Guid="{4D6D042A-53B6-4F82-A69A-C5D47F37899F}">
+        <File Id="fil653B712CE97114CE7A0FB028C47C2EE4" Source="$(var.HarvestPath)\Octgn.Server.dll.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpBB3FBFA8930E710EA15D7C39668E6B92" Guid="{54006DA1-AC01-4DF4-81D6-A43D89F0C21C}">
+        <File Id="fil5974997ECA52452C12CBBAC4AA8EE638" Source="$(var.HarvestPath)\Octgn.WindowsDesktopUtilities.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp3E631296B6A9F7DE8958713A82C16A85" Guid="{AE8B1622-FE02-45D0-B4B6-D845B644B9CC}">
+        <File Id="filE085A10E86DAA2724A3EAB33BFC235AE" Source="$(var.HarvestPath)\Octide.exe" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpEC029F3A7060E84C5B2D271A9EDDB2A8" Guid="{4450B3D3-5DD0-4D48-B50A-9D1A4030D99A}">
+        <File Id="fil4FC94796D8AF5704272B67CBA4B3EEF4" Source="$(var.HarvestPath)\Octide.exe.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpAF0E057F905629B87D150B5E4CBA6ECF" Guid="{5CECD031-4604-4E93-9138-61CC6AD0A505}">
+        <File Id="filCC840F8C439A6275BFDCC523E5E0EB75" Source="$(var.HarvestPath)\Polenter.SharpSerializer.PCL.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp5482D5772865980D333DA18D1F255E64" Guid="{DB4C0951-3188-4C73-8075-20035BF62872}">
+        <File Id="fil8B16167CC7454A1CA2703D872FD59E90" Source="$(var.HarvestPath)\ProxygenTest.exe" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp1C38F2C71379D97BF0854CDDD948F94D" Guid="{FD029054-7AB7-4012-B2CA-AE637A0823B3}">
+        <File Id="filDA0AAE19DBC236E0F91C98D399C0CC2E" Source="$(var.HarvestPath)\ProxygenTest.exe.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp2DF0B2895DFC3CB720B48A6D9BFD37EF" Guid="{9AE4B157-EB2A-4C8C-86C2-960F35B5445D}">
+        <File Id="fil759547BBD39D067958C66E9281A84E0E" Source="$(var.HarvestPath)\System.AppContext.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp73085246C202ABD1D96D2E5DEFB2A801" Guid="{CA32B1BC-6C46-4727-8B00-89F4EEF9F64E}">
+        <File Id="filEDD81E77BF6933BF90C42AE0EFAA681B" Source="$(var.HarvestPath)\System.Buffers.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpFCAB0086ACF92637C85CEFB939B694E1" Guid="{1FB987C6-7561-46BF-92BE-F36CAA91F8AD}">
+        <File Id="filAD99C15B3296CE6AABBE5BB40D132051" Source="$(var.HarvestPath)\System.Collections.Concurrent.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE4B4F7691D3ACD4A72AE99FFE470CE17" Guid="{997891D5-EA75-4CBA-AD54-231619711A29}">
+        <File Id="filF5B5D111739157EBBB5E22D86DF5780A" Source="$(var.HarvestPath)\System.Collections.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp33FDA478CB86F083519801379B2D2D8B" Guid="{36D7D220-83F9-4378-AE86-0A147F789AF3}">
+        <File Id="fil5D4575804C3CE3ACC76FF53290806177" Source="$(var.HarvestPath)\System.Collections.Immutable.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp75515765AA531707944115B02998F998" Guid="{45DBD801-1AAE-4776-AA2D-35223CA4BEB6}">
+        <File Id="fil6D02755830088A3C5A117FEE2B465D5D" Source="$(var.HarvestPath)\System.Collections.NonGeneric.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp22D219EF6A7035FFC0254F6BE572FF77" Guid="{1FD30790-289F-4EB2-86C3-A69A8E10335C}">
+        <File Id="filCD75540AD97745722ED0A7EAABF287E1" Source="$(var.HarvestPath)\System.Collections.Specialized.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp22AEF5790256905123AF78698CD859DD" Guid="{3347A2DF-8DF7-48A7-BBBF-EE5123F05E9F}">
+        <File Id="fil09C18C7CA467795F6FA97EEB9E2387EB" Source="$(var.HarvestPath)\System.ComponentModel.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp5349EC5703EBCAA1E6C7DA272802BE58" Guid="{EC98AF41-E268-4E2D-9E7F-5C368A259E23}">
+        <File Id="fil399C00E90F93D6D53C7EB4198B8E6425" Source="$(var.HarvestPath)\System.ComponentModel.EventBasedAsync.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7B3236183FA982DA508702B357E3D75E" Guid="{93E9F3C3-4AD8-4AAA-98A2-FD37055545AC}">
+        <File Id="fil832F201A04CF05CFC4CF092D70DAB4D9" Source="$(var.HarvestPath)\System.ComponentModel.Primitives.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp58C198180EDB7D42EDD28920E1B2E513" Guid="{77662EA5-14BE-4561-BDF5-8D296BB089EB}">
+        <File Id="filF9ABD40F11D5C42FF00EF312FB605BA8" Source="$(var.HarvestPath)\System.ComponentModel.TypeConverter.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp03737AA3B5F539D51D9418A6ED0E4F6C" Guid="{A754B558-3E42-486E-9BAC-002360BA90DC}">
+        <File Id="fil5272CFE8A4472345C08FD356C568CCDB" Source="$(var.HarvestPath)\System.Console.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpB25E057E8242CD01A509E8CBCAB104DA" Guid="{A7BE0DF6-180C-40AA-B7A9-AF54152C9468}">
+        <File Id="filEE34C54941CD776131B74466DF35363A" Source="$(var.HarvestPath)\System.Data.Common.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp44C51162C2752731AF9E2E31BB09713C" Guid="{A5FDD183-F6D7-46EE-BEFD-28DC3BC4EA1F}">
+        <File Id="filB040E785B28D49D2AB7820EA35D4E70F" Source="$(var.HarvestPath)\System.Diagnostics.Contracts.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpB0C2F11F7CA680BF7E48B8A4268E9C98" Guid="{D5B5CF06-641A-470A-8AF3-04D2286BB463}">
+        <File Id="fil3C470A1D30CD627DFFBF6DD8881B668D" Source="$(var.HarvestPath)\System.Diagnostics.Debug.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpA59732DC764B94E5F1FB4BDE22083814" Guid="{1A3C1F4E-5D9F-49EA-B699-2771AAEEFA60}">
+        <File Id="fil2F1CF172154C6293C5A6ACB1E151C0A9" Source="$(var.HarvestPath)\System.Diagnostics.FileVersionInfo.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpF6FEF9FF36C695681C6A77FAD09A51DA" Guid="{BD8234C5-6C22-487B-9612-8D5109DDA19D}">
+        <File Id="fil51269EFEE8943C4F9AB6A03955BB33AD" Source="$(var.HarvestPath)\System.Diagnostics.Process.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpFE82493E4455C953D8F01BA5365F9C1A" Guid="{45E0DDB3-947D-47EA-BB6A-2ED0CE076490}">
+        <File Id="fil0F5FC5A056E90A15787004331E6B2B8F" Source="$(var.HarvestPath)\System.Diagnostics.StackTrace.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp0E83A6F1E468052C63DFCFE168BE9F86" Guid="{B6FCEBB8-46AD-46A2-9255-2D3574ADCFBE}">
+        <File Id="filF010877744275880482B24613609AB8D" Source="$(var.HarvestPath)\System.Diagnostics.TextWriterTraceListener.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp50A76DD8AF0E25149A565F185A1F29A3" Guid="{4C0F83BD-493D-41B0-B514-FD9A5D20A49F}">
+        <File Id="fil89402E5A5EF55D5D1DC9EB807D0163CD" Source="$(var.HarvestPath)\System.Diagnostics.Tools.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpDBAE7236105C33C9758DD48E8B6DCCB2" Guid="{1C61ACF1-2B8B-4626-B45C-CD8F11E5BF37}">
+        <File Id="fil57119B89E434A6BBC42AE8C1D26609BF" Source="$(var.HarvestPath)\System.Diagnostics.TraceSource.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp5686A5DCF2A08C618B3500928277C12C" Guid="{3A9E6D35-71B1-4F4D-AC73-7ED1DEEDE407}">
+        <File Id="fil70BB899DCE8D657F32B0FAC4DFF6638E" Source="$(var.HarvestPath)\System.Diagnostics.Tracing.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp8D6B0D0D5B997AF1B9BB2F2784692E03" Guid="{9AA15ACD-382C-4049-9ECD-469513EAEF5F}">
+        <File Id="filB19BBDDEF37FA03C3CE38BCFF05583EC" Source="$(var.HarvestPath)\System.Drawing.Primitives.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp15CD896C1257803F1EAAF21F13643142" Guid="{ABD667F5-04F1-491A-8147-D1134064F8C5}">
+        <File Id="filC982A846E7172EA04317E0E51B86A4E6" Source="$(var.HarvestPath)\System.Dynamic.Runtime.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp29422AE271D6B2356E2AF332D256B1DE" Guid="{AE8862F6-4D91-4ACA-A51A-466500A58847}">
+        <File Id="filB54F98D44891971453C10FBE1B05B1AB" Source="$(var.HarvestPath)\System.Globalization.Calendars.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpAA087E95574A085C5201D270F443E62E" Guid="{68D940CB-5A8D-48C7-852B-B54652AA01BC}">
+        <File Id="filAE617BAD3153A0952E9F3AC5EEF74A91" Source="$(var.HarvestPath)\System.Globalization.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp2AE6AC0EBDF241F5A2F3268BA1ACA754" Guid="{9DC69118-2295-48A1-A7A4-2F57F68EA2FD}">
+        <File Id="filE95A7394964F5DE38E1D4BF952444394" Source="$(var.HarvestPath)\System.Globalization.Extensions.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp129F5F5267671C7AB542077C2BDD8D72" Guid="{8974EA8D-C30B-455D-A086-3F7C1D317456}">
+        <File Id="fil9EAB17C18CD3A8D30FCF1017E3F9B1E6" Source="$(var.HarvestPath)\System.IO.Compression.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp23F7C2354109EC7F3034457C47235AA0" Guid="{A547F79B-0124-472C-A337-AF991CC8EA0A}">
+        <File Id="filA88EB5E9549A3F482ECCF70642AE8E9F" Source="$(var.HarvestPath)\System.IO.Compression.ZipFile.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp1AB2F694FBE065FEC98E27EC233540D7" Guid="{BE7E6EFB-960C-4C99-950F-B6A8B8CDF87F}">
+        <File Id="filF97298386D9CA5BBFEF3BA1266204948" Source="$(var.HarvestPath)\System.IO.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4F71FF3179249F40AA83CC5D26424EFE" Guid="{C8616FA7-00A1-4797-9729-4DA5BBD648B9}">
+        <File Id="filC6DDCD354E20866B99A7A52238AAF325" Source="$(var.HarvestPath)\System.IO.FileSystem.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpCE934969B52A8BF6C3B94FA9636916F6" Guid="{EEDDCC38-9551-4711-AEF6-7C2C6251A6FF}">
+        <File Id="fil0E00B68474AC0129918FF360842A9CBF" Source="$(var.HarvestPath)\System.IO.FileSystem.DriveInfo.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpC99C1FCF2F2B5727FFA9240232755632" Guid="{C8C173A6-FA1A-4AB0-A4F3-7C7A0C19DB4A}">
+        <File Id="filC3D4C9C1D8A5E81CA2C9F12AA05C8E2F" Source="$(var.HarvestPath)\System.IO.FileSystem.Primitives.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp39DE53A6E602C76462F0260E369F2792" Guid="{3745A51F-666F-45D1-8BAD-D4ED49E335E6}">
+        <File Id="fil576190832420D0AA668E4332EFFB4CBF" Source="$(var.HarvestPath)\System.IO.FileSystem.Watcher.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4A7BCFB5DA46BC95D2E49236FC59D8A5" Guid="{3AB5E8F2-1762-4F16-B892-7FF5CEC48964}">
+        <File Id="filC8B845031D596C89E35A64614B930E36" Source="$(var.HarvestPath)\System.IO.IsolatedStorage.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp3C994A927E01FC3CC7E0AE001AF0CD4C" Guid="{D1BF7152-3293-4C95-8997-59EE159FCE9C}">
+        <File Id="filA22B487AC8691FA22B43B5D947EB4791" Source="$(var.HarvestPath)\System.IO.MemoryMappedFiles.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp461F4A455CD0EB1AD2E4E35B51C09850" Guid="{13AEF4EC-8434-4DCC-9D7F-A00AF600F8D0}">
+        <File Id="fil0B2EFCDE9779CC5CD0E6EB630A00C291" Source="$(var.HarvestPath)\System.IO.Pipes.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp6042D98678A0BF1EE1EB0EC4AF5E5C52" Guid="{5632BB95-22B4-4C68-A80A-A68BA4BD2E41}">
+        <File Id="fil770B68ECB2EAAA73F75AE90EC59CDF4E" Source="$(var.HarvestPath)\System.IO.UnmanagedMemoryStream.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpEE5BBE99E2C22FC8023A8976953D2181" Guid="{CDEC4CC0-ACBE-42B6-BD7A-4C6CACD31B3D}">
+        <File Id="fil9624BD0666E81BA5E2C9A90C8EE12DF1" Source="$(var.HarvestPath)\System.Linq.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp3B693E836B896CF886DF7174A12D37F7" Guid="{E971D830-737B-4ED2-8DDE-A12DAA074A3D}">
+        <File Id="filC4914ECA26BAF54E9A2DD6F052DA9C90" Source="$(var.HarvestPath)\System.Linq.Expressions.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp8EB6B1FB2B50FFBB0CA48841D0C7E01B" Guid="{AD821D24-D7F9-4253-95A5-2C524877A1D8}">
+        <File Id="filE34040F3256391C32697BF02C1A69D6C" Source="$(var.HarvestPath)\System.Linq.Parallel.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpDB259A99945F85FEC221D6F75ACCB8EF" Guid="{9848B1FE-521F-48DE-8841-FD8501A838D6}">
+        <File Id="fil3B519832BFCC96F2B9F9A9E556AD7266" Source="$(var.HarvestPath)\System.Linq.Queryable.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4CFC7C3721FFD91FA4E9798A516D5E97" Guid="{D5B3EFC5-EDCA-4E7D-A4AA-B6F9B746FFEC}">
+        <File Id="fil1E24D2F3B531B1D76E1631314436BD58" Source="$(var.HarvestPath)\System.Memory.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7C8ACFEA497AD75401FFD01A9AEB31D4" Guid="{AC79619F-0002-435F-B513-1AFA9E3C599D}">
+        <File Id="filE0C3E4A153D639D49A90C05560AF1912" Source="$(var.HarvestPath)\System.Net.Http.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpD577135453C63C124E24214ACA6ED9B4" Guid="{D16189F6-446A-42E6-B7F1-C1133971A9B6}">
+        <File Id="filE386BE0BA9453CEB70C0D0A4F87AFE13" Source="$(var.HarvestPath)\System.Net.NameResolution.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp5CF9D73D8F28A4EF0D37B0136ED71006" Guid="{73148841-EE5C-4D9A-84E6-57A2464FC0E9}">
+        <File Id="filBE42196B38AEB33D0CDF75251FE2D7B1" Source="$(var.HarvestPath)\System.Net.NetworkInformation.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE95A3A7DB0E5B6B057A2BEF1A9ACCBA6" Guid="{0873A9AB-1AA7-4901-A848-81F523C4C592}">
+        <File Id="filE8CE2C8F8D88989206070BB80BED53C7" Source="$(var.HarvestPath)\System.Net.Ping.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp57ED19A38749352B4A6312602AF32EEA" Guid="{28DC0795-B482-4DBC-900F-14899BB54EE3}">
+        <File Id="fil73A9A1A5553BBD979A6AE05955A0BFC3" Source="$(var.HarvestPath)\System.Net.Primitives.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp3BED5AB46AF442FB282395C20F099F24" Guid="{089D3360-C91C-48E6-8B79-27D97F56A3B6}">
+        <File Id="filBF1F0395A4430CE4FD07957B53031C4A" Source="$(var.HarvestPath)\System.Net.Requests.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4629EBAC56A143487ECF260AF98BF78D" Guid="{623C9057-6193-41B1-8033-F00D8986A4A7}">
+        <File Id="fil591D46E363F8E823067D9B8BEF2F7B81" Source="$(var.HarvestPath)\System.Net.Security.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp6A4CEF696231A141C3BD0E963AF7FC9A" Guid="{02C58340-7BEF-48F2-903C-2B17782253D4}">
+        <File Id="filDEE378E4FB4D3F4448BC26AA15C9E83D" Source="$(var.HarvestPath)\System.Net.Sockets.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpC11D8B4CADC383AE71657D4082C7C44C" Guid="{60F7B7A8-AAE3-40EF-A2F1-B857ECD1876C}">
+        <File Id="filC9BBDB35B270BFF7BFB6C819013763B8" Source="$(var.HarvestPath)\System.Net.WebHeaderCollection.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7CDF555F26EC27374503C4D251C0ADD7" Guid="{74F89CB6-CA25-451D-91FF-124A1011E519}">
+        <File Id="fil7E89DC70B56E449D3B0FBFB3811872C9" Source="$(var.HarvestPath)\System.Net.WebSockets.Client.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7FDA86390D774733F2019204F3EF9348" Guid="{EAAFC104-26AC-4BE8-ACA3-438D4E7DDE4E}">
+        <File Id="filFF4A0F663A05BAEEDC1EF2CA53FB8D4F" Source="$(var.HarvestPath)\System.Net.WebSockets.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpA780BD9CC7EF10DE58A9E17B691B0205" Guid="{1EEC271F-A505-41A1-A9A0-40528285FF98}">
+        <File Id="fil41D7AC86F0924A477EE48B3AF9E39249" Source="$(var.HarvestPath)\System.Numerics.Vectors.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp0ECCBE7E7A91EA3F9AC4E08C42060A74" Guid="{B16FD2CA-B56A-4C11-9BB4-138B28F49857}">
+        <File Id="filCD330848999366093EF4945E95052719" Source="$(var.HarvestPath)\System.ObjectModel.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7320660D409A823430EC1ADFF0D83564" Guid="{EE146B61-D9B8-4CB3-BB7A-625989D92253}">
+        <File Id="fil0F1435C9F703FD077AC5E77B34B69CC8" Source="$(var.HarvestPath)\System.Reflection.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp68097EB457BBDE8DE960E7CC72000139" Guid="{E56A7E68-CE60-49D6-B7A1-6ECAB8A32BE3}">
+        <File Id="filFFC887013D8E0165D1A96DFCECBB62D6" Source="$(var.HarvestPath)\System.Reflection.Extensions.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpC2109B9173A8B91CBDD411618A20588C" Guid="{3151EF4D-086D-410E-AA7E-EF903F0D3D63}">
+        <File Id="fil2A581D7BEB9E3BA198BA51891387E525" Source="$(var.HarvestPath)\System.Reflection.Primitives.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp48A7934AD38EE63A44A9478E1C31E3BB" Guid="{F502B4E2-F726-4DF0-B1AA-76EB287371C5}">
+        <File Id="fil3BB10164D9FC561AC346D63A8AB66A9E" Source="$(var.HarvestPath)\System.Resources.Reader.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp92E77A73B8159FC7BF51704F06BB1689" Guid="{0CBDC236-6829-4FEF-B339-9CA2D6BC6577}">
+        <File Id="fil7656E2B5556FCB519B0B66F7B480FE7B" Source="$(var.HarvestPath)\System.Resources.ResourceManager.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp82CD5F539E128C7A8CC025CBA927B9F3" Guid="{6D0F86D2-A35F-4988-9FFE-D40CD132C3E3}">
+        <File Id="fil3BCC5DD79CA7001CCCDB0DE845D707D3" Source="$(var.HarvestPath)\System.Resources.Writer.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp04E7760BC247B05C847A4A6D5D8C7091" Guid="{F65429FB-D22D-4A1A-8BF6-4C6EE5A6DF5C}">
+        <File Id="fil8974B12282083EB6B4CB7BAC26546374" Source="$(var.HarvestPath)\System.Runtime.CompilerServices.Unsafe.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp336F82620F5FFCA06611B8FD22F7066F" Guid="{F8FBE5B7-753D-4721-9655-761320B08557}">
+        <File Id="fil3B157F8B05D7C8C49D0B2E4879F2135C" Source="$(var.HarvestPath)\System.Runtime.CompilerServices.VisualC.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpF68CE304EDD0D14A7BFF18236F51BC48" Guid="{457D6A4F-F2B1-43A9-9961-D0CCDDF26950}">
+        <File Id="fil1DF46A3A328CA5A1B3C9E619D2E6B80A" Source="$(var.HarvestPath)\System.Runtime.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp975FB1B5D4A3126E0525915FB4C90ECF" Guid="{89F7BB3A-6767-479E-80C6-398D585BCB35}">
+        <File Id="filA4A42760CA9FD5DD6B18B4E51A05E900" Source="$(var.HarvestPath)\System.Runtime.Extensions.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE55D5ABD5E06B7AC82A1A464F710DC2E" Guid="{925D1B8C-1A5D-4ED7-8B77-E0DE322FDC33}">
+        <File Id="fil1B530BA53CDCE15C6F6170DBC8B8D72B" Source="$(var.HarvestPath)\System.Runtime.Handles.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpF8D128DB049817F164973BCC38DE4935" Guid="{7F6F9733-8461-49D6-8D9D-5B458C38ED71}">
+        <File Id="filFD0221B77EC7449E1F90EA01B453DEC9" Source="$(var.HarvestPath)\System.Runtime.InteropServices.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpEF0EA4DA72195CE89ADEBCDFBBB1A537" Guid="{00DCC2D6-D341-49C1-BF20-D5AD80493489}">
+        <File Id="fil3469E12317CB8788F95F8E393705340B" Source="$(var.HarvestPath)\System.Runtime.InteropServices.RuntimeInformation.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp058B1E2892E76D2F98E9569E383E5B83" Guid="{52923318-ABC0-4112-BB6B-625FE15063E5}">
+        <File Id="fil57772530FF83DF69270D8AA86333BE83" Source="$(var.HarvestPath)\System.Runtime.Numerics.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp8383C67527BDAFE41A3001900C896480" Guid="{897509BE-F50B-42AA-9CA9-245AD8EE9A57}">
+        <File Id="fil508F4D8A219CB235A6A05A06440BAD9A" Source="$(var.HarvestPath)\System.Runtime.Serialization.Formatters.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp1D49D64F849E58598D108BA2293DAD87" Guid="{EDA66BFB-DBF0-498C-A332-2B5E4C4858A8}">
+        <File Id="fil996377CBD20957AB61D1F7794647229A" Source="$(var.HarvestPath)\System.Runtime.Serialization.Json.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpFFD9C90842D9C8A5251533EE3764882E" Guid="{674DC373-21BD-4090-97BB-1F5D6C4BD081}">
+        <File Id="fil78BB41794127DCA0098197C99B85DEC0" Source="$(var.HarvestPath)\System.Runtime.Serialization.Primitives.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp852AADF38F8E567003DDA62F8B2655B6" Guid="{E4865509-28CB-4EDC-91FF-E84C300BEBB2}">
+        <File Id="filFBE1D5D50943EABD41BF7FBDDE38558D" Source="$(var.HarvestPath)\System.Runtime.Serialization.Xml.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp43A33CE3413979CC718E796B1C1E3E5B" Guid="{E802E4F8-563A-4267-81A7-D02525BFCE78}">
+        <File Id="fil6E218B321475AAF07492F4993D21A018" Source="$(var.HarvestPath)\System.Security.AccessControl.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp74104254FD237403FE1336A0257C4330" Guid="{074C5637-A46F-4F72-8DAA-290AF03260B5}">
+        <File Id="fil4B059CBA3EE02B33F172310663FA47A2" Source="$(var.HarvestPath)\System.Security.Claims.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp92D5F6B984CFD9B211394CCCEE1F04A5" Guid="{FB7C5DCC-CCD8-4A0B-B155-15C1DA59364E}">
+        <File Id="filEBF3D292F27598D7663F2D486D689D1E" Source="$(var.HarvestPath)\System.Security.Cryptography.Algorithms.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7B9CC5FD009F8DDFD5BF9EA0D105C4CA" Guid="{7D8706C4-A8A6-4996-827E-975104623301}">
+        <File Id="fil50D322D8544CA61F46C2ADE1B6D20EAB" Source="$(var.HarvestPath)\System.Security.Cryptography.Cng.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpDFB191D893C4B975B51D3352B7B82109" Guid="{074BDA5B-4110-4F24-B8DA-B751A52772CE}">
+        <File Id="fil5903FB61F7250A24E1C6485BA5781F06" Source="$(var.HarvestPath)\System.Security.Cryptography.Csp.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp626E0E80197224B4DF0D25BD513CFE42" Guid="{769C853B-1F4B-4FC3-AB10-CDBB59FE9F64}">
+        <File Id="fil1992BB2EBFE606350BB0C0A3EB90AE08" Source="$(var.HarvestPath)\System.Security.Cryptography.Encoding.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp11C8DA598E403582C9E9F65C927CA880" Guid="{22C6D0F4-4C54-4E3A-B0BE-CB4A9677225F}">
+        <File Id="filFDF5ED320EBDD3488A9A83071319B9FD" Source="$(var.HarvestPath)\System.Security.Cryptography.Pkcs.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp9AFF12285630BC013517118B5EEA5D3C" Guid="{6407C3C2-59EE-456A-9275-210E1D673196}">
+        <File Id="fil5CF1A17519FD312AFF94811EE6B36214" Source="$(var.HarvestPath)\System.Security.Cryptography.Primitives.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpF504650A7859834E56B465827ADA1936" Guid="{6735B4A7-C2CF-411F-AB7D-D6361F952B6F}">
+        <File Id="filF3505C51B6D770D84F54BDDB6F4AE5C2" Source="$(var.HarvestPath)\System.Security.Cryptography.ProtectedData.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp6951ADE3434FC5DEA7A943576EAFC9C9" Guid="{5E5AECB5-1E10-45C6-8F49-5C624DD6BE5A}">
+        <File Id="fil19629832AA6A1448CA14FB1052541870" Source="$(var.HarvestPath)\System.Security.Cryptography.X509Certificates.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpA0BE31D5F64E6C8E4232B1246C6E6EBA" Guid="{5E324E42-5445-4FDF-99FE-D2F686434362}">
+        <File Id="filB839AACE9B1FA27047CB38A105A51A43" Source="$(var.HarvestPath)\System.Security.Principal.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp6AEFC17E20EAA1A80B51320D84CB4117" Guid="{CEA74AA7-E6D2-4557-893E-E6EED9F9A425}">
+        <File Id="fil79E5070652584CDC0B95879F06EF0079" Source="$(var.HarvestPath)\System.Security.Principal.Windows.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE7D2AE44E717D315763AA4408AAB16FB" Guid="{FC6FFF3F-5DD7-4951-BFC7-3CECBB511D5C}">
+        <File Id="fil2DEEED95EC66E42E5135E15E0D4BDEAC" Source="$(var.HarvestPath)\System.Security.SecureString.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp75DAC5FDC2337ECAD4CD4B6633997292" Guid="{AF5302DC-81D0-464F-A916-125D79044AAB}">
+        <File Id="fil882D2FAAA08CD42BDE8C89122E0451FC" Source="$(var.HarvestPath)\System.Text.Encoding.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp69B094884B9A8B61C779794ADEBBC1A9" Guid="{E7E2271A-8418-4929-A4CE-15A0C75F9749}">
+        <File Id="filF2A6B49561E51548D949049A3979C98E" Source="$(var.HarvestPath)\System.Text.Encoding.Extensions.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpC5D9D0B15AFBC0CF5AFAE1D408F93B74" Guid="{02C7A035-48E0-450B-9EC4-0661D0BE8FE8}">
+        <File Id="filFE0C8F47D86E044043A5140C2900BC86" Source="$(var.HarvestPath)\System.Text.RegularExpressions.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpF574B7D15C8F67E99CE93D4A59FC6585" Guid="{56C97A61-1741-4352-9D8B-F61F08348593}">
+        <File Id="fil6382A5666A4DE7DD4AB95697F7D2C79F" Source="$(var.HarvestPath)\System.Threading.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpEA99956125140C149444D0EA2A2FBD11" Guid="{888C8D7B-0523-4BEE-AFDB-8A4E64A451A5}">
+        <File Id="filFAEBEC1A0D6D5ECFF6E97BBAE0CA0AE3" Source="$(var.HarvestPath)\System.Threading.Overlapped.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp3B63C4A8BD59792FD308ADD749073AE3" Guid="{A0323136-12C6-4CA0-8B19-5872DD184AD2}">
+        <File Id="filAFB2C8AB9328AAA60E4F1F016E024155" Source="$(var.HarvestPath)\System.Threading.Tasks.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp632B6E4876B3D900A85D26C65E49B166" Guid="{2F8B12D0-BF0D-479D-A8C1-EF5FE00E0FF2}">
+        <File Id="filDD4E8354C14401F7691CA8D69B4AB49D" Source="$(var.HarvestPath)\System.Threading.Tasks.Parallel.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp6B712402D454F08D96D36C530166919B" Guid="{712D0088-7576-42CA-A93C-356B93B26018}">
+        <File Id="filFF87888E479CA922120322C6DD2CA43C" Source="$(var.HarvestPath)\System.Threading.Thread.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp8AEEDC24B08C41AED47ACF763BF574A1" Guid="{789A38BB-82A4-46D9-9D5E-DB5EF2873F53}">
+        <File Id="filAA0C516BEAE2F97B5992ADB07A7F7275" Source="$(var.HarvestPath)\System.Threading.ThreadPool.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpBAD65A0DD84D5EC853BB247DBE86F887" Guid="{BF23A0F0-92C4-47B4-B1E1-18931C0981C4}">
+        <File Id="filC3DA66B6AA09D95F39F5A2E562CCEA8B" Source="$(var.HarvestPath)\System.Threading.Timer.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpCB5E5E4C7D798FA2732BABDEB0BE886D" Guid="{8482BD14-7A43-4B95-BD60-9FC6E8DDB04C}">
+        <File Id="fil2D8127F560A04E97657BE7D1D9CB7525" Source="$(var.HarvestPath)\System.ValueTuple.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp4FE4E61EC9791201921745B40643CBB8" Guid="{19A73B39-7058-4619-B793-61D37CEF0A79}">
+        <File Id="fil6F11DE09547B0AE8405683CDB88F7FC4" Source="$(var.HarvestPath)\System.Windows.Interactivity.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpB29480D26980660C0E9ADE25F14B43AD" Guid="{EC622B3D-BB2F-4649-BDE3-537373EEEB66}">
+        <File Id="filA4CB8C3F6118005605F8F71AB7E4A572" Source="$(var.HarvestPath)\System.Xml.ReaderWriter.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE59C0BD28DF5A4DF51B1078ACE43A415" Guid="{762ABE47-40C8-41EF-9726-65BDC28B98E2}">
+        <File Id="fil6CC059A8F8B87D96BDD3CBBDDC6744CC" Source="$(var.HarvestPath)\System.Xml.XDocument.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp3123E1EB1C5D225391FC1D6617D55C3F" Guid="{6F2A4195-32F7-4E41-BE7A-3E2F488256E3}">
+        <File Id="filAF8592E2C3BEA2ADA7883648F5BD3E2B" Source="$(var.HarvestPath)\System.Xml.XmlDocument.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp31F020064DD03E3B81CC5C22BABF3806" Guid="{F44DCB21-1854-4532-9E9E-5DBB6D5704FA}">
+        <File Id="fil6551700C172C6669B5CFDCBAC0B650DD" Source="$(var.HarvestPath)\System.Xml.XmlSerializer.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7F8869CF8631075DAAB292885B3366B9" Guid="{5352FBD9-EF07-4F56-A7E5-D2325F73B7F2}">
+        <File Id="filBA372692826B579213FAF4D36C948A0B" Source="$(var.HarvestPath)\System.Xml.XPath.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp808A78AA924556012D14BE1271FD1203" Guid="{0F719ECF-DED9-4DA2-96DC-C44F5C59F0D3}">
+        <File Id="filD68A3D67F917418E29DB132D939A3029" Source="$(var.HarvestPath)\System.Xml.XPath.XDocument.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpF8D234C94A74E417EF588934DCFF97BD" Guid="{A29EE95B-F0B8-4BF0-9619-197C03E32472}">
+        <File Id="fil07765C69E2C4D71D1FC1CD8CA672FEA2" Source="$(var.HarvestPath)\TestableIO.System.IO.Abstractions.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpD00056C26CE3E92AF69A9586119ED38D" Guid="{3709FFAE-82B3-486F-8A9C-F6528B3D0199}">
+        <File Id="fil692327FD8941FA6A0FE25A6511E5C400" Source="$(var.HarvestPath)\TestableIO.System.IO.Abstractions.Wrappers.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp5DEA586D2ED0D6139C9215BE23D7EF3E" Guid="{7305C4B9-0BCE-4175-99E8-90EAA9001FA2}">
+        <File Id="fil492F2C28F3962CA93730F18422E5479B" Source="$(var.HarvestPath)\ToggleSwitch.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpD3FCA1DCFD6F1C58BCEAF979F86ABDE5" Guid="{1425CE82-09E1-4B79-8699-31F4347A0D6F}">
+        <File Id="fil89D560951B37A5D6C19ADE0A5C1AF890" Source="$(var.HarvestPath)\WpfCircularProgressBar.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp331A8D1EB324EFA20DDAC123A3CCBC20" Guid="{065C342A-C644-413E-B5C1-36BAD98018FA}">
+        <File Id="fil7877B30D7CCBC9A1D241D01A032E7702" Source="$(var.HarvestPath)\WpfCircularProgressBar.dll.config" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp7165B8BA93A80A0EA1B7728AD04D6E72" Guid="{6130F867-AA10-4D34-B47B-F9895036AFB3}">
+        <File Id="fil0F135695E925EFFCE422A78CD28F4C92" Source="$(var.HarvestPath)\Xceed.Wpf.AvalonDock.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmpE2468C9865F90573476173F547848D40" Guid="{6BE880F7-0A49-4346-8EAB-6583856B680D}">
+        <File Id="fil283C54AA0CCA5A82032AD6F88F3D5D84" Source="$(var.HarvestPath)\Xceed.Wpf.AvalonDock.Themes.Aero.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp25B7CDE65FC6F7EDFBADDCA69300789E" Guid="{7BEC34C4-3394-41AD-A1C1-24F75E9F641C}">
+        <File Id="filB6214F7016ABD85F0A90650A1F105B9C" Source="$(var.HarvestPath)\Xceed.Wpf.AvalonDock.Themes.Metro.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp9A0FBE0E3FB55EEBB37903AC9A080A23" Guid="{48581701-1778-44BA-9AB7-E0EB16A63BA8}">
+        <File Id="filBB96100CC38385FF7DB0DBFE799C5F23" Source="$(var.HarvestPath)\Xceed.Wpf.AvalonDock.Themes.VS2010.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="cmp6DF273F8C8C1322EE403E364E1D04A16" Guid="{87A3836B-6BBC-40E9-B742-150047C66EB4}">
+        <File Id="fil4F8E845B9B0CB9B26B9D7BA0D7737124" Source="$(var.HarvestPath)\Xceed.Wpf.Toolkit.dll" KeyPath="no" />
+        <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+      <Directory Id="dir82972532CA27BEF6B972C3A142E19BC1" Name="cs-CZ">
+        <Component Id="cmpCAB95CA222FD066C2C7497309ED3B42D" Guid="{6E4D0FED-F993-4121-975B-EE12DA6FFF34}">
+          <File Id="filCA42D07B4FBD03D93F55D109D4CAC8DD" Source="$(var.HarvestPath)\cs-CZ\Xceed.Wpf.AvalonDock.resources.dll" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+      </Directory>
+      <Directory Id="dirAF6DD7A53CA77B3027ADFBAEC049BD01" Name="DiscordIntegration">
+        <Directory Id="dir811F417A61360E81212787DAAAEA6D18" Name="DiscordGameSdk">
+          <Component Id="cmpC0276994A573A078D26013C7FDACBC9F" Guid="{E5E7CD95-6E15-417A-AC7B-A0CE1EAC2C73}">
+            <File Id="fil60282A969E4ADB939D147700568C1FA4" Source="$(var.HarvestPath)\DiscordIntegration\DiscordGameSdk\discord_game_sdk.bundle" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+          <Component Id="cmpE52BB7FC3DC29679069503B4DF297C59" Guid="{93AF5E00-F43F-403F-AC38-E1AA1FC9CD73}">
+            <File Id="fil4FE9C5992E55E086DEB5F14F17040536" Source="$(var.HarvestPath)\DiscordIntegration\DiscordGameSdk\discord_game_sdk.dll" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+          <Component Id="cmpAD718F30AB48C261D251811A652C1A94" Guid="{4B959758-1B46-4C20-82B9-5C874EAEEB86}">
+            <File Id="filB561F9823DCBCAFE44A9058BFB1907CC" Source="$(var.HarvestPath)\DiscordIntegration\DiscordGameSdk\discord_game_sdk.dylib" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+          <Component Id="cmp25256AE2947632219BC83B85B9C41CC9" Guid="{5BDCD566-F5C0-4D12-B61A-41F0C72B1C1C}">
+            <File Id="fil15A92A4DBB5617EB41BF5F1589376F7D" Source="$(var.HarvestPath)\DiscordIntegration\DiscordGameSdk\discord_game_sdk.so" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+        </Directory>
+      </Directory>
+      <Directory Id="dir236726D31B8846E56F94A60B4BDA0D5D" Name="ja-JP">
+        <Component Id="cmp3D9D9347147FF3133AFC17C7F9A998A4" Guid="{60F4AAC4-6D5B-47DE-B1E1-E4F6753C599A}">
+          <File Id="fil760D80DF8AD4E443D2C0E378EAF5D02B" Source="$(var.HarvestPath)\ja-JP\Xceed.Wpf.AvalonDock.resources.dll" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+      </Directory>
+      <Directory Id="dirF5C503B5843C4B671B9659DAD472C99B" Name="nl-BE">
+        <Component Id="cmp7DADD6ADD2F165DAFF4A877D9CE92226" Guid="{FBCF5BA4-3CF0-4194-8EAD-7110880DB8F4}">
+          <File Id="fil3AC2CD3D341C21CA07A55027F15A368F" Source="$(var.HarvestPath)\nl-BE\Xceed.Wpf.AvalonDock.resources.dll" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+      </Directory>
+      <Directory Id="dir61B122782F2749F187324C134F6498C1" Name="Resources">
+        <Component Id="cmp2FC36AEE2CF320C880B44E1AA37C3621" Guid="{83B249B0-A5B4-4683-A339-03DD8FD6734D}">
+          <File Id="fil12236043116FD118BA8377F978BFCF29" Source="$(var.HarvestPath)\Resources\Icon.ico" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Directory Id="dir239481E6A388B3487D44CE1316E7F18D" Name="FileIcons">
+          <Component Id="cmp5309461917AF261F7AA012868E31B24D" Guid="{D3219A79-B955-4C39-A50E-5DE010ACDD91}">
+            <File Id="filCFF5B796DD323F2CD1F94F9BB1D19852" Source="$(var.HarvestPath)\Resources\FileIcons\Deck.ico" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+          <Component Id="cmp15CBF72A1B5100D015A36ED54D768755" Guid="{703541B4-69A9-43A5-A4A8-86497BC2902D}">
+            <File Id="filEC9744E3D94AA0DF3F4D57C841ABA097" Source="$(var.HarvestPath)\Resources\FileIcons\Game.ico" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+          <Component Id="cmp66EA0083CE16F42885E9A45C8423F861" Guid="{E1AEABA2-81B2-4944-94CC-5400F3B141E9}">
+            <File Id="fil6D03A9A21CDF9D68DE2C9BD237901984" Source="$(var.HarvestPath)\Resources\FileIcons\Patch.ico" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+          <Component Id="cmp7C5531A9CFC5BBD59347B4FE096D00AA" Guid="{7E1EA7D3-A6B8-4FC2-875F-EC8FE7947C4F}">
+            <File Id="fil856A84B94078810C5F3E2627A9083523" Source="$(var.HarvestPath)\Resources\FileIcons\Set.ico" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+        </Directory>
+        <Directory Id="dirC9449A876BE1D543C4BEF0F2A70550D0" Name="LoadingWindowAds">
+          <Component Id="cmp365D3C9E067374AF45EF43A234B8A344" Guid="{4FC026B4-3B92-4FCE-95E0-155A8A6A1B4C}">
+            <File Id="fil7D8171D3B9A84D453F45F1F4BEAD1C40" Source="$(var.HarvestPath)\Resources\LoadingWindowAds\0.jpg" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+        </Directory>
+      </Directory>
+      <Directory Id="dir54B0732D1EC7055747BB11A9069B5872" Name="Schemas">
+        <Component Id="cmpF0C980121A5E61260C111F3B30F232B7" Guid="{E0265E59-4F6D-4278-A2B5-FCE19DE25DF3}">
+          <File Id="fil06729F2D22F76C1C14C4E5CCFECD7113" Source="$(var.HarvestPath)\Schemas\CardGenerator.cs" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp0A14E0A89CCA0C7068384033422CD7AB" Guid="{760395F7-8D8F-47EC-B672-4693F2865DFF}">
+          <File Id="fil1F00E8F3533087C519DA9886F47F4BA3" Source="$(var.HarvestPath)\Schemas\CardGenerator.xsd" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp99F64E4ABB9D6E632DDB60A9C9B7966D" Guid="{E3315A42-9307-495D-9D38-932932865B0E}">
+          <File Id="fil292F5D9F5EB7C3E21016F041725CC72B" Source="$(var.HarvestPath)\Schemas\CardSet.cs" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp6CFF27CB489486958633E8131F5E4D96" Guid="{8D948D47-A76E-4189-AC93-0E4B101DCA59}">
+          <File Id="fil887442C9CD7F584C63B462A90CCA26A8" Source="$(var.HarvestPath)\Schemas\CardSet.xsd" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp72BBB1DEFF5AA8D14FFE7F59F6DF3CD4" Guid="{28709386-E0C1-49DC-B923-A45F2423F082}">
+          <File Id="fil50E5CC3FA9E1647BD267C83949B4CFC2" Source="$(var.HarvestPath)\Schemas\CardSet.xsx" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp50DEB045C2F6D94CF8F4EE13A02F2E29" Guid="{6D48957D-7F95-4D69-8376-04470450AB1A}">
+          <File Id="fil6F6409B748DE1C1F03D9A4D261A0CC34" Source="$(var.HarvestPath)\Schemas\Game.cs" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp2BD3867353E7AAE34423CE42D2161179" Guid="{754482FF-31FE-41C8-9D15-B3B2E9FAC957}">
+          <File Id="fil877781121FC71C521AB357B0EA510EB8" Source="$(var.HarvestPath)\Schemas\Game.xsd" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+      </Directory>
+      <Directory Id="dirEE481B3D48A90B5CC7FF22BC03F5F006" Name="Scripting">
+        <Directory Id="dir9A922803B4F75A03E6F353457F8EA5A3" Name="Lib">
+          <Component Id="cmp5891E87842F703FAAD0E25A183FCAFB4" Guid="{59D01964-048B-4ECD-B7B1-5E5E4E4A10DC}">
+            <File Id="filF74F3F46C3FAF66790BE2A322E6C041E" Source="$(var.HarvestPath)\Scripting\Lib\abc.py" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+          <Component Id="cmpA1F9E1D023828076838FEAF99357F1C8" Guid="{5769C0D7-2130-4F15-8513-262929BBF1C9}">
+            <File Id="filA944E6A3C541E96E07B20E67F9238C39" Source="$(var.HarvestPath)\Scripting\Lib\bisect.py" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+          <Component Id="cmp82ABC1C65A89C8B85616CDB19B418F0A" Guid="{C619A228-08E8-46F2-BDF5-C607C58AB91E}">
+            <File Id="filE566A2EF10CB0BBC2FEACEF2E8C7D619" Source="$(var.HarvestPath)\Scripting\Lib\collections.py" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+          <Component Id="cmp4224008DC8B545EE045E5C1D4F07B8A4" Guid="{868A5E45-2D93-49EF-9AE9-CFE17FAE9FA8}">
+            <File Id="fil81BFE11B785618DA3DB5A17566D83C68" Source="$(var.HarvestPath)\Scripting\Lib\heapq.py" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+          <Component Id="cmpF7B23DD6C32500246DFE17B18912EEA7" Guid="{58656FD3-1DC3-4585-8B2B-7660473D087C}">
+            <File Id="filE90141BD7A0FA78089564C66FD2EECBE" Source="$(var.HarvestPath)\Scripting\Lib\keyword.py" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+          <Component Id="cmp224C9CBD6D60697EF584DDD66966547B" Guid="{0054687E-AAFC-4C70-BEA2-AAC3E9550873}">
+            <File Id="filF114FBC343C5F1E1638FCBE963F0B047" Source="$(var.HarvestPath)\Scripting\Lib\_abcoll.py" KeyPath="no" />
+            <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+          </Component>
+        </Directory>
+      </Directory>
+      <Directory Id="dirA1E22504AD8FC7CFED287202DA6698C6" Name="Sleeves">
+        <Component Id="cmp250FF729C8BD9E2DCC0A29FF3A42538B" Guid="{B87B441B-C68A-471E-B20A-B7BBC58275A2}">
+          <File Id="fil0C4964D6D7A9F476E33F19B23A08B05D" Source="$(var.HarvestPath)\Sleeves\Air-Travel.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp851CF2A12D28A04576ED178EBC3EC14D" Guid="{CB1CE20B-4A27-4E10-83B9-B43B1DFBD779}">
+          <File Id="filD7620265864475FB3EEC08D09DFFF8DB" Source="$(var.HarvestPath)\Sleeves\Canival.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmpBD11FE282EF2D6805D8CAF0C92545FC6" Guid="{2B2834A4-C3C3-474F-A858-FF206FF6D6FD}">
+          <File Id="fil581B5B6F35B918A5DA83D8FBE0792CFD" Source="$(var.HarvestPath)\Sleeves\cb1.png" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp79D5CC1F35DDD4676DDE2FF3572F57A6" Guid="{DB42DE5B-AC7A-4B10-B291-201BBB25B3B3}">
+          <File Id="filC391F0296D6AC22C661C6042EE0783F5" Source="$(var.HarvestPath)\Sleeves\cb2.png" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp192CC8EA92A74866C878D594EA47AB46" Guid="{934AE7B5-83FA-4758-9998-9BC2A1976A4A}">
+          <File Id="fil212585BA14DB604B7B6C8EC2435209B6" Source="$(var.HarvestPath)\Sleeves\Dragon-Strategy.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp5E0622C834B75698A044409D256FADC6" Guid="{F05A2E12-53F5-4B7F-84A9-A8FCC56C7C11}">
+          <File Id="filB3F095641B257D2EC37F995DEFB6D783" Source="$(var.HarvestPath)\Sleeves\Face-In-The-Crowd.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp94D11D053AB4429B17BB1608BBF07CC6" Guid="{041496A7-E766-4260-AD10-C2DE1763961E}">
+          <File Id="fil82E6E391CC2B8CBCE76ACE3457ED581B" Source="$(var.HarvestPath)\Sleeves\GGG.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp560C08D6E294663FC928D9126A053846" Guid="{99E57949-6B99-4975-816B-FC988D617C27}">
+          <File Id="fil320A638E2A30AAA5A92264B3EEE11129" Source="$(var.HarvestPath)\Sleeves\Homewrecker.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp9033A5A91CE68C70E9E5ADAC500381C9" Guid="{B256759C-6AE9-40B0-8C6D-C0496B6EED3F}">
+          <File Id="fil0D758772E4249CAC52B1C872AFB55487" Source="$(var.HarvestPath)\Sleeves\Invent.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp9A12F2C14A49C01E49B1D3F62169973E" Guid="{7C8EB136-3ACF-4567-9323-6F536A75911B}">
+          <File Id="fil912EE67B44627F17F582BDE8CEAEB4D7" Source="$(var.HarvestPath)\Sleeves\Master-Ritualist.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp2E2A69436DE79A0A6BA0F2F81AE392F5" Guid="{27026BAC-DF30-482E-BCD8-1AA3E7E38030}">
+          <File Id="filBADC6F7D71DFF3BB30C3CACA7A14F4F8" Source="$(var.HarvestPath)\Sleeves\Monstrous-Lassitude.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp6AD9909523DFE5DF92AF0684CBEB1DA3" Guid="{3EC32BA4-5F5E-41C0-9E7E-A9A8E33C1ACF}">
+          <File Id="fil39391AC12009D64F70040623FEB908CD" Source="$(var.HarvestPath)\Sleeves\P-Warrior.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp223CC4B60E550995D6D9E5C8339B3CC5" Guid="{064FA73F-0782-4DB2-BD95-DCD028F1795A}">
+          <File Id="filEB3F10289D9191546E78C466597F36D7" Source="$(var.HarvestPath)\Sleeves\Rudo-Shade.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmpCE90934757713436DECA2402F52E8757" Guid="{A200A652-F90B-4C58-A55C-311E38F0E5ED}">
+          <File Id="fil668672504F49F717118693173798DC91" Source="$(var.HarvestPath)\Sleeves\Straw-Man.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmpEB3AFAB0420906A35F7DC855CC84A3AC" Guid="{8BD442EE-DC16-40E7-93C3-8B0DD6D570A9}">
+          <File Id="fil257C2F949BEC9DC7609B8527C19C4E09" Source="$(var.HarvestPath)\Sleeves\Thabbashite-Assailant.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+        <Component Id="cmp83A66EE5FA3672E5E11057D6309018B7" Guid="{D18AC9E6-BF97-4D07-856B-F5B55DE951C3}">
+          <File Id="filB6A49476269249BC9B2FC4BB75F6C7D6" Source="$(var.HarvestPath)\Sleeves\The-Spoils.jpg" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+      </Directory>
+      <Directory Id="dir71F51BB8FFD7417900F6A6C18D636546" Name="SyntaxHighlighting">
+        <Component Id="cmp78FEACFB17F978B10A3C8CAE9BD4C26E" Guid="{8EAE20CF-C905-4551-8467-99EB054E8DE4}">
+          <File Id="fil001E169FAF5F2F06989BD552A8EACD3C" Source="$(var.HarvestPath)\SyntaxHighlighting\Python.xshd" KeyPath="no" />
+          <RegistryValue Root="HKCU" Key="Software\Octgn" Name="Installed" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+      </Directory>
+    </DirectoryRef>
+  </Fragment>
+  <Fragment>
+    <ComponentGroup Id="O__HeatGenerated">
+      <ComponentRef Id="cmpE5004356FE7CC543DB30277EBA335A30" />
+      <ComponentRef Id="cmp669D7BFE3F77F8D3E757F78FE36D1217" />
+      <ComponentRef Id="cmp488D27FD7F12CC5B0CA2DA2EA3B41D0D" />
+      <ComponentRef Id="cmp7DB90804D3EED1D9CFD3C64FFB5E4115" />
+      <ComponentRef Id="cmp5B1CB9670A427F5E3F2553830607FC0D" />
+      <ComponentRef Id="cmp3E2C89676240A14A7164CA0B257A401F" />
+      <ComponentRef Id="cmp0E16CB47C3F6B22E2FFDD2CC515AD1C8" />
+      <ComponentRef Id="cmpD6D0ACC34D73AA09627602A91169D2DB" />
+      <ComponentRef Id="cmp39527D5EC1B0688C7C9D63712D499341" />
+      <ComponentRef Id="cmp78D15F6F5231CF1E19D525ABEE99FCA6" />
+      <ComponentRef Id="cmp253E049275FEE4BD1697BDA6EA4C9417" />
+      <ComponentRef Id="cmp13D6573EA8CF3F99F44BAE837E2771F0" />
+      <ComponentRef Id="cmpE395334EA0B9B925C1A69130E5678AF0" />
+      <ComponentRef Id="cmp2AC41B9A3E9E58C9FAC717C515DD6534" />
+      <ComponentRef Id="cmp6ECE5161C032390B6D41F4669C9B2FBA" />
+      <ComponentRef Id="cmpB828F2E0E3908AEB84554538E14583D2" />
+      <ComponentRef Id="cmp0B410F6F5DE5B5ECFF29B60BFB274F0F" />
+      <ComponentRef Id="cmpC173D9C7C59B34A6E81F67962030049C" />
+      <ComponentRef Id="cmpAA3D78E9B3AE6821E2C081A41FD040FD" />
+      <ComponentRef Id="cmp286A3BDB1EC430B908FD322B1322D746" />
+      <ComponentRef Id="cmp219E02EF943746676A4668B48FBE1820" />
+      <ComponentRef Id="cmp7F9ECE136F3D1474CBD79D0EDC835364" />
+      <ComponentRef Id="cmp48E1E5C93860F49EF00841C60B81D2E9" />
+      <ComponentRef Id="cmp5A3B0FEEF305F52451B314C57A61717B" />
+      <ComponentRef Id="cmp04FD776539E2628403B1D84D7E4D2BF3" />
+      <ComponentRef Id="cmp558FC5B3CC2B23E0A8DE37F92B4255E0" />
+      <ComponentRef Id="cmp15D8C5940372B97CA9C98944AF6922A3" />
+      <ComponentRef Id="cmpEE5095AF5D6CA4E21BB31324DCA12A9D" />
+      <ComponentRef Id="cmp90BBBFEF1982BB90418B4644CF2F7828" />
+      <ComponentRef Id="cmpFEB20DDD1566488925514934FC1DD9D5" />
+      <ComponentRef Id="cmp93AF99501BD43251496EBFA1881A64EF" />
+      <ComponentRef Id="cmp6E690104F2F1BB697CC4758AD1E26E58" />
+      <ComponentRef Id="cmp1B3BA240BD1C077BF83416736D48186D" />
+      <ComponentRef Id="cmp4305F7BD8AC4EC7C4D0AA718D88266C2" />
+      <ComponentRef Id="cmp351597C63B1AC6EEBF7FC5A22A89959E" />
+      <ComponentRef Id="cmp90A934A8431ACC8512A4EA7F53BC937E" />
+      <ComponentRef Id="cmp9799763CBFF3E472309F980CF7998B39" />
+      <ComponentRef Id="cmpF3639C930704BB7395EC1FA447E3381B" />
+      <ComponentRef Id="cmpCB2E6D7505E8F9992D331D3A906C43F4" />
+      <ComponentRef Id="cmpA06D8E3E1D88DC98CDABEDC2E5C06BB4" />
+      <ComponentRef Id="cmpE3CF238EBFAA39F9B8A792C87C154D23" />
+      <ComponentRef Id="cmp1D298ECB70462F6B6B9C736D46C3703A" />
+      <ComponentRef Id="cmp1343B58142FF8A721A61A226461A348A" />
+      <ComponentRef Id="cmpA2394AB6E80CFE6873404D7E45067744" />
+      <ComponentRef Id="cmpC7DD7DCD8E4083B4375CEC2B790F42C4" />
+      <ComponentRef Id="cmpE45996FE404705547B851665885248CF" />
+      <ComponentRef Id="cmp06B5FF1D134B60C8550290639423F91D" />
+      <ComponentRef Id="cmp7254E72FE73F320AEB41601E41FB205C" />
+      <ComponentRef Id="cmp3BEA937DC04A8694133FFFE7D2D9DD04" />
+      <ComponentRef Id="cmp7DC125062D4B14D8FC6C510683E68764" />
+      <ComponentRef Id="cmp4370A5F473BC7C578FA8C4A674514135" />
+      <ComponentRef Id="cmpBF316BAA97EE8CE76D0E2E7D86CB70F5" />
+      <ComponentRef Id="cmp82951EB65984B52CAC92DE74F90EEE71" />
+      <ComponentRef Id="cmpD6E0355A434255FE85D95233B0AEB24C" />
+      <ComponentRef Id="cmpFC2072AC6AB749CFD7255D8127B1D945" />
+      <ComponentRef Id="cmp0CF5B14E86747BCFC1DDFCDF28AE4A82" />
+      <ComponentRef Id="cmp9ECFE97C3E16F0F19742C25CE41E91CC" />
+      <ComponentRef Id="cmp6107C12C2A55CB8E7E97FF2C9A33F385" />
+      <ComponentRef Id="cmpE5B545219A4761BDD755E5F33A229024" />
+      <ComponentRef Id="cmp7762CAE69A07BF558B2EDF1798F02FA8" />
+      <ComponentRef Id="cmp07814B6C8393BF87D48FD742866B4421" />
+      <ComponentRef Id="cmpCBAD1189E4A95476F45730EA6D8A3E03" />
+      <ComponentRef Id="cmpAE19781133491B2193381E0614D1D3D9" />
+      <ComponentRef Id="cmp76294603D17E356B01EC46623A3970CE" />
+      <ComponentRef Id="cmpB84206E7872F2865ED1F54C864FA6F34" />
+      <ComponentRef Id="cmpA29803D2B7B90F564254224D67C6AFD4" />
+      <ComponentRef Id="cmpACFF2DEC99E6BC166A0253634ED41A4F" />
+      <ComponentRef Id="cmp1874AB219070404EED322213C6A1A49E" />
+      <ComponentRef Id="cmp6C6E3A4782B29A777EAFACCECDE25A75" />
+      <ComponentRef Id="cmpB66FADA902303B620146AF05EF8B205C" />
+      <ComponentRef Id="cmp8DFFC5DEB197ECE614FFE3F5C7E04DE4" />
+      <ComponentRef Id="cmpAEDF2B3BA3696FBDD725B364F3E86ECE" />
+      <ComponentRef Id="cmp72CF3E6159C32478210203D321CFE41F" />
+      <ComponentRef Id="cmpF44C29B10AEFDB62AD0AF98A017AA917" />
+      <ComponentRef Id="cmp260D7C50CBDB73562628EC85FC92D384" />
+      <ComponentRef Id="cmp66F3E11ECD62C2F3F07FE833435629AE" />
+      <ComponentRef Id="cmp2C5E7C277E5AA44B5685A4B212F12806" />
+      <ComponentRef Id="cmp7573EC2390E2B47667BC392F0AB1294C" />
+      <ComponentRef Id="cmp5D12C26270BD09CA3D45919FA8719AE2" />
+      <ComponentRef Id="cmp5B6706A46F3A714C8F8DBBC8D99570F8" />
+      <ComponentRef Id="cmp5B4B4955C58608067B41D6BE02863260" />
+      <ComponentRef Id="cmp4D072D5842DFB1E9399C435C746D295F" />
+      <ComponentRef Id="cmpEEB4733FD782D8FCC77902F908470D17" />
+      <ComponentRef Id="cmp14EC87DA50B81B5E6A67429F9F656722" />
+      <ComponentRef Id="cmpECB62EFCC36DED701B049645322D5EA4" />
+      <ComponentRef Id="cmpDB3F27CA75DD8B428D656610D824F43E" />
+      <ComponentRef Id="cmp8F4B94EF0828B6BB61CFB54CF020D91D" />
+      <ComponentRef Id="cmp78D420543530ED3C4E9AF59E5E43A46A" />
+      <ComponentRef Id="cmp13DB3273CD8E9EFBC311065EC87BC2ED" />
+      <ComponentRef Id="cmp01B928B4ECBFCD61A6907C15B51FD576" />
+      <ComponentRef Id="cmp4AC56D024FE3EBC0C5D484FD32C6AD39" />
+      <ComponentRef Id="cmpE198BBD5DE02A49C4928C1C0050A8D2C" />
+      <ComponentRef Id="cmp816741CB75C2802164361F1A72B563A8" />
+      <ComponentRef Id="cmpC5DE7EC60F5EA8A9A5B95B7D4B9C5BC5" />
+      <ComponentRef Id="cmp4A176DBA1ADB8645F1FA42676F3A6B86" />
+      <ComponentRef Id="cmp4625614E297B1252FE7F922014CC80F1" />
+      <ComponentRef Id="cmp4DB7CFE68CF05E3AD59E02028E042BB9" />
+      <ComponentRef Id="cmp63DE213263DED6C2550F304BEE2CFE7A" />
+      <ComponentRef Id="cmp7F4884BAFC25CC83145B44C41BD9E715" />
+      <ComponentRef Id="cmp5F98DC92A09C93FA41A8E8735029D622" />
+      <ComponentRef Id="cmp94F2EBC9267AA03E64C0B4C125B6E0ED" />
+      <ComponentRef Id="cmp258FD747182EA4C603508266DBC1755E" />
+      <ComponentRef Id="cmp46AC8D28D9CA83259E3ED6310534D2DB" />
+      <ComponentRef Id="cmp6660405BF614CDE8F11AAA818351849C" />
+      <ComponentRef Id="cmpAED5FD47C57C7237045FCBCFE4808351" />
+      <ComponentRef Id="cmp2708F486C57CA602B063BE9697C5C4FF" />
+      <ComponentRef Id="cmp52CC0A0B26C40F9923BF174EBA67CAE4" />
+      <ComponentRef Id="cmp9B0BCDBA40A5A291A237F6B435F5FF75" />
+      <ComponentRef Id="cmp178679DA6076A0B4B6DF75E8E4258E14" />
+      <ComponentRef Id="cmp92EE4200C4A0C8862AD9CF28B1628DF1" />
+      <ComponentRef Id="cmp85D8CC8E2390ACE57897B8F9779150CD" />
+      <ComponentRef Id="cmpBB3FBFA8930E710EA15D7C39668E6B92" />
+      <ComponentRef Id="cmp3E631296B6A9F7DE8958713A82C16A85" />
+      <ComponentRef Id="cmpEC029F3A7060E84C5B2D271A9EDDB2A8" />
+      <ComponentRef Id="cmpAF0E057F905629B87D150B5E4CBA6ECF" />
+      <ComponentRef Id="cmp5482D5772865980D333DA18D1F255E64" />
+      <ComponentRef Id="cmp1C38F2C71379D97BF0854CDDD948F94D" />
+      <ComponentRef Id="cmp2DF0B2895DFC3CB720B48A6D9BFD37EF" />
+      <ComponentRef Id="cmp73085246C202ABD1D96D2E5DEFB2A801" />
+      <ComponentRef Id="cmpFCAB0086ACF92637C85CEFB939B694E1" />
+      <ComponentRef Id="cmpE4B4F7691D3ACD4A72AE99FFE470CE17" />
+      <ComponentRef Id="cmp33FDA478CB86F083519801379B2D2D8B" />
+      <ComponentRef Id="cmp75515765AA531707944115B02998F998" />
+      <ComponentRef Id="cmp22D219EF6A7035FFC0254F6BE572FF77" />
+      <ComponentRef Id="cmp22AEF5790256905123AF78698CD859DD" />
+      <ComponentRef Id="cmp5349EC5703EBCAA1E6C7DA272802BE58" />
+      <ComponentRef Id="cmp7B3236183FA982DA508702B357E3D75E" />
+      <ComponentRef Id="cmp58C198180EDB7D42EDD28920E1B2E513" />
+      <ComponentRef Id="cmp03737AA3B5F539D51D9418A6ED0E4F6C" />
+      <ComponentRef Id="cmpB25E057E8242CD01A509E8CBCAB104DA" />
+      <ComponentRef Id="cmp44C51162C2752731AF9E2E31BB09713C" />
+      <ComponentRef Id="cmpB0C2F11F7CA680BF7E48B8A4268E9C98" />
+      <ComponentRef Id="cmpA59732DC764B94E5F1FB4BDE22083814" />
+      <ComponentRef Id="cmpF6FEF9FF36C695681C6A77FAD09A51DA" />
+      <ComponentRef Id="cmpFE82493E4455C953D8F01BA5365F9C1A" />
+      <ComponentRef Id="cmp0E83A6F1E468052C63DFCFE168BE9F86" />
+      <ComponentRef Id="cmp50A76DD8AF0E25149A565F185A1F29A3" />
+      <ComponentRef Id="cmpDBAE7236105C33C9758DD48E8B6DCCB2" />
+      <ComponentRef Id="cmp5686A5DCF2A08C618B3500928277C12C" />
+      <ComponentRef Id="cmp8D6B0D0D5B997AF1B9BB2F2784692E03" />
+      <ComponentRef Id="cmp15CD896C1257803F1EAAF21F13643142" />
+      <ComponentRef Id="cmp29422AE271D6B2356E2AF332D256B1DE" />
+      <ComponentRef Id="cmpAA087E95574A085C5201D270F443E62E" />
+      <ComponentRef Id="cmp2AE6AC0EBDF241F5A2F3268BA1ACA754" />
+      <ComponentRef Id="cmp129F5F5267671C7AB542077C2BDD8D72" />
+      <ComponentRef Id="cmp23F7C2354109EC7F3034457C47235AA0" />
+      <ComponentRef Id="cmp1AB2F694FBE065FEC98E27EC233540D7" />
+      <ComponentRef Id="cmp4F71FF3179249F40AA83CC5D26424EFE" />
+      <ComponentRef Id="cmpCE934969B52A8BF6C3B94FA9636916F6" />
+      <ComponentRef Id="cmpC99C1FCF2F2B5727FFA9240232755632" />
+      <ComponentRef Id="cmp39DE53A6E602C76462F0260E369F2792" />
+      <ComponentRef Id="cmp4A7BCFB5DA46BC95D2E49236FC59D8A5" />
+      <ComponentRef Id="cmp3C994A927E01FC3CC7E0AE001AF0CD4C" />
+      <ComponentRef Id="cmp461F4A455CD0EB1AD2E4E35B51C09850" />
+      <ComponentRef Id="cmp6042D98678A0BF1EE1EB0EC4AF5E5C52" />
+      <ComponentRef Id="cmpEE5BBE99E2C22FC8023A8976953D2181" />
+      <ComponentRef Id="cmp3B693E836B896CF886DF7174A12D37F7" />
+      <ComponentRef Id="cmp8EB6B1FB2B50FFBB0CA48841D0C7E01B" />
+      <ComponentRef Id="cmpDB259A99945F85FEC221D6F75ACCB8EF" />
+      <ComponentRef Id="cmp4CFC7C3721FFD91FA4E9798A516D5E97" />
+      <ComponentRef Id="cmp7C8ACFEA497AD75401FFD01A9AEB31D4" />
+      <ComponentRef Id="cmpD577135453C63C124E24214ACA6ED9B4" />
+      <ComponentRef Id="cmp5CF9D73D8F28A4EF0D37B0136ED71006" />
+      <ComponentRef Id="cmpE95A3A7DB0E5B6B057A2BEF1A9ACCBA6" />
+      <ComponentRef Id="cmp57ED19A38749352B4A6312602AF32EEA" />
+      <ComponentRef Id="cmp3BED5AB46AF442FB282395C20F099F24" />
+      <ComponentRef Id="cmp4629EBAC56A143487ECF260AF98BF78D" />
+      <ComponentRef Id="cmp6A4CEF696231A141C3BD0E963AF7FC9A" />
+      <ComponentRef Id="cmpC11D8B4CADC383AE71657D4082C7C44C" />
+      <ComponentRef Id="cmp7CDF555F26EC27374503C4D251C0ADD7" />
+      <ComponentRef Id="cmp7FDA86390D774733F2019204F3EF9348" />
+      <ComponentRef Id="cmpA780BD9CC7EF10DE58A9E17B691B0205" />
+      <ComponentRef Id="cmp0ECCBE7E7A91EA3F9AC4E08C42060A74" />
+      <ComponentRef Id="cmp7320660D409A823430EC1ADFF0D83564" />
+      <ComponentRef Id="cmp68097EB457BBDE8DE960E7CC72000139" />
+      <ComponentRef Id="cmpC2109B9173A8B91CBDD411618A20588C" />
+      <ComponentRef Id="cmp48A7934AD38EE63A44A9478E1C31E3BB" />
+      <ComponentRef Id="cmp92E77A73B8159FC7BF51704F06BB1689" />
+      <ComponentRef Id="cmp82CD5F539E128C7A8CC025CBA927B9F3" />
+      <ComponentRef Id="cmp04E7760BC247B05C847A4A6D5D8C7091" />
+      <ComponentRef Id="cmp336F82620F5FFCA06611B8FD22F7066F" />
+      <ComponentRef Id="cmpF68CE304EDD0D14A7BFF18236F51BC48" />
+      <ComponentRef Id="cmp975FB1B5D4A3126E0525915FB4C90ECF" />
+      <ComponentRef Id="cmpE55D5ABD5E06B7AC82A1A464F710DC2E" />
+      <ComponentRef Id="cmpF8D128DB049817F164973BCC38DE4935" />
+      <ComponentRef Id="cmpEF0EA4DA72195CE89ADEBCDFBBB1A537" />
+      <ComponentRef Id="cmp058B1E2892E76D2F98E9569E383E5B83" />
+      <ComponentRef Id="cmp8383C67527BDAFE41A3001900C896480" />
+      <ComponentRef Id="cmp1D49D64F849E58598D108BA2293DAD87" />
+      <ComponentRef Id="cmpFFD9C90842D9C8A5251533EE3764882E" />
+      <ComponentRef Id="cmp852AADF38F8E567003DDA62F8B2655B6" />
+      <ComponentRef Id="cmp43A33CE3413979CC718E796B1C1E3E5B" />
+      <ComponentRef Id="cmp74104254FD237403FE1336A0257C4330" />
+      <ComponentRef Id="cmp92D5F6B984CFD9B211394CCCEE1F04A5" />
+      <ComponentRef Id="cmp7B9CC5FD009F8DDFD5BF9EA0D105C4CA" />
+      <ComponentRef Id="cmpDFB191D893C4B975B51D3352B7B82109" />
+      <ComponentRef Id="cmp626E0E80197224B4DF0D25BD513CFE42" />
+      <ComponentRef Id="cmp11C8DA598E403582C9E9F65C927CA880" />
+      <ComponentRef Id="cmp9AFF12285630BC013517118B5EEA5D3C" />
+      <ComponentRef Id="cmpF504650A7859834E56B465827ADA1936" />
+      <ComponentRef Id="cmp6951ADE3434FC5DEA7A943576EAFC9C9" />
+      <ComponentRef Id="cmpA0BE31D5F64E6C8E4232B1246C6E6EBA" />
+      <ComponentRef Id="cmp6AEFC17E20EAA1A80B51320D84CB4117" />
+      <ComponentRef Id="cmpE7D2AE44E717D315763AA4408AAB16FB" />
+      <ComponentRef Id="cmp75DAC5FDC2337ECAD4CD4B6633997292" />
+      <ComponentRef Id="cmp69B094884B9A8B61C779794ADEBBC1A9" />
+      <ComponentRef Id="cmpC5D9D0B15AFBC0CF5AFAE1D408F93B74" />
+      <ComponentRef Id="cmpF574B7D15C8F67E99CE93D4A59FC6585" />
+      <ComponentRef Id="cmpEA99956125140C149444D0EA2A2FBD11" />
+      <ComponentRef Id="cmp3B63C4A8BD59792FD308ADD749073AE3" />
+      <ComponentRef Id="cmp632B6E4876B3D900A85D26C65E49B166" />
+      <ComponentRef Id="cmp6B712402D454F08D96D36C530166919B" />
+      <ComponentRef Id="cmp8AEEDC24B08C41AED47ACF763BF574A1" />
+      <ComponentRef Id="cmpBAD65A0DD84D5EC853BB247DBE86F887" />
+      <ComponentRef Id="cmpCB5E5E4C7D798FA2732BABDEB0BE886D" />
+      <ComponentRef Id="cmp4FE4E61EC9791201921745B40643CBB8" />
+      <ComponentRef Id="cmpB29480D26980660C0E9ADE25F14B43AD" />
+      <ComponentRef Id="cmpE59C0BD28DF5A4DF51B1078ACE43A415" />
+      <ComponentRef Id="cmp3123E1EB1C5D225391FC1D6617D55C3F" />
+      <ComponentRef Id="cmp31F020064DD03E3B81CC5C22BABF3806" />
+      <ComponentRef Id="cmp7F8869CF8631075DAAB292885B3366B9" />
+      <ComponentRef Id="cmp808A78AA924556012D14BE1271FD1203" />
+      <ComponentRef Id="cmpF8D234C94A74E417EF588934DCFF97BD" />
+      <ComponentRef Id="cmpD00056C26CE3E92AF69A9586119ED38D" />
+      <ComponentRef Id="cmp5DEA586D2ED0D6139C9215BE23D7EF3E" />
+      <ComponentRef Id="cmpD3FCA1DCFD6F1C58BCEAF979F86ABDE5" />
+      <ComponentRef Id="cmp331A8D1EB324EFA20DDAC123A3CCBC20" />
+      <ComponentRef Id="cmp7165B8BA93A80A0EA1B7728AD04D6E72" />
+      <ComponentRef Id="cmpE2468C9865F90573476173F547848D40" />
+      <ComponentRef Id="cmp25B7CDE65FC6F7EDFBADDCA69300789E" />
+      <ComponentRef Id="cmp9A0FBE0E3FB55EEBB37903AC9A080A23" />
+      <ComponentRef Id="cmp6DF273F8C8C1322EE403E364E1D04A16" />
+      <ComponentRef Id="cmpCAB95CA222FD066C2C7497309ED3B42D" />
+      <ComponentRef Id="cmpC0276994A573A078D26013C7FDACBC9F" />
+      <ComponentRef Id="cmpE52BB7FC3DC29679069503B4DF297C59" />
+      <ComponentRef Id="cmpAD718F30AB48C261D251811A652C1A94" />
+      <ComponentRef Id="cmp25256AE2947632219BC83B85B9C41CC9" />
+      <ComponentRef Id="cmp3D9D9347147FF3133AFC17C7F9A998A4" />
+      <ComponentRef Id="cmp7DADD6ADD2F165DAFF4A877D9CE92226" />
+      <ComponentRef Id="cmp2FC36AEE2CF320C880B44E1AA37C3621" />
+      <ComponentRef Id="cmp5309461917AF261F7AA012868E31B24D" />
+      <ComponentRef Id="cmp15CBF72A1B5100D015A36ED54D768755" />
+      <ComponentRef Id="cmp66EA0083CE16F42885E9A45C8423F861" />
+      <ComponentRef Id="cmp7C5531A9CFC5BBD59347B4FE096D00AA" />
+      <ComponentRef Id="cmp365D3C9E067374AF45EF43A234B8A344" />
+      <ComponentRef Id="cmpF0C980121A5E61260C111F3B30F232B7" />
+      <ComponentRef Id="cmp0A14E0A89CCA0C7068384033422CD7AB" />
+      <ComponentRef Id="cmp99F64E4ABB9D6E632DDB60A9C9B7966D" />
+      <ComponentRef Id="cmp6CFF27CB489486958633E8131F5E4D96" />
+      <ComponentRef Id="cmp72BBB1DEFF5AA8D14FFE7F59F6DF3CD4" />
+      <ComponentRef Id="cmp50DEB045C2F6D94CF8F4EE13A02F2E29" />
+      <ComponentRef Id="cmp2BD3867353E7AAE34423CE42D2161179" />
+      <ComponentRef Id="cmp5891E87842F703FAAD0E25A183FCAFB4" />
+      <ComponentRef Id="cmpA1F9E1D023828076838FEAF99357F1C8" />
+      <ComponentRef Id="cmp82ABC1C65A89C8B85616CDB19B418F0A" />
+      <ComponentRef Id="cmp4224008DC8B545EE045E5C1D4F07B8A4" />
+      <ComponentRef Id="cmpF7B23DD6C32500246DFE17B18912EEA7" />
+      <ComponentRef Id="cmp224C9CBD6D60697EF584DDD66966547B" />
+      <ComponentRef Id="cmp250FF729C8BD9E2DCC0A29FF3A42538B" />
+      <ComponentRef Id="cmp851CF2A12D28A04576ED178EBC3EC14D" />
+      <ComponentRef Id="cmpBD11FE282EF2D6805D8CAF0C92545FC6" />
+      <ComponentRef Id="cmp79D5CC1F35DDD4676DDE2FF3572F57A6" />
+      <ComponentRef Id="cmp192CC8EA92A74866C878D594EA47AB46" />
+      <ComponentRef Id="cmp5E0622C834B75698A044409D256FADC6" />
+      <ComponentRef Id="cmp94D11D053AB4429B17BB1608BBF07CC6" />
+      <ComponentRef Id="cmp560C08D6E294663FC928D9126A053846" />
+      <ComponentRef Id="cmp9033A5A91CE68C70E9E5ADAC500381C9" />
+      <ComponentRef Id="cmp9A12F2C14A49C01E49B1D3F62169973E" />
+      <ComponentRef Id="cmp2E2A69436DE79A0A6BA0F2F81AE392F5" />
+      <ComponentRef Id="cmp6AD9909523DFE5DF92AF0684CBEB1DA3" />
+      <ComponentRef Id="cmp223CC4B60E550995D6D9E5C8339B3CC5" />
+      <ComponentRef Id="cmpCE90934757713436DECA2402F52E8757" />
+      <ComponentRef Id="cmpEB3AFAB0420906A35F7DC855CC84A3AC" />
+      <ComponentRef Id="cmp83A66EE5FA3672E5E11057D6309018B7" />
+      <ComponentRef Id="cmp78FEACFB17F978B10A3C8CAE9BD4C26E" />
+    </ComponentGroup>
+  </Fragment>
 </Wix>

--- a/octgnFX/Octgn.InstallerLib/Octgn.InstallerLib.wixproj
+++ b/octgnFX/Octgn.InstallerLib/Octgn.InstallerLib.wixproj
@@ -61,9 +61,15 @@
 	<Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
 		<Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
 	</Target>
+	<!--
+	Heat file list generation is now handled by deploy\Update-HeatFileList.ps1
+	Run the PowerShell script to update the file list while preserving GUIDs
+	-->
+	<!--
 	<Target Name="BeforeBuild" Condition="'$(Configuration)' == 'Debug'">
 		<HeatDirectory Directory="..\Octgn\bin\$(Configuration)" PreprocessorVariable="var.HarvestPath" OutputFile="HeatGeneratedFileList.wxs" ComponentGroupName="O__HeatGenerated" DirectoryRefId="INSTALLDIR" AutogenerateGuids="False" ToolPath="$(WixToolPath)" SuppressFragments="true" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" Transforms="HeatGeneratedFileList.xslt" RunAsSeparateProcess="$(RunWixToolsOutOfProc)" />
 	</Target>
+	-->
 	<!--
 	To modify your build process, add your task inside one of the targets below and uncomment it.
 	Other similar extension points exist, see Wix.targets.


### PR DESCRIPTION
- Add PowerShell script to generate WiX Heat file list while preserving existing component GUIDs
- Remove automatic Heat generation from MSBuild process
- Script intelligently detects when regeneration is needed based on actual file changes
- Filters out .pdb, .xml, data.path, and logs files (same as XSLT transform)
- Provides detailed reporting of new/removed/modified files
- Includes batch file wrapper for easy execution
- Maintains upgrade compatibility by preserving component identities

Usage: deploy\update-heat-filelist.bat [Debug|Release] [-Force]