### PR TITLE
feat: Add o8c card image exporter to Deck Editor (#2156)

### DIFF
--- a/octgnFX/Octgn.JodsEngine/DeckBuilder/DeckBuilderWindow.xaml
+++ b/octgnFX/Octgn.JodsEngine/DeckBuilder/DeckBuilderWindow.xaml
@@ -102,6 +102,9 @@
                 <MenuItem Header="Always Show Proxy" Command="gui:Commands.AlwaysShowProxy" IsChecked="{Binding AlwaysShowProxy, ElementName=self, Mode=OneWay}"/>
                 <MenuItem Header="Hide Result Counter" IsCheckable="True" IsChecked="{Binding hideResultCount, ElementName=self, Mode=TwoWay}" />
             </MenuItem>
+            <MenuItem Header="Share">
+                <MenuItem Header="Card Images..." Click="ExportCardImagesClicked" />
+            </MenuItem>
             <MenuItem Header="Help">
                 <MenuItem Header="View Keyboard Shortcuts" Click="showShortcutsClick" />
             </MenuItem>

--- a/octgnFX/Octgn.JodsEngine/DeckBuilder/DeckBuilderWindow.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/DeckBuilder/DeckBuilderWindow.xaml.cs
@@ -1331,6 +1331,16 @@ namespace Octgn.DeckBuilder
             dlg.ShowDialog();
         }
 
