### PR TITLE
Fix #1915: check reserved property names in o8build

### DIFF
--- a/octgnFX/o8build/GameValidator.cs
+++ b/octgnFX/o8build/GameValidator.cs
@@ -467,9 +467,19 @@
 
             if (game.card.property != null && game.card.property.Any())
             {
+                var reservedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "name", "id", "alternate", "size", "type", "set"
+                };
+
                 List<string> props = new List<string>();
                 foreach (var prop in game.card.property)
                 {
+                    if (reservedNames.Contains(prop.name))
+                    {
+                        throw new UserMessageException("Property '{0}' is a reserved name and cannot be used in file: {1}", prop.name, Path.Combine(Directory.FullName, "defintion.xml"));
+                    }
+
                     if (!props.Contains(prop.name))
                     {
                         props.Add(prop.name);

--- a/octgnFX/o8build/GameValidator.cs
+++ b/octgnFX/o8build/GameValidator.cs
@@ -25,6 +25,11 @@
 
     public class GameValidator
     {
+        private static readonly HashSet<string> ReservedPropertyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "name", "id", "alternate", "size", "type", "set"
+        };
+
         internal DirectoryInfo Directory { get; set; }
 
         internal delegate void WarningDelegate(string message, params object[] args);
@@ -467,15 +472,10 @@
 
             if (game.card.property != null && game.card.property.Any())
             {
-                var reservedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    "name", "id", "alternate", "size", "type", "set"
-                };
-
                 List<string> props = new List<string>();
                 foreach (var prop in game.card.property)
                 {
-                    if (reservedNames.Contains(prop.name))
+                    if (ReservedPropertyNames.Contains(prop.name))
                     {
                         throw new UserMessageException("Property '{0}' is a reserved name and cannot be used in file: {1}", prop.name, Path.Combine(Directory.FullName, "definition.xml"));
                     }

--- a/octgnFX/o8build/GameValidator.cs
+++ b/octgnFX/o8build/GameValidator.cs
@@ -477,7 +477,7 @@
                 {
                     if (reservedNames.Contains(prop.name))
                     {
-                        throw new UserMessageException("Property '{0}' is a reserved name and cannot be used in file: {1}", prop.name, Path.Combine(Directory.FullName, "defintion.xml"));
+                        throw new UserMessageException("Property '{0}' is a reserved name and cannot be used in file: {1}", prop.name, Path.Combine(Directory.FullName, "definition.xml"));
                     }
 
                     if (!props.Contains(prop.name))
@@ -486,7 +486,7 @@
                     }
                     else
                     {
-                        throw new UserMessageException("Duplicate property defined named {0} in file: {1}", prop.name, Path.Combine(Directory.FullName, "defintion.xml"));
+                        throw new UserMessageException("Duplicate property defined named {0} in file: {1}", prop.name, Path.Combine(Directory.FullName, "definition.xml"));
                     }
                 }
                 props.Clear();


### PR DESCRIPTION
## Summary

Fixes #1915 — o8build should catch the use of reserved property names in game definitions.

Also partially addresses #1914 — `type` is now included in the reserved names list.

## Changes

Added a check in `GameValidator.cs` that throws a validation error if any card property name matches a reserved name. The reserved names (case-insensitive) are:

- `name`
- `id`
- `alternate`
- `size`
- `type`
- `set`

Previously, games using these property names would build successfully but fail at runtime with strange errors.