### PR TITLE
Fix #2212: Fix null reference in PreGameLobby.Start() when no players exist

### DIFF
--- a/octgnFX/Octgn.JodsEngine/Controls/PreGameLobby.xaml.cs
+++ b/octgnFX/Octgn.JodsEngine/Controls/PreGameLobby.xaml.cs
@@ -220,9 +220,12 @@ namespace Octgn.Controls
             // At start the global items belong to the player with the lowest id
             if (Player.GlobalPlayer != null)
             {
-                Player host = Player.AllExceptGlobal.OrderBy(p => p.Id).First();
-                foreach (Octgn.Play.Group group in Player.GlobalPlayer.Groups)
-                    group.Controller = host;
+                Player host = Player.AllExceptGlobal.OrderBy(p => p.Id).FirstOrDefault();
+                if (host != null)
+                {
+                    foreach (Octgn.Play.Group group in Player.GlobalPlayer.Groups)
+                        group.Controller = host;
+                }
             }
             if (callStartGame)
             {

--- a/octgnFX/Octgn.JodsEngine/Scripting/PythonAPI.py
+++ b/octgnFX/Octgn.JodsEngine/Scripting/PythonAPI.py
@@ -290,7 +290,8 @@ class Group(NamedObject):
   def setVisibility(self, value): _api.GroupSetVisibility(self._id, value)
   @property
   def controller(self):
-    return Player(_api.GroupController(self._id))
+    controllerId = _api.GroupController(self._id)
+    return Player(controllerId) if controllerId is not None else None
   def setController(self, player): _api.GroupSetController(self._id, player._id)
   def create(self, model, quantity = 1):
     ids = _api.Create(model, self._id, quantity)


### PR DESCRIPTION
Fixes #2212

This fix prevents a NullReferenceException in PreGameLobby.Start() when trying to assign global items to a player.

**Problem:**
- "Can't start any game" error occurs with "System.InvalidOperationException: 序列未包含項目"
- The error happens in PreGameLobby.Start() when calling  on an empty Player.AllExceptGlobal collection
- This occurs when there are no players except the global player

**Solution:**
- Changed  to  to safely get the first player or null
- Added null check before assigning global items to prevent exception
- This allows the game to start even when there are no players (edge case)

**Files Changed:**
-  - Fixed null reference in Start() method

## Testing
- [ ] Basic game start functionality
- [ ] Verify game starts when no players exist (edge case)
- [ ] Ensure normal player assignment still works
- [ ] Test with multiple players