### PR TITLE
Fix #2230: Sort sets by release date instead of name

### DIFF
--- a/octgnFX/Octgn.JodsEngine/DeckBuilder/SetPropertyDef.cs
+++ b/octgnFX/Octgn.JodsEngine/DeckBuilder/SetPropertyDef.cs
@@ -14,7 +14,7 @@ namespace Octgn.DeckBuilder
         {
             base.Name = "Set";
             base.Type = 0;
-            _allSets = allSets.OrderBy(s => s.Name).ToList();
+            _allSets = allSets.OrderBy(s => s.ReleaseDate).ToList();
         }
 
         public IList<Set> Sets


### PR DESCRIPTION
This PR addresses issue #2230 by modifying the sorting logic in SetPropertyDef.cs to sort sets by their ReleaseDate instead of alphabetically by name.

**Changes made:**
- Modified  to use  instead of 

This change will ensure that sets appear in the Deck Editor sorted by their release date, making it easier for users to find newer sets when building decks.