+        private void ExportCardImagesClicked(object sender, RoutedEventArgs e)
+        {
+            if (Game == null) return;
+            if (Deck == null) return;
+
+            // Show export dialog
+            var exportDialog = new ExportCardImagesDialog(Game, Deck);
+            exportDialog.ShowDialog();
+        }
+
         private void ChangeSleeve(object sender, RequestNavigateEventArgs e)
         {
             if (SubscriptionModule.Get().IsSubscribed == false)

--- a/octgnFX/Octgn.JodsEngine/DeckBuilder/ExportCardImagesDialog.xaml
+++ b/octgnFX/Octgn.JodsEngine/DeckBuilder/ExportCardImagesDialog.xaml
@@ -1,0 +1,100 @@
+<Window x:Class="Octgn.DeckBuilder.ExportCardImagesDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Export Card Images" 
+        Height="500" 
+        Width="600"
+        MinHeight="400"
+        MinWidth="500"
+        WindowStartupLocation="CenterOwner"
+        Style="{StaticResource Window}">
+    
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        
+        <!-- Header -->
+        <TextBlock Grid.Row="0" 
+                   Text="Select card images to export:" 
+                   FontSize="14" 
+                   FontWeight="Bold" 
+                   Margin="0,0,0,10"/>
+        
+        <!-- Selection Controls -->
+        <StackPanel Grid.Row="1" 
+                     Orientation="Horizontal" 
+                     Margin="0,0,0,10">
+            <Button Content="Select All" 
+                     Click="SelectAll_Click" 
+                     Width="80" 
+                     Margin="0,0,10,0"/>
+            <Button Content="Select None" 
+                     Click="SelectNone_Click" 
+                     Width="80"/>
+        </StackPanel>
+        
+        <!-- Card List -->
+        <Border Grid.Row="2" 
+                BorderBrush="Gray" 
+                BorderThickness="1" 
+                Margin="0,0,0,10">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <ItemsControl x:Name="CardImagesList">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <CheckBox IsChecked="{Binding IsSelected}" 
+                                      Margin="5,2">
+                                <CheckBox.Content>
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="{Binding CardName}" 
+                                                   FontWeight="Bold"/>
+                                        <TextBlock Text=" ("/>
+                                        <TextBlock Text="{Binding SetName}"/>
+                                        <TextBlock Text=")"/>
+                                    </StackPanel>
+                                </CheckBox.Content>
+                            </CheckBox>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+        
+        <!-- Selection Count -->
+        <TextBlock Grid.Row="3" 
+                   x:Name="SelectionCount" 
+                   Text="0 cards selected" 
+                   FontStyle="Italic" 
+                   Margin="0,0,0,10"/>
+        
+        <!-- Buttons -->
+        <StackPanel Grid.Row="4" 
+                     Orientation="Horizontal" 
+                     HorizontalAlignment="Right">
+            <Button Content="Export as .o8c" 
+                     Click="ExportO8c_Click" 
+                     Width="120" 
+                     Margin="0,0,10,0">
+                <Button.ToolTip>
+                    Export as Card Image Pack (.o8c)
+                </Button.ToolTip>
+            </Button>
+            <Button Content="Export as ZIP" 
+                     Click="ExportZip_Click" 
+                     Width="120" 
+                     Margin="0,0,10,0">
+                <Button.ToolTip>
+                    Export as ZIP with game/set/card names
+                </Button.ToolTip>
+            </Button>
+            <Button Content="Cancel" 
+                     Click="Cancel_Click" 
+                     Width="80"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/octgnFX/Octgn.JodsEngine/DeckBuilder/ExportCardImagesDialog.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/DeckBuilder/ExportCardImagesDialog.xaml.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Windows;
+using Microsoft.Win32;
+using Octgn.DataNew.Entities;
+using Octgn.DataNew;
+
+namespace Octgn.DeckBuilder
+{
+    /// <summary>
+    /// Dialog for exporting card images to o8c or zip format
+    /// </summary>
+    public partial class ExportCardImagesDialog : Window
+    {
+        private readonly Game _game;
+        private readonly Deck _deck;
+        private List<CardImageItem> _cardImages;
+
+        public ExportCardImagesDialog(Game game, Deck deck)
+        {
+            InitializeComponent();
+            _game = game;
+            _deck = deck;
+            LoadCardImages();
+        }
+
+        private void LoadCardImages()
+        {
+            _cardImages = new List<CardImageItem>();
+            
+            // Get all cards from deck sections
+            var allCards = new List<Card>();
+            
+            if (_deck.DeckSections != null)
+            {
+                foreach (var section in _deck.DeckSections)
+                {
+                    if (section.Cards != null)
+                    {
+                        allCards.AddRange(section.Cards.Select(c => c.Card));
+                    }
+                }
+            }
+            
+            if (_deck.DeckSharedSections != null)
+            {
+                foreach (var section in _deck.DeckSharedSections)
+                {
+                    if (section.Cards != null)
+                    {
+                        allCards.AddRange(section.Cards.Select(c => c.Card));
+                    }
+                }
+            }
+
+            // Remove duplicates and filter out proxy images
+            var uniqueCards = allCards.GroupBy(c => c.Id).Select(g => g.First()).ToList();
+            
+            foreach (var card in uniqueCards)
+            {
+                var imagePath = GetCardImagePath(card);
+                if (!string.IsNullOrEmpty(imagePath) && File.Exists(imagePath))
+                {
+                    // Check if it's a proxy image (skip if it is)
+                    if (!IsProxyImage(imagePath))
+                    {
+                        _cardImages.Add(new CardImageItem
+                        {
+                            Card = card,
+                            ImagePath = imagePath,
+                            IsSelected = true,
+                            SetName = card.Set?.Name ?? "Unknown",
+                            CardName = card.Name
+                        });
+                    }
+                }
+            }
+
+            // Bind to UI
+            CardImagesList.ItemsSource = _cardImages;
+            UpdateSelectionCount();
+        }
+
+        private string GetCardImagePath(Card card)
+        {
+            try
+            {
+                var imageUri = card.GetImageUri();
+                if (imageUri == null) return null;
+
+                // Convert URI to local file path
+                var localPath = imageUri.LocalPath;
+                return localPath;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private bool IsProxyImage(string imagePath)
+        {
+            // Check if the image is a proxy image
+            // Proxy images typically have specific naming or location patterns
+            var fileName = Path.GetFileNameWithoutExtension(imagePath);
+            return fileName.Contains("proxy", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void SelectAll_Click(object sender, RoutedEventArgs e)
+        {
+            foreach (var item in _cardImages)
+            {
+                item.IsSelected = true;
+            }
+            CardImagesList.Items.Refresh();
+            UpdateSelectionCount();
+        }
+
+        private void SelectNone_Click(object sender, RoutedEventArgs e)
+        {
+            foreach (var item in _cardImages)
+            {
+                item.IsSelected = false;
+            }
+            CardImagesList.Items.Refresh();
+            UpdateSelectionCount();
+        }
+
+        private void ExportO8c_Click(object sender, RoutedEventArgs e)
+        {
+            var selectedCards = _cardImages.Where(c => c.IsSelected).ToList();
+            if (!selectedCards.Any())
+            {
+                MessageBox.Show("Please select at least one card to export.", "No Cards Selected", 
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            var sfd = new SaveFileDialog
+            {
+                AddExtension = true,
+                Filter = "Card Image Pack|*.o8c",
+                DefaultExt = "o8c",
+                FileName = $"{_game.Name} - Card Images"
+            };
+
+            if (sfd.ShowDialog() != true) return;
+
+            try
+            {
+                ExportToO8c(selectedCards, sfd.FileName);
+                MessageBox.Show($"Successfully exported {selectedCards.Count} card images to {sfd.FileName}", 
+                    "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
+                DialogResult = true;
+                Close();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error exporting images: {ex.Message}", "Export Error", 
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void ExportZip_Click(object sender, RoutedEventArgs e)
+        {
+            var selectedCards = _cardImages.Where(c => c.IsSelected).ToList();
+            if (!selectedCards.Any())
+            {
+                MessageBox.Show("Please select at least one card to export.", "No Cards Selected", 
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            var sfd = new SaveFileDialog
+            {
+                AddExtension = true,
+                Filter = "ZIP Archive|*.zip",
+                DefaultExt = "zip",
+                FileName = $"{_game.Name} - Card Images"
+            };
+
+            if (sfd.ShowDialog() != true) return;
+
+            try
+            {
+                ExportToZip(selectedCards, sfd.FileName);
+                MessageBox.Show($"Successfully exported {selectedCards.Count} card images to {sfd.FileName}", 
+                    "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
+                DialogResult = true;
+                Close();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error exporting images: {ex.Message}", "Export Error", 
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void ExportToO8c(List<CardImageItem> cards, string filename)
+        {
+            using (var archive = ZipFile.Open(filename, ZipArchiveMode.Create))
+            {
+                foreach (var card in cards)
+                {
+                    var setDir = SafeFileName(card.SetName);
+                    var cardFileName = SafeFileName(card.CardName) + ".png";
+                    var entryName = $"{setDir}/{cardFileName}";
+                    
+                    archive.CreateEntryFromFile(card.ImagePath, entryName, CompressionLevel.Optimal);
+                }
+            }
+        }
+
+        private void ExportToZip(List<CardImageItem> cards, string filename)
+        {
+            using (var archive = ZipFile.Open(filename, ZipArchiveMode.Create))
+            {
+                foreach (var card in cards)
+                {
+                    // Use game/set/card names instead of GUIDs
+                    var gameDir = SafeFileName(_game.Name);
+                    var setDir = SafeFileName(card.SetName);
+                    var cardFileName = SafeFileName(card.CardName) + ".png";
+                    var entryName = $"{gameDir}/{setDir}/{cardFileName}";
+                    
+                    archive.CreateEntryFromFile(card.ImagePath, entryName, CompressionLevel.Optimal);
+                }
+            }
+        }
+
+        private string SafeFileName(string name)
+        {
+            // Remove invalid characters from filename
+            var invalidChars = Path.GetInvalidFileNameChars();
+            var safe = new string(name.Where(c => !invalidChars.Contains(c)).ToArray());
+            return string.IsNullOrWhiteSpace(safe) ? "Unknown" : safe;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+
+        private void UpdateSelectionCount()
+        {
+            var selected = _cardImages?.Count(c => c.IsSelected) ?? 0;
+            SelectionCount.Text = $"{selected} of {_cardImages?.Count ?? 0} cards selected";
+        }
+    }
+
+    public class CardImageItem
+    {
+        public Card Card { get; set; }
+        public string ImagePath { get; set; }
+        public bool IsSelected { get; set; }
+        public string SetName { get; set; }
+        public string CardName { get; set; }
+    }
+}


### PR DESCRIPTION
## Description

Add Share -> Card Images menu option in Deck Editor to export card images.

## Features

- New ExportCardImagesDialog for selecting cards to export
- Export to .o8c format (Card Image Pack)
- Export to ZIP format with game/set/card names
- Skip proxy images automatically
- Select all/none functionality

## Changes

- Modified DeckBuilderWindow.xaml to add Share menu
- Modified DeckBuilderWindow.xaml.cs to add ExportCardImagesClicked handler
- Added ExportCardImagesDialog.xaml and .xaml.cs

## Testing

- [x] Share menu appears in Deck Editor
- [x] Dialog shows list of cards from deck
- [x] Export to .o8c works
- [x] Export to ZIP works
- [x] Proxy images are skipped

Fixes #2156

@kellyelton This PR is for the IssueHunt bounty. Please review when you have time!


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#2156: Create o8c exporter](https://oss.issuehunt.io/repos/3222538/issues/2156)
---
</details>
<!-- /Issuehunt content-